### PR TITLE
Make location address optional; surface BE field-validation errors on form fields

### DIFF
--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -504,6 +504,13 @@ export function CommodityFormDialog({
       // whether to offer a Retry button (network / unknown only —
       // validation / conflict need the user to edit before resubmit).
       // Falls back to a generic copy when the body has nothing useful.
+      //
+      // Unlike the single-step forms (which suppress the banner via
+      // shouldShowGenericError once every field error maps), this
+      // multi-step form ALWAYS keeps the banner as an always-on summary:
+      // inline errors point at the offending step, the banner gives the
+      // overall status. Don't "simplify" this to match the others — it
+      // would hide the step-jump cue.
       setServerError(classifyServerError(err, t("commodities:form.serverError")))
     }
   }

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -42,7 +42,7 @@ import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { TagsInput } from "@/components/files/TagsInput"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { HttpError } from "@/lib/http"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 import { clearPendingFiles, loadPendingFiles, savePendingFiles } from "@/lib/pending-files-store"
 import { type ClassifiedServerError, classifyServerError } from "@/lib/server-error"
 import { ServerErrorBanner } from "@/components/ServerErrorBanner"
@@ -485,15 +485,13 @@ export function CommodityFormDialog({
       // first failing field. Necessary even with FE schema mirrors —
       // BE rules can be stricter than what the FE schema models, and
       // we should never silently round-trip a 422.
-      const fieldErrors = parseCommodityFieldErrors(err)
-      if (fieldErrors) {
-        for (const [name, message] of Object.entries(fieldErrors)) {
-          setError(name as keyof CommodityFormInput, { type: "server", message })
-        }
-        const firstField = Object.keys(fieldErrors)[0]
+      const fieldResult = applyServerFieldErrors(err, setError, {
+        fields: Object.values(STEP_FIELDS).flat(),
+      })
+      if (fieldResult && fieldResult.mapped.length > 0) {
         // Compound paths like `urls.0` need the root segment when
         // looking up which step owns the field.
-        const firstFieldRoot = firstField.split(".")[0]
+        const firstFieldRoot = fieldResult.mapped[0].split(".")[0]
         const targetStep = (FORM_STEPS as readonly string[]).find((s) =>
           STEP_FIELDS[s as StepKey].some((f) => f === firstFieldRoot)
         ) as StepKey | undefined
@@ -2368,78 +2366,6 @@ function clearDraft(key: string): void {
   } catch {
     // see writeDraft
   }
-}
-
-// parseCommodityFieldErrors extracts per-field validation messages
-// from the BE's 422 envelope so we can map them back onto RHF.
-//
-// The Inventario BE wraps validation errors in:
-//   {
-//     "errors": [
-//       {
-//         "status": "Unprocessable Entity",
-//         "error": {                 // jsonapi.Error.UserError (raw JSON)
-//           "type": "validation.Errors",
-//           "error": {               // ozzo / jellydator validation envelope
-//             "data": {
-//               "attributes": {
-//                 "<field>": "<message>"
-//               }
-//             }
-//           }
-//         }
-//       }
-//     ]
-//   }
-//
-// Returns a flat `{ field: message }` map limited to known commodity
-// form fields, or null when the response doesn't match the shape.
-function parseCommodityFieldErrors(err: unknown): Record<string, string> | null {
-  if (!(err instanceof HttpError)) return null
-  const data = err.data as unknown
-  if (!data || typeof data !== "object") return null
-  const errorsArr = (data as { errors?: unknown }).errors
-  if (!Array.isArray(errorsArr) || errorsArr.length === 0) return null
-  const first = errorsArr[0]
-  if (!first || typeof first !== "object") return null
-  const userErr = (first as { error?: unknown }).error
-  if (!userErr || typeof userErr !== "object") return null
-  const inner = (userErr as { error?: unknown }).error
-  if (!inner || typeof inner !== "object") return null
-  const dataObj = (inner as { data?: unknown }).data
-  if (!dataObj || typeof dataObj !== "object") return null
-  const attrs = (dataObj as { attributes?: unknown }).attributes
-  if (!attrs || typeof attrs !== "object") return null
-  // Only keep keys that actually live on the form (filter unknown
-  // server-only fields out so RHF.setError doesn't reject the path).
-  const known = new Set<string>()
-  for (const fields of Object.values(STEP_FIELDS)) {
-    for (const f of fields) known.add(f)
-  }
-  const result: Record<string, string> = {}
-  for (const [k, v] of Object.entries(attrs)) {
-    if (!known.has(k)) continue
-    if (typeof v === "string") {
-      result[k] = v
-      continue
-    }
-    // Array-typed fields (e.g. `urls`) come back as an object keyed
-    // by the failing index → message:
-    //   "urls": { "0": "Host: cannot be blank; …" }
-    // Emit compound paths (`urls.0`, `urls.1`) so RHF's `setError`
-    // can store the message under `errors.urls[idx]`, and our
-    // per-row error UI can attach the message to the offending row
-    // instead of forcing the user to scan a concatenated banner.
-    if (v && typeof v === "object") {
-      for (const [idx, msg] of Object.entries(v as Record<string, unknown>)) {
-        if (typeof msg !== "string") continue
-        const idxNum = Number(idx)
-        const compoundKey = Number.isFinite(idxNum) ? `${k}.${idxNum}` : k
-        result[compoundKey] = msg
-      }
-    }
-  }
-  return Object.keys(result).length > 0 ? result : null
 }
 
 // buildDefaults populates the form with safe initial values. For edit

--- a/frontend/src/components/items/StatusTransitionDialog.tsx
+++ b/frontend/src/components/items/StatusTransitionDialog.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import type { CommodityStatusValue } from "@/features/commodities/constants"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 
 // CURRENCY_SYMBOLS mirrors the mock's `CURRENCIES` lookup. We only need
 // the symbol prefix for the sale-price input adornment; the rest of
@@ -157,6 +158,7 @@ export function StatusTransitionDialog({
     handleSubmit,
     register,
     reset,
+    setError,
     setValue,
   } = useForm<StatusTransitionFormInput>({
     resolver: zodResolver(statusTransitionSchema),
@@ -221,7 +223,14 @@ export function StatusTransitionDialog({
             if (isSold && values.sale_price && values.sale_price !== "") {
               payload.sale_price = Number(values.sale_price)
             }
-            await onSubmit(payload)
+            try {
+              await onSubmit(payload)
+            } catch (err) {
+              // Host toasts a summary and re-throws; map field-level 422s.
+              applyServerFieldErrors(err, setError, {
+                fields: ["status_date", "status_note", "sale_price"],
+              })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/loans/EditLoanDialog.tsx
+++ b/frontend/src/components/loans/EditLoanDialog.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { editLoanFormSchema, type EditLoanFormInput } from "@/features/loans/schemas"
 import type { LoanEntity, UpdateLoanRequest } from "@/features/loans/api"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 import { formatDate } from "@/lib/intl"
 
 // Edit a loan's mutable fields. The dialog is intentionally separate
@@ -96,6 +97,7 @@ export function EditLoanDialog({
     handleSubmit,
     register,
     reset,
+    setError,
     setValue,
     watch,
   } = useForm<EditLoanFormInput>({
@@ -146,7 +148,14 @@ export function EditLoanDialog({
               borrower_note: values.borrower_note ?? "",
               due_back_at: values.due_back_at ?? "",
             })
-            await onSubmit(patch)
+            try {
+              await onSubmit(patch)
+            } catch (err) {
+              // Host toasts a summary and re-throws; map field-level 422s.
+              applyServerFieldErrors(err, setError, {
+                fields: ["borrower_name", "borrower_contact", "borrower_note", "due_back_at"],
+              })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/loans/LendDialog.tsx
+++ b/frontend/src/components/loans/LendDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { lendFormSchema, type LendFormInput } from "@/features/loans/schemas"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 
 // LendSubmitValues normalises the form output to the shape callers
 // actually want — every field non-undefined string — so they don't
@@ -66,6 +67,7 @@ export function LendDialog({ open, onOpenChange, onSubmit, isPending = false }: 
     handleSubmit,
     register,
     reset,
+    setError,
   } = useForm<LendFormInput>({
     resolver: zodResolver(lendFormSchema),
     defaultValues: buildDefaults(),
@@ -92,13 +94,26 @@ export function LendDialog({ open, onOpenChange, onSubmit, isPending = false }: 
           // when a <input type="date"> has an empty/edge value.
           noValidate
           onSubmit={handleSubmit(async (values) => {
-            await onSubmit({
-              borrower_name: values.borrower_name,
-              borrower_contact: values.borrower_contact ?? "",
-              borrower_note: values.borrower_note ?? "",
-              lent_at: values.lent_at,
-              due_back_at: values.due_back_at ?? "",
-            })
+            try {
+              await onSubmit({
+                borrower_name: values.borrower_name,
+                borrower_contact: values.borrower_contact ?? "",
+                borrower_note: values.borrower_note ?? "",
+                lent_at: values.lent_at,
+                due_back_at: values.due_back_at ?? "",
+              })
+            } catch (err) {
+              // Host toasts a summary and re-throws; map field-level 422s.
+              applyServerFieldErrors(err, setError, {
+                fields: [
+                  "borrower_name",
+                  "borrower_contact",
+                  "borrower_note",
+                  "lent_at",
+                  "due_back_at",
+                ],
+              })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/loans/LendTab.tsx
+++ b/frontend/src/components/loans/LendTab.tsx
@@ -87,6 +87,9 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
       // so the toast actually shows "commodity is already out (kind=…,
       // id=…, party=…)" instead of the generic transport message.
       toast.error(parseServerError(err, t("loans:toast.lendError")))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 
@@ -118,6 +121,9 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
       setEditing(null)
     } catch (err) {
       toast.error(parseServerError(err, t("loans:toast.editError")))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 

--- a/frontend/src/components/locations/AreaFormDialog.tsx
+++ b/frontend/src/components/locations/AreaFormDialog.tsx
@@ -27,6 +27,7 @@ import { AREA_ICONS, IconPicker } from "@/components/locations/IconPicker"
 import type { Area } from "@/features/areas/api"
 import { areaSchema, type AreaFormInput } from "@/features/areas/schemas"
 import type { Location } from "@/features/locations/api"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 
 interface AreaFormDialogProps {
@@ -113,7 +114,16 @@ export function AreaFormDialog({
       await onSubmit(values)
       onOpenChange(false)
     } catch (err) {
-      setServerError(classifyServerError(err, t("locations:areaDialog.errorGeneric")))
+      // Highlight the offending field on a 422 instead of only showing
+      // the generic banner; fall back to the banner for non-field errors.
+      const fieldResult = applyServerFieldErrors(err, form.setError, {
+        fields: Object.keys(areaSchema.shape),
+      })
+      setServerError(
+        shouldShowGenericError(fieldResult)
+          ? classifyServerError(err, t("locations:areaDialog.errorGeneric"))
+          : null
+      )
     }
   }
 

--- a/frontend/src/components/locations/LocationFormDialog.tsx
+++ b/frontend/src/components/locations/LocationFormDialog.tsx
@@ -20,6 +20,7 @@ import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { IconPicker, LOCATION_ICONS } from "@/components/locations/IconPicker"
 import type { Location } from "@/features/locations/api"
 import { locationSchema, type LocationFormInput } from "@/features/locations/schemas"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 
 interface LocationFormDialogProps {
@@ -101,7 +102,18 @@ export function LocationFormDialog({
       await onSubmit(values)
       onOpenChange(false)
     } catch (err) {
-      setServerError(classifyServerError(err, t("locations:dialog.errorGeneric")))
+      // Map BE field-level validation errors (e.g. 422 `address: cannot be
+      // blank`) back onto the inputs so the failing field is highlighted
+      // with its inline message; only fall back to the generic banner for
+      // non-field errors or anything that couldn't be placed on a field.
+      const fieldResult = applyServerFieldErrors(err, form.setError, {
+        fields: Object.keys(locationSchema.shape),
+      })
+      setServerError(
+        shouldShowGenericError(fieldResult)
+          ? classifyServerError(err, t("locations:dialog.errorGeneric"))
+          : null
+      )
     }
   }
 

--- a/frontend/src/components/locations/__tests__/LocationFormDialog.test.tsx
+++ b/frontend/src/components/locations/__tests__/LocationFormDialog.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event"
 import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
 import { renderWithProviders } from "@/test/render"
 import type { Location } from "@/features/locations/api"
+import { HttpError } from "@/lib/http"
 
 // Direct-mount tests for LocationFormDialog. The host pages
 // (LocationsListPage / LocationDetailPage) wire the dialog into
@@ -149,5 +150,40 @@ describe("<LocationFormDialog />", () => {
     // the typed-but-unsaved value.
     await Promise.resolve()
     expect(nameInput).toHaveValue("Mid-edit")
+  })
+
+  it("maps a 422 field validation error onto the offending input instead of a generic banner", async () => {
+    const user = userEvent.setup()
+    // The BE's nested 422 envelope, naming the failing attribute. The
+    // dialog must surface this inline on the address field — not as the
+    // generic "something went wrong" banner (the reported bug).
+    const envelope = {
+      errors: [
+        {
+          status: "Unprocessable Entity",
+          error: {
+            type: "validation.Errors",
+            error: { data: { attributes: { address: "cannot be blank" } } },
+          },
+        },
+      ],
+    }
+    const onSubmit = () => Promise.reject(new HttpError("boom", 422, "/locations", envelope))
+
+    renderWithProviders({
+      children: <LocationFormDialog open onOpenChange={() => undefined} onSubmit={onSubmit} />,
+    })
+
+    const nameInput = await screen.findByTestId("location-name-input")
+    await user.type(nameInput, "Garage")
+    await user.click(screen.getByTestId("location-form-submit"))
+
+    // The address field shows the server's field-level message…
+    await waitFor(() =>
+      expect(screen.getByTestId("location-address-error")).toHaveTextContent("cannot be blank")
+    )
+    // …and the generic server-error banner is suppressed because every
+    // error mapped cleanly onto a field.
+    expect(screen.queryByTestId("location-form-server-error")).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/maintenance/MaintenanceScheduleDialog.tsx
+++ b/frontend/src/components/maintenance/MaintenanceScheduleDialog.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import type { MaintenanceScheduleEntity } from "@/features/maintenance/api"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 import {
   maintenanceFormSchema,
   type MaintenanceFormInput,
@@ -104,6 +105,7 @@ function MaintenanceScheduleForm({
     formState: { errors, isSubmitting },
     handleSubmit,
     register,
+    setError,
   } = useForm<MaintenanceFormInput, unknown, MaintenanceFormOutput>({
     resolver: zodResolver(maintenanceFormSchema),
     defaultValues: buildDefaults(initial),
@@ -120,12 +122,19 @@ function MaintenanceScheduleForm({
       // on a <input type="date"> with an edge value.
       noValidate
       onSubmit={handleSubmit(async (values) => {
-        await onSubmit({
-          title: values.title,
-          interval_days: values.interval_days,
-          next_due_at: values.next_due_at ? values.next_due_at : undefined,
-          notes: values.notes ? values.notes : undefined,
-        })
+        try {
+          await onSubmit({
+            title: values.title,
+            interval_days: values.interval_days,
+            next_due_at: values.next_due_at ? values.next_due_at : undefined,
+            notes: values.notes ? values.notes : undefined,
+          })
+        } catch (err) {
+          // Host toasts a summary and re-throws; map field-level 422s.
+          applyServerFieldErrors(err, setError, {
+            fields: ["title", "interval_days", "next_due_at", "notes"],
+          })
+        }
       })}
     >
       <DialogHeader>

--- a/frontend/src/components/maintenance/MaintenanceTab.tsx
+++ b/frontend/src/components/maintenance/MaintenanceTab.tsx
@@ -212,6 +212,9 @@ export function MaintenanceTab({ commodityId, commodityCount }: MaintenanceTabPr
                 t("maintenance:toast.saveError", { defaultValue: "Couldn't save the schedule." })
               )
             )
+            // Re-throw so the dialog can map field-level 422 errors onto its
+            // inputs (it stays open). The toast above is the summary.
+            throw err
           }
         }}
         submitting={create.isPending || update.isPending}

--- a/frontend/src/components/services/SendForServiceDialog.tsx
+++ b/frontend/src/components/services/SendForServiceDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { serviceFormSchema, type ServiceFormInput } from "@/features/services/schemas"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 
 // SendForServiceSubmitValues mirrors LendSubmitValues' shape — every
 // optional field surfaces as a non-undefined string so callers don't
@@ -66,6 +67,7 @@ export function SendForServiceDialog({
     handleSubmit,
     register,
     reset,
+    setError,
   } = useForm<ServiceFormInput>({
     resolver: zodResolver(serviceFormSchema),
     defaultValues: buildDefaults(),
@@ -86,15 +88,30 @@ export function SendForServiceDialog({
         <form
           className="flex flex-col gap-4"
           onSubmit={handleSubmit(async (values) => {
-            await onSubmit({
-              provider_name: values.provider_name,
-              provider_contact: values.provider_contact ?? "",
-              reason: values.reason ?? "",
-              sent_at: values.sent_at,
-              expected_return_at: values.expected_return_at ?? "",
-              cost_amount: values.cost_amount ?? "",
-              cost_currency: values.cost_currency ?? "",
-            })
+            try {
+              await onSubmit({
+                provider_name: values.provider_name,
+                provider_contact: values.provider_contact ?? "",
+                reason: values.reason ?? "",
+                sent_at: values.sent_at,
+                expected_return_at: values.expected_return_at ?? "",
+                cost_amount: values.cost_amount ?? "",
+                cost_currency: values.cost_currency ?? "",
+              })
+            } catch (err) {
+              // Host toasts a summary and re-throws; map field-level 422s.
+              applyServerFieldErrors(err, setError, {
+                fields: [
+                  "provider_name",
+                  "provider_contact",
+                  "reason",
+                  "sent_at",
+                  "expected_return_at",
+                  "cost_amount",
+                  "cost_currency",
+                ],
+              })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/services/ServiceTab.tsx
+++ b/frontend/src/components/services/ServiceTab.tsx
@@ -83,6 +83,9 @@ export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
       // detail/title/error/message field out and falls back to a generic
       // toast copy when nothing useful is in the payload.
       toast.error(parseServerError(err, t("services:toast.sendError")))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 

--- a/frontend/src/components/supplies/SuppliesTab.tsx
+++ b/frontend/src/components/supplies/SuppliesTab.tsx
@@ -64,6 +64,9 @@ export function SuppliesTab({ commodityId }: SuppliesTabProps) {
           t("supplies:toasts.createError", { defaultValue: "Couldn't add the supply link." })
         )
       )
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 
@@ -86,6 +89,9 @@ export function SuppliesTab({ commodityId }: SuppliesTabProps) {
           t("supplies:toasts.updateError", { defaultValue: "Couldn't update the supply link." })
         )
       )
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 

--- a/frontend/src/components/supplies/SupplyLinkDialog.tsx
+++ b/frontend/src/components/supplies/SupplyLinkDialog.tsx
@@ -21,6 +21,7 @@ import {
   type SupplyLinkFormValues,
 } from "@/features/supplies/schemas"
 import type { SupplyLinkEntity } from "@/features/supplies/api"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 
 export type { SupplyLinkFormValues } from "@/features/supplies/schemas"
 
@@ -59,6 +60,7 @@ export function SupplyLinkDialog({
     handleSubmit,
     register,
     reset,
+    setError,
   } = useForm<SupplyLinkFormInput>({
     resolver: zodResolver(supplyLinkFormSchema),
     defaultValues: emptyDefaults,
@@ -96,11 +98,18 @@ export function SupplyLinkDialog({
           className="flex flex-col gap-4"
           noValidate
           onSubmit={handleSubmit(async (values) => {
-            await onSubmit({
-              label: values.label.trim(),
-              url: values.url.trim(),
-              notes: values.notes ?? "",
-            })
+            try {
+              await onSubmit({
+                label: values.label.trim(),
+                url: values.url.trim(),
+                notes: values.notes ?? "",
+              })
+            } catch (err) {
+              // The host toasts a summary and re-throws; map the BE's
+              // field-level 422 onto the inputs so the offending field is
+              // highlighted instead of the user only getting a toast.
+              applyServerFieldErrors(err, setError, { fields: ["label", "url", "notes"] })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/supplies/__tests__/SupplyLinkDialog.test.tsx
+++ b/frontend/src/components/supplies/__tests__/SupplyLinkDialog.test.tsx
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest"
 
 import { SupplyLinkDialog } from "@/components/supplies/SupplyLinkDialog"
 import { initI18n } from "@/i18n"
+import { HttpError } from "@/lib/http"
 
 beforeAll(async () => {
   await initI18n({ lng: "en" })
@@ -83,6 +84,39 @@ describe("<SupplyLinkDialog />", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1)
     expect(onSubmit.mock.calls[0]?.[0]?.label).toBe("Renamed")
+  })
+
+  it("maps a 422 field error from the server onto the input and stays open", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    // The host catches, toasts, and re-throws; the dialog must map the
+    // BE's field-level 422 onto the offending input instead of silently
+    // closing or only relying on the toast.
+    const envelope = {
+      errors: [
+        {
+          status: "Unprocessable Entity",
+          error: {
+            type: "validation.Errors",
+            error: { data: { attributes: { url: "must be a valid URL" } } },
+          },
+        },
+      ],
+    }
+    const onSubmit = vi.fn().mockRejectedValue(new HttpError("boom", 422, "/supplies", envelope))
+    render(
+      <SupplyLinkDialog open title="Add link" onSubmit={onSubmit} onOpenChange={onOpenChange} />
+    )
+
+    await user.type(screen.getByTestId("supply-link-label-input"), "Water filter")
+    await user.type(screen.getByTestId("supply-link-url-input"), "https://example.com/x")
+    await user.click(screen.getByTestId("supply-link-submit"))
+
+    expect(await screen.findByTestId("supply-link-url-error")).toHaveTextContent(
+      "must be a valid URL"
+    )
+    // A field error keeps the dialog open so the user can fix it.
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 
   it("is axe-clean while open", async () => {

--- a/frontend/src/components/tags/TagFormDialog.tsx
+++ b/frontend/src/components/tags/TagFormDialog.tsx
@@ -19,6 +19,7 @@ import { TagBadge } from "./TagBadge"
 import { TagColorPicker } from "./TagColorPicker"
 import type { TagColor, TagEntity } from "@/features/tags/api"
 import { normaliseSlug, tagFormSchema, type TagFormInput } from "@/features/tags/schemas"
+import { applyServerFieldErrors } from "@/lib/form-errors"
 
 export interface TagFormDialogProps {
   open: boolean
@@ -48,6 +49,7 @@ export function TagFormDialog({
     handleSubmit,
     register,
     reset,
+    setError,
     setValue,
     watch,
   } = useForm<TagFormInput>({
@@ -107,11 +109,17 @@ export function TagFormDialog({
         <form
           className="flex flex-col gap-4"
           onSubmit={handleSubmit(async (values) => {
-            await onSubmit({
-              label: values.label,
-              slug: values.slug,
-              color: values.color as TagColor,
-            })
+            try {
+              await onSubmit({
+                label: values.label,
+                slug: values.slug,
+                color: values.color as TagColor,
+              })
+            } catch (err) {
+              // Host toasts a summary and re-throws; map the BE's field-level
+              // 422 (e.g. duplicate slug) onto the inputs.
+              applyServerFieldErrors(err, setError, { fields: ["label", "slug", "color"] })
+            }
           })}
         >
           <div className="flex flex-col gap-1.5">

--- a/frontend/src/lib/__tests__/form-errors.test.ts
+++ b/frontend/src/lib/__tests__/form-errors.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
+import { HttpError } from "@/lib/http"
+
+function validationEnvelope(attributes: Record<string, unknown>) {
+  return {
+    errors: [
+      {
+        status: "Unprocessable Entity",
+        error: { type: "validation.Errors", error: { data: { attributes } } },
+      },
+    ],
+  }
+}
+
+describe("applyServerFieldErrors", () => {
+  it("sets known fields on the form and reports them as mapped", () => {
+    const err = new HttpError("boom", 422, "/x", validationEnvelope({ address: "cannot be blank" }))
+    const setError = vi.fn()
+
+    const result = applyServerFieldErrors(err, setError, { fields: ["name", "address"] })
+
+    expect(setError).toHaveBeenCalledWith("address", {
+      type: "server",
+      message: "cannot be blank",
+    })
+    expect(result).toEqual({ mapped: ["address"], unmapped: {} })
+  })
+
+  it("routes unknown server fields to unmapped without touching the form", () => {
+    const err = new HttpError(
+      "boom",
+      422,
+      "/x",
+      validationEnvelope({ address: "cannot be blank", tenant_id: "must be set" })
+    )
+    const setError = vi.fn()
+
+    const result = applyServerFieldErrors(err, setError, { fields: ["name", "address"] })
+
+    expect(setError).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      mapped: ["address"],
+      unmapped: { tenant_id: "must be set" },
+    })
+  })
+
+  it("remaps server snake_case roots to camelCase form fields via map", () => {
+    const err = new HttpError(
+      "boom",
+      422,
+      "/x",
+      validationEnvelope({ default_group_id: "does not exist" })
+    )
+    const setError = vi.fn()
+
+    const result = applyServerFieldErrors(err, setError, {
+      fields: ["name", "defaultGroupId"],
+      map: { default_group_id: "defaultGroupId" },
+    })
+
+    expect(setError).toHaveBeenCalledWith("defaultGroupId", {
+      type: "server",
+      message: "does not exist",
+    })
+    expect(result).toEqual({ mapped: ["defaultGroupId"], unmapped: {} })
+  })
+
+  it("preserves compound array suffixes when mapping", () => {
+    const err = new HttpError(
+      "boom",
+      422,
+      "/x",
+      validationEnvelope({ urls: { "0": "must be a valid URL" } })
+    )
+    const setError = vi.fn()
+
+    const result = applyServerFieldErrors(err, setError, { fields: ["urls"] })
+
+    expect(setError).toHaveBeenCalledWith("urls.0", {
+      type: "server",
+      message: "must be a valid URL",
+    })
+    expect(result).toEqual({ mapped: ["urls.0"], unmapped: {} })
+  })
+
+  it("returns null when the error is not a field-validation envelope", () => {
+    const err = new HttpError("boom", 500, "/x", null)
+    const setError = vi.fn()
+
+    expect(applyServerFieldErrors(err, setError, { fields: ["name"] })).toBeNull()
+    expect(setError).not.toHaveBeenCalled()
+  })
+})
+
+describe("shouldShowGenericError", () => {
+  it("shows the banner when the error wasn't a field envelope", () => {
+    expect(shouldShowGenericError(null)).toBe(true)
+  })
+
+  it("shows the banner when nothing mapped to a form field", () => {
+    expect(shouldShowGenericError({ mapped: [], unmapped: { foo: "bar" } })).toBe(true)
+  })
+
+  it("shows the banner when some field errors were left unmapped", () => {
+    expect(shouldShowGenericError({ mapped: ["address"], unmapped: { foo: "bar" } })).toBe(true)
+  })
+
+  it("hides the banner when every error mapped cleanly", () => {
+    expect(shouldShowGenericError({ mapped: ["address"], unmapped: {} })).toBe(false)
+  })
+})

--- a/frontend/src/lib/__tests__/server-error.test.ts
+++ b/frontend/src/lib/__tests__/server-error.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, it } from "vitest"
 
 import { HttpError } from "@/lib/http"
-import { classifyServerError, isRetryableKind, parseServerError } from "@/lib/server-error"
+import {
+  classifyServerError,
+  extractFieldErrors,
+  isRetryableKind,
+  parseServerError,
+} from "@/lib/server-error"
+
+// Builds the BE's nested 422 validation envelope around an `attributes`
+// object, mirroring what `errormarshal.Marshal(validation.Errors)` emits.
+function validationEnvelope(attributes: Record<string, unknown>) {
+  return {
+    errors: [
+      {
+        status: "Unprocessable Entity",
+        error: {
+          type: "validation.Errors",
+          error: { data: { attributes } },
+        },
+      },
+    ],
+  }
+}
 
 describe("parseServerError", () => {
   it("returns the trimmed string body when the server replied with plain text", () => {
@@ -70,6 +91,54 @@ describe("classifyServerError", () => {
       kind: "unknown",
       message: "Try again",
     })
+  })
+})
+
+describe("extractFieldErrors", () => {
+  it("pulls a single field message out of the nested 422 envelope", () => {
+    const err = new HttpError("boom", 422, "/x", validationEnvelope({ address: "cannot be blank" }))
+    expect(extractFieldErrors(err)).toEqual({ address: "cannot be blank" })
+  })
+
+  it("extracts every attribute when several fields fail", () => {
+    const err = new HttpError(
+      "boom",
+      422,
+      "/x",
+      validationEnvelope({ name: "cannot be blank", short_name: "is too long" })
+    )
+    expect(extractFieldErrors(err)).toEqual({
+      name: "cannot be blank",
+      short_name: "is too long",
+    })
+  })
+
+  it("flattens array-indexed fields into dotted paths", () => {
+    const err = new HttpError(
+      "boom",
+      422,
+      "/x",
+      validationEnvelope({ urls: { "0": "must be a valid URL", "2": "cannot be blank" } })
+    )
+    expect(extractFieldErrors(err)).toEqual({
+      "urls.0": "must be a valid URL",
+      "urls.2": "cannot be blank",
+    })
+  })
+
+  it("returns null for a non-HttpError value", () => {
+    expect(extractFieldErrors(new Error("nope"))).toBeNull()
+  })
+
+  it("returns null when the body isn't a field-validation envelope", () => {
+    // A plain JSON:API detail error carries no data.attributes map.
+    const err = new HttpError("boom", 422, "/x", { errors: [{ detail: "Bad input" }] })
+    expect(extractFieldErrors(err)).toBeNull()
+  })
+
+  it("returns null when attributes is present but empty", () => {
+    const err = new HttpError("boom", 422, "/x", validationEnvelope({}))
+    expect(extractFieldErrors(err)).toBeNull()
   })
 })
 

--- a/frontend/src/lib/form-errors.ts
+++ b/frontend/src/lib/form-errors.ts
@@ -1,0 +1,78 @@
+// react-hook-form adapter for the BE's field-level validation errors.
+//
+// `extractFieldErrors` (in `lib/server-error.ts`) turns a 422 envelope
+// into a flat `{ <server-field-path>: <message> }` map. This module maps
+// those server paths onto the form's own fields via `setError`, so the
+// failing input gets highlighted and its inline error copy renders next
+// to it instead of the user only seeing a generic banner.
+//
+// Server field paths are the BE model's snake_case attribute names
+// (`address`, `short_name`, …) plus compound array paths (`urls.0`).
+// When a form's react-hook-form field names differ from the BE names
+// (e.g. camelCase `defaultGroupId` ↔ `default_group_id`), pass a `map`
+// of `{ <server-root-segment>: <form-field-name> }`.
+import type { FieldValues, Path, UseFormSetError } from "react-hook-form"
+
+import { extractFieldErrors } from "./server-error"
+
+export interface ServerFieldErrorResult {
+  // Form field paths that were successfully set on the form.
+  mapped: string[]
+  // Server field paths (+ messages) that did NOT match a known form
+  // field — the caller should still surface these (banner / toast) so
+  // they aren't silently dropped.
+  unmapped: Record<string, string>
+}
+
+export interface ApplyServerFieldErrorsOptions {
+  // The form's own field names (typically the zod schema's keys). Only
+  // server errors whose root segment maps to one of these are written to
+  // the form; the rest go to `unmapped`.
+  fields: readonly string[]
+  // Optional `{ <server-root-segment>: <form-field-name> }` overrides for
+  // forms whose field names differ from the BE attribute names.
+  map?: Record<string, string>
+}
+
+// applyServerFieldErrors writes the BE's per-field validation messages
+// onto a react-hook-form instance and reports what it could and could
+// not place. Returns null when `err` isn't a field-level validation
+// envelope at all (network / conflict / 5xx / non-validation 422), so
+// the caller can fall straight through to its generic error surface.
+export function applyServerFieldErrors<TFieldValues extends FieldValues>(
+  err: unknown,
+  setError: UseFormSetError<TFieldValues>,
+  options: ApplyServerFieldErrorsOptions
+): ServerFieldErrorResult | null {
+  const raw = extractFieldErrors(err)
+  if (!raw) return null
+
+  const known = new Set(options.fields)
+  const mapped: string[] = []
+  const unmapped: Record<string, string> = {}
+
+  for (const [serverPath, message] of Object.entries(raw)) {
+    const root = serverPath.split(".")[0]
+    const formRoot = options.map?.[root] ?? root
+    if (!known.has(formRoot)) {
+      unmapped[serverPath] = message
+      continue
+    }
+    // Swap only the root segment when remapped, preserving any compound
+    // suffix (`urls.0` stays `urls.0`; `default_group_id` → `defaultGroupId`).
+    const formPath = formRoot + serverPath.slice(root.length)
+    setError(formPath as Path<TFieldValues>, { type: "server", message })
+    mapped.push(formPath)
+  }
+
+  return { mapped, unmapped }
+}
+
+// shouldShowGenericError decides whether a caller should ALSO render its
+// generic banner/toast after calling `applyServerFieldErrors`. True when
+// the error wasn't a field-validation envelope, when nothing mapped to a
+// form field, or when some field errors were left unmapped — in all
+// three cases the field highlights alone wouldn't tell the full story.
+export function shouldShowGenericError(result: ServerFieldErrorResult | null): boolean {
+  return !result || result.mapped.length === 0 || Object.keys(result.unmapped).length > 0
+}

--- a/frontend/src/lib/form-errors.ts
+++ b/frontend/src/lib/form-errors.ts
@@ -60,6 +60,7 @@ export function applyServerFieldErrors<TFieldValues extends FieldValues>(
     }
     // Swap only the root segment when remapped, preserving any compound
     // suffix (`urls.0` stays `urls.0`; `default_group_id` → `defaultGroupId`).
+    // `options.map` keys are root segments only — never a compound path.
     const formPath = formRoot + serverPath.slice(root.length)
     setError(formPath as Path<TFieldValues>, { type: "server", message })
     mapped.push(formPath)

--- a/frontend/src/lib/server-error.ts
+++ b/frontend/src/lib/server-error.ts
@@ -122,3 +122,63 @@ export function getServerErrorMeta(err: unknown): Record<string, string> | null 
   const first = (data as ErrorEnvelope).errors?.[0]
   return first?.meta ?? null
 }
+
+// Recursively flattens a validation-error tree into dotted field paths.
+// Leaf values are the human-readable messages; intermediate objects are
+// walked (array-valued fields arrive keyed by failing index, e.g.
+// `{ urls: { "0": "…" } }` → `urls.0`).
+function flattenFieldErrors(node: unknown, prefix: string, out: Record<string, string>): void {
+  if (!node || typeof node !== "object") return
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof value === "string") {
+      out[path] = value
+    } else if (value && typeof value === "object") {
+      flattenFieldErrors(value, path, out)
+    }
+  }
+}
+
+// extractFieldErrors pulls per-field validation messages out of the BE's
+// 422 envelope so callers can map them onto individual form fields
+// instead of dropping a single generic banner. The Inventario BE nests
+// validation errors as:
+//
+//   {
+//     "errors": [
+//       {
+//         "status": "Unprocessable Entity",
+//         "error": {                 // jsonapi.Error.UserError (raw JSON)
+//           "type": "validation.Errors",
+//           "error": {               // ozzo / jellydator validation envelope
+//             "data": { "attributes": { "<field>": "<message>" } }
+//           }
+//         }
+//       }
+//     ]
+//   }
+//
+// Returns a flat `{ <dotted-field-path>: <message> }` map (e.g.
+// `{ address: "cannot be blank" }` or `{ "urls.0": "…" }`), or null when
+// the response isn't a field-level `validation.Errors` envelope. The
+// caller decides which keys actually live on its form — see
+// `applyServerFieldErrors` in `lib/form-errors.ts`.
+export function extractFieldErrors(err: unknown): Record<string, string> | null {
+  if (!(err instanceof HttpError)) return null
+  const data = err.data
+  if (!data || typeof data !== "object") return null
+  const first = (data as ErrorEnvelope).errors?.[0] as { error?: unknown } | undefined
+  if (!first || typeof first !== "object") return null
+  const userErr = first.error
+  if (!userErr || typeof userErr !== "object") return null
+  const inner = (userErr as { error?: unknown }).error
+  if (!inner || typeof inner !== "object") return null
+  const dataObj = (inner as { data?: unknown }).data
+  if (!dataObj || typeof dataObj !== "object") return null
+  const attrs = (dataObj as { attributes?: unknown }).attributes
+  if (!attrs || typeof attrs !== "object") return null
+
+  const result: Record<string, string> = {}
+  flattenFieldErrors(attrs, "", result)
+  return Object.keys(result).length > 0 ? result : null
+}

--- a/frontend/src/pages/EditProfilePage.tsx
+++ b/frontend/src/pages/EditProfilePage.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/features/auth/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
 import { HttpError } from "@/lib/http"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
@@ -146,7 +147,17 @@ export function EditProfilePage() {
       // save and see a "Profile updated" banner.
       setProfileSaved(true)
     } catch (err) {
-      setProfileError(classifyServerError(err, t("settings:profile.edit.errorGeneric")))
+      // Map BE field validation onto the inputs (server uses snake_case
+      // `default_group_id`; the form field is camelCase `defaultGroupId`).
+      const fieldResult = applyServerFieldErrors(err, profileForm.setError, {
+        fields: Object.keys(profileEditSchema.shape),
+        map: { default_group_id: "defaultGroupId" },
+      })
+      setProfileError(
+        shouldShowGenericError(fieldResult)
+          ? classifyServerError(err, t("settings:profile.edit.errorGeneric"))
+          : null
+      )
     }
   }
 

--- a/frontend/src/pages/EditProfilePage.tsx
+++ b/frontend/src/pages/EditProfilePage.tsx
@@ -147,8 +147,12 @@ export function EditProfilePage() {
       // save and see a "Profile updated" banner.
       setProfileSaved(true)
     } catch (err) {
-      // Map BE field validation onto the inputs (server uses snake_case
-      // `default_group_id`; the form field is camelCase `defaultGroupId`).
+      // Map any BE field-level 422 (`validation.Errors`) onto the inputs.
+      // The map covers the snake_case `default_group_id` → camelCase
+      // `defaultGroupId` rename; note the common stale-default-group
+      // rejection is a 400 (see above), not a field 422, so it still
+      // falls through to the banner — the map only kicks in if the BE
+      // ever returns a 422 naming that attribute.
       const fieldResult = applyServerFieldErrors(err, profileForm.setError, {
         fields: Object.keys(profileEditSchema.shape),
         map: { default_group_id: "defaultGroupId" },

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -459,8 +459,11 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
       })
       toast.success(t("commodities:toast.statusUpdated"))
       setTransitionTarget(null)
-    } catch {
+    } catch (err) {
       toast.error(t("commodities:toast.statusUpdateError"))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 

--- a/frontend/src/pages/files/FileEditPage.tsx
+++ b/frontend/src/pages/files/FileEditPage.tsx
@@ -15,6 +15,7 @@ import { Page, PageHeader } from "@/components/ui/page"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useFile, useUpdateFile } from "@/features/files/hooks"
 import { fileMetadataSchema, type FileMetadataFormInput } from "@/features/files/schemas"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 
@@ -80,7 +81,14 @@ export function FileEditPage() {
       toast.success(t("files:edit.save"))
       onCancel()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      // Map BE field-level 422s onto the inputs; only toast for non-field
+      // errors (or anything that couldn't be placed on a field).
+      const result = applyServerFieldErrors(err, form.setError, {
+        fields: ["title", "description", "path", "category", "tags"],
+      })
+      if (shouldShowGenericError(result)) {
+        toast.error(err instanceof Error ? err.message : String(err))
+      }
     }
   }
 

--- a/frontend/src/pages/groups/CreateGroupPage.tsx
+++ b/frontend/src/pages/groups/CreateGroupPage.tsx
@@ -16,6 +16,7 @@ import { IconPicker } from "@/components/groups/IconPicker"
 import { useCreateGroup } from "@/features/group/hooks"
 import { createGroupSchema, type CreateGroupInput } from "@/features/group/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
@@ -68,7 +69,14 @@ export function CreateGroupPage() {
       toast.success(t("groups:create.successToast"))
       navigate(`/g/${encodeURIComponent(created.slug)}`)
     } catch (err) {
-      setServerError(classifyServerError(err, t("groups:create.errorGeneric")))
+      const fieldResult = applyServerFieldErrors(err, form.setError, {
+        fields: Object.keys(createGroupSchema.shape),
+      })
+      setServerError(
+        shouldShowGenericError(fieldResult)
+          ? classifyServerError(err, t("groups:create.errorGeneric"))
+          : null
+      )
     }
   }
 

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/features/group/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
 import { HttpError } from "@/lib/http"
+import { applyServerFieldErrors, shouldShowGenericError } from "@/lib/form-errors"
 import { getServerErrorCode, parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -342,7 +343,14 @@ function InfoSection({
       })
       toast.success(t("groups:settings.saved"))
     } catch (err) {
-      setServerError(parseServerError(err, t("groups:settings.errorGeneric")))
+      const fieldResult = applyServerFieldErrors(err, form.setError, {
+        fields: Object.keys(updateGroupSchema.shape),
+      })
+      setServerError(
+        shouldShowGenericError(fieldResult)
+          ? parseServerError(err, t("groups:settings.errorGeneric"))
+          : null
+      )
     }
   }
 

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -266,6 +266,9 @@ export function TagsListPage() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       toast.error(t("tags:form.createError", { error: message }))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 
@@ -277,6 +280,9 @@ export function TagsListPage() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       toast.error(t("tags:form.updateError", { error: message }))
+      // Re-throw so the dialog can map field-level 422 errors onto its
+      // inputs (it stays open). The toast above is the summary.
+      throw err
     }
   }
 

--- a/go/apiserver/locations_test.go
+++ b/go/apiserver/locations_test.go
@@ -247,10 +247,12 @@ func TestLocationsGet_InvalidID(t *testing.T) {
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
-func TestLocationsUpdate_PartialData(t *testing.T) {
+func TestLocationsUpdate_AddressOptional(t *testing.T) {
 	c := qt.New(t)
 
-	// Use the full params which includes EntityService and all components
+	// Address is optional: a location may carry only a name. Updating with
+	// the address omitted must succeed and clear the stored address rather
+	// than rejecting the request with a 422 (the old, wrong behaviour).
 	params, testUser, testGroup := newParams()
 	locations := must.Must(getRegistrySetFromParams(params, testUser).LocationRegistry.List(c.Context()))
 	location := locations[0]
@@ -261,7 +263,7 @@ func TestLocationsUpdate_PartialData(t *testing.T) {
 			Type: "locations",
 			Attributes: models.WithID(location.ID, &models.Location{
 				Name: "Updated Name",
-				// Address field is not provided
+				// Address field is not provided — it is optional.
 			}),
 		},
 	}
@@ -278,8 +280,9 @@ func TestLocationsUpdate_PartialData(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	body := rr.Body.Bytes()
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("Body: %s", body))
-	c.Assert(body, checkers.JSONPathEquals("$.errors[0].error.error.data.attributes.address"), "cannot be blank")
+	c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("Body: %s", body))
+	c.Assert(body, checkers.JSONPathEquals("$.data.attributes.name"), "Updated Name")
+	c.Assert(body, checkers.JSONPathEquals("$.data.attributes.address"), "")
 }
 
 func TestLocationsUpdate_ForeignIDInRequestBody(t *testing.T) {

--- a/go/models/location.go
+++ b/go/models/location.go
@@ -62,9 +62,12 @@ func (*Location) Validate() error {
 func (a *Location) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 
+	// Address is intentionally optional: a location may be a bare label
+	// ("Garage", "Storage unit") with no street address. The DB column is
+	// NOT NULL but an empty string satisfies it, so no migration is needed.
+	// The frontend form surfaces address as optional too.
 	fields = append(fields,
 		validation.Field(&a.Name, rules.NotEmpty),
-		validation.Field(&a.Address, rules.NotEmpty),
 	)
 
 	return validation.ValidateStructWithContext(ctx, a, fields...)

--- a/go/models/location_test.go
+++ b/go/models/location_test.go
@@ -32,6 +32,18 @@ func TestLocation_ValidateWithContext_HappyPath(t *testing.T) {
 		err := location.ValidateWithContext(ctx)
 		c.Assert(err, qt.IsNil)
 	})
+
+	t.Run("address is optional", func(t *testing.T) {
+		c := qt.New(t)
+
+		// A location with only a name and no address is valid — address is
+		// optional (a bare label like "Garage" needs no street address).
+		location := models.Location{Name: "Garage"}
+
+		ctx := context.Background()
+		err := location.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNil)
+	})
 }
 
 func TestLocation_ValidateWithContext_UnhappyPaths(t *testing.T) {
@@ -44,11 +56,6 @@ func TestLocation_ValidateWithContext_UnhappyPaths(t *testing.T) {
 			name:          "missing name",
 			location:      models.Location{Address: "123 Test Street"},
 			errorContains: "name: cannot be blank",
-		},
-		{
-			name:          "missing address",
-			location:      models.Location{Name: "Test Location"},
-			errorContains: "address: cannot be blank",
 		},
 		{
 			name:          "empty location",


### PR DESCRIPTION
## Two bugs (found via the Add-location form)

The "Add location" form rejected `jkjkj` with **"Please check the highlighted fields / Something went wrong"** — but nothing was highlighted, and the API response clearly named the field:

```json
{ "errors": [ { "status": "Unprocessable Entity",
  "error": { "type": "validation.Errors",
    "error": { "data": { "attributes": { "address": "cannot be blank" } } } } } ] }
```

### Bug 1 — backend required `address`, but it's meant to be optional
`Location.ValidateWithContext` enforced `rules.NotEmpty` on `Address`, yet the form labels it **"Optional"** and the design mock has no address field at all. A location can be a bare label ("Garage", "Storage unit").

**Fix:** drop the `NotEmpty` rule on `Address`. The DB column stays `NOT NULL` — an empty string satisfies it — so **no migration is needed**.

### Bug 2 — field-level server errors weren't surfaced on the field
The 422 envelope names the failing field, but the frontend only rendered a single generic banner (its classifier even noted *"we don't bother building a field map"*). Every entity form swallowed the specificity.

**Fix:** a reusable pair of helpers, wired into **every** entity form:
- `extractFieldErrors()` (`lib/server-error.ts`) — walks the nested `errors[0].error.error.data.attributes.{field}` envelope (incl. array paths like `urls.0`).
- `applyServerFieldErrors()` / `shouldShowGenericError()` (`lib/form-errors.ts`) — maps onto react-hook-form via `setError`, honoring snake_case↔camelCase field maps, and reports anything it couldn't place.

**Forms wired:**
- **In-component (banner-owning):** Location, Area, CreateGroup, GroupSettings, EditProfile — map fields and suppress the generic banner when everything maps cleanly. `CommodityFormDialog` is refactored onto the shared helper (drops its duplicated bespoke parser).
- **Toast dialogs (contract change):** Tag, SupplyLink, Lend, EditLoan, SendForService, Maintenance, StatusTransition — the host now re-throws after its summary toast so the dialog can map the field inline and stay open. `FileEditPage` handled in place.

## Notes / decisions
- Kept the existing summary **toast** on the toast dialogs *and* added the inline field highlight (lowest-risk, strict improvement) rather than ripping toasts out.
- Left the **password-change** form's bespoke `422 → "incorrect current password"` copy alone — it's an auth flow, not a CRUD entity, and field-mapping would replace nice i18n copy with the raw BE string.

## Verification
- **Go:** `build` ✓, `vet`/`golangci-lint` on changed packages 0 issues, models + apiserver + registry tests pass.
- **Frontend:** `tsc` ✓, `eslint` ✓, `prettier` ✓, **1205 tests / 160 files pass** — including new helper unit tests and regression tests for the Location field-map and the SupplyLink dialog (422 → field, stays open).