### PR TITLE
[#1967] Auto-provision the back-office operator in demo/preview deploys

### DIFF
--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
@@ -28,14 +28,20 @@ type Config struct {
 	Role     string `yaml:"role" env:"ROLE"`
 	Password string `yaml:"password" env:"PASSWORD"`
 	Force    bool   `yaml:"force" env:"FORCE"`
-	// MFAEnforced defaults to true (secure posture): the operator must enrol
-	// TOTP via `inventario backoffice mfa setup` before they can sign in.
-	// Demo/preview auto-provisioning sets --mfa-enforced=false so the seeded
-	// operator can sign in with password only — a Helm Job has no interactive
-	// terminal to complete TOTP enrolment, and an MFA-enforced no-secret row
-	// fails closed with HTTP 501 at login (issue #1967). env-default keeps the
-	// secure default when the value comes from config/env rather than a flag.
-	MFAEnforced bool `yaml:"mfa-enforced" env:"MFA_ENFORCED" env-default:"true"`
+	// MFAEnforced is a *bool so an OMITTED value (nil) stays distinct from an
+	// explicit false. nil flows to the service, which applies the secure
+	// default of true (see services/backoffice.resolveMFAEnforced): the
+	// operator must enrol TOTP via `inventario backoffice mfa setup` before
+	// /backoffice/login will issue a session token (a no-secret MFAEnforced=true
+	// row fails closed with HTTP 501). A plain bool would be unsafe here —
+	// shared.ReadSection overwrites this struct from a zero-valued wrapper, and
+	// cleanenv can't tell an omitted YAML/env key from an explicit `false` (both
+	// are the bool zero value), so an env-default on a bool could silently flip
+	// an operator's explicit `mfa-enforced: false` back to true or leave a
+	// partially-populated config section insecurely false. The pointer makes the
+	// unset/true/false states explicit; demo/preview pass --mfa-enforced=false
+	// to provision a password-only operator (issue #1967).
+	MFAEnforced *bool `yaml:"mfa-enforced" env:"MFA_ENFORCED"`
 }
 
 // Command is the cobra wrapper around `backoffice bootstrap`.
@@ -43,18 +49,21 @@ type Command struct {
 	command.Base
 
 	config Config
+	// mfaEnforcedFlag backs the --mfa-enforced flag. cobra needs a concrete
+	// bool; run() promotes it into the request only when the flag was
+	// explicitly set (Flags().Changed), giving precedence
+	// flag > config/env > secure default (nil → true at the service).
+	mfaEnforcedFlag bool
 }
 
 // New constructs the command with the supplied database config.
 func New(dbConfig *shared.DatabaseConfig) *Command {
 	c := &Command{}
 
-	// Secure default: MFA is enforced unless the operator/Job explicitly opts
-	// out with --mfa-enforced=false. Set before TryReadSection so a config
-	// file / env that omits the key keeps the safe value; cleanenv's
-	// env-default:"true" preserves it on the env path too.
-	c.config.MFAEnforced = true
-
+	// Populate config from an optional config.yaml `backoffice.bootstrap`
+	// section + INVENTARIO_BACKOFFICE_BOOTSTRAP_* env. MFAEnforced is a *bool,
+	// so an omitted key stays nil (→ secure default at the service) rather than
+	// a silent insecure false.
 	shared.TryReadSection("backoffice.bootstrap", &c.config)
 
 	c.Base = command.NewBase(&cobra.Command{
@@ -117,7 +126,7 @@ func (c *Command) registerFlags() {
 	c.Cmd().Flags().StringVar(&c.config.Role, "role", c.config.Role, "Back-office role: platform_admin (default) or support_agent")
 	c.Cmd().Flags().StringVar(&c.config.Password, "password", c.config.Password, "Password (auto-generated if omitted)")
 	c.Cmd().Flags().BoolVar(&c.config.Force, "force", c.config.Force, "Allow adding a second+ back-office user when one already exists")
-	c.Cmd().Flags().BoolVar(&c.config.MFAEnforced, "mfa-enforced", c.config.MFAEnforced, "Require TOTP enrollment before the operator can sign in (default true; set false for demo/preview where password-only login is wanted)")
+	c.Cmd().Flags().BoolVar(&c.mfaEnforcedFlag, "mfa-enforced", true, "Require TOTP enrollment before the operator can sign in (default true; set --mfa-enforced=false for demo/preview where password-only login is wanted)")
 }
 
 func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
@@ -161,16 +170,24 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 		}
 	}()
 
+	// MFA precedence: an explicit --mfa-enforced flag wins; otherwise fall back
+	// to the config-file/env value (cfg.MFAEnforced, nil when unset). A nil
+	// reaches the service as "use the secure default" (true). Flags().Changed
+	// lets --mfa-enforced=false win while an omitted flag defers to config/env,
+	// and an absent value everywhere stays enforced.
+	mfaEnforced := cfg.MFAEnforced
+	if c.Cmd().Flags().Changed("mfa-enforced") {
+		v := c.mfaEnforcedFlag
+		mfaEnforced = &v
+	}
+
 	result, err := svc.Bootstrap(c.Cmd().Context(), backoffice.BootstrapRequest{
-		Email:    email,
-		Name:     name,
-		Role:     role,
-		Password: cfg.Password,
-		Force:    cfg.Force,
-		// Pass the flag value through as a non-nil override; the CLI's own
-		// default is true, so omitting --mfa-enforced preserves the secure
-		// posture while demo Jobs can opt out with --mfa-enforced=false.
-		MFAEnforced: &cfg.MFAEnforced,
+		Email:       email,
+		Name:        name,
+		Role:        role,
+		Password:    cfg.Password,
+		Force:       cfg.Force,
+		MFAEnforced: mfaEnforced,
 	})
 	if err != nil {
 		return errxtrace.Wrap("failed to bootstrap backoffice user", err)

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
@@ -28,6 +28,14 @@ type Config struct {
 	Role     string `yaml:"role" env:"ROLE"`
 	Password string `yaml:"password" env:"PASSWORD"`
 	Force    bool   `yaml:"force" env:"FORCE"`
+	// MFAEnforced defaults to true (secure posture): the operator must enrol
+	// TOTP via `inventario backoffice mfa setup` before they can sign in.
+	// Demo/preview auto-provisioning sets --mfa-enforced=false so the seeded
+	// operator can sign in with password only — a Helm Job has no interactive
+	// terminal to complete TOTP enrolment, and an MFA-enforced no-secret row
+	// fails closed with HTTP 501 at login (issue #1967). env-default keeps the
+	// secure default when the value comes from config/env rather than a flag.
+	MFAEnforced bool `yaml:"mfa-enforced" env:"MFA_ENFORCED" env-default:"true"`
 }
 
 // Command is the cobra wrapper around `backoffice bootstrap`.
@@ -40,6 +48,12 @@ type Command struct {
 // New constructs the command with the supplied database config.
 func New(dbConfig *shared.DatabaseConfig) *Command {
 	c := &Command{}
+
+	// Secure default: MFA is enforced unless the operator/Job explicitly opts
+	// out with --mfa-enforced=false. Set before TryReadSection so a config
+	// file / env that omits the key keeps the safe value; cleanenv's
+	// env-default:"true" preserves it on the env path too.
+	c.config.MFAEnforced = true
 
 	shared.TryReadSection("backoffice.bootstrap", &c.config)
 
@@ -73,6 +87,15 @@ ROLE:
     seed value).
   • support_agent is also accepted for non-first invocations under --force.
 
+MFA:
+
+  • --mfa-enforced defaults to true: the operator must enrol TOTP via
+    "inventario backoffice mfa setup" before /backoffice/login will issue a
+    session token. Until then login returns HTTP 501.
+  • Pass --mfa-enforced=false to provision a password-only operator for
+    demo/preview environments where no TOTP app is available (issue #1967).
+    Never use this in production.
+
 Examples:
   inventario backoffice bootstrap --email admin@example.com --name "Ops Admin"
   inventario backoffice bootstrap --email second@example.com --name "Second" --force
@@ -94,6 +117,7 @@ func (c *Command) registerFlags() {
 	c.Cmd().Flags().StringVar(&c.config.Role, "role", c.config.Role, "Back-office role: platform_admin (default) or support_agent")
 	c.Cmd().Flags().StringVar(&c.config.Password, "password", c.config.Password, "Password (auto-generated if omitted)")
 	c.Cmd().Flags().BoolVar(&c.config.Force, "force", c.config.Force, "Allow adding a second+ back-office user when one already exists")
+	c.Cmd().Flags().BoolVar(&c.config.MFAEnforced, "mfa-enforced", c.config.MFAEnforced, "Require TOTP enrollment before the operator can sign in (default true; set false for demo/preview where password-only login is wanted)")
 }
 
 func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
@@ -143,6 +167,10 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 		Role:     role,
 		Password: cfg.Password,
 		Force:    cfg.Force,
+		// Pass the flag value through as a non-nil override; the CLI's own
+		// default is true, so omitting --mfa-enforced preserves the secure
+		// posture while demo Jobs can opt out with --mfa-enforced=false.
+		MFAEnforced: &cfg.MFAEnforced,
 	})
 	if err != nil {
 		return errxtrace.Wrap("failed to bootstrap backoffice user", err)

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
@@ -246,3 +246,46 @@ func TestBootstrap_RejectsMalformedEmail(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "validation failed")
 }
+
+// TestBootstrap_MFADefaultsEnforced pins the secure default: with no
+// --mfa-enforced flag (and no config/env override) the seeded operator is
+// created MFA-enforced. Guards against the regression PR #1994 review flagged —
+// a plain bool / env-default could let an omitted value silently land as false.
+func TestBootstrap_MFADefaultsEnforced(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNil)
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+	c.Assert(users[0].MFAEnforced, qt.IsTrue,
+		qt.Commentf("omitting --mfa-enforced must keep the secure default (MFA enforced)"))
+}
+
+// TestBootstrap_MFADisabledByFlag pins the demo/preview opt-out: an explicit
+// --mfa-enforced=false provisions a password-only operator (MFAEnforced=false),
+// so a Helm Job — which has no interactive terminal for TOTP enrolment — can
+// seed an operator that can actually sign in at /backoffice/login (issue #1967).
+func TestBootstrap_MFADisabledByFlag(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+		"--mfa-enforced=false",
+	)
+	c.Assert(err, qt.IsNil)
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+	c.Assert(users[0].MFAEnforced, qt.IsFalse,
+		qt.Commentf("--mfa-enforced=false must provision a password-only operator"))
+}

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -78,6 +78,15 @@ type BootstrapRequest struct {
 	Role     models.BackofficeRole
 	Password string // optional; auto-generated when empty
 	Force    bool   // allow creating an additional user when the table is non-empty
+	// MFAEnforced controls the new operator's MFAEnforced column. nil keeps
+	// the secure default (true): the operator must enrol TOTP via
+	// `inventario backoffice mfa setup` before the login handler will issue a
+	// session token (a no-secret MFAEnforced=true row gets the 501
+	// fail-closed response). Demo/preview auto-provisioning passes a non-nil
+	// false so the seeded operator can sign in with password only — there is
+	// no interactive terminal on a Helm Job to copy a TOTP enrolment URL, and
+	// forcing MFA there reproduces the demo lockout #1967 warns about.
+	MFAEnforced *bool
 }
 
 // BootstrapResult captures the outcome of a Bootstrap call.
@@ -178,15 +187,7 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		PasswordHash: string(hash),
 		Role:         role,
 		IsActive:     true,
-		// MFAEnforced defaults to true in Phase 4: every freshly
-		// bootstrapped operator must run `inventario backoffice mfa setup`
-		// before they can sign in. The login flow returns 501 with
-		// `backoffice.mfa_not_implemented` while MFAEnforced=true but no
-		// secret row exists; the operator's first sign-in only succeeds
-		// after the CLI enrols them. This matches the schema default
-		// (also flipped to true at this commit) so the data state and
-		// the security promise stay in sync.
-		MFAEnforced: true,
+		MFAEnforced:  resolveMFAEnforced(req.MFAEnforced),
 	}
 
 	// Run the model's full validation (length caps, EmailPattern match)
@@ -218,6 +219,20 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		User:              created,
 		GeneratedPassword: generated,
 	}, nil
+}
+
+// resolveMFAEnforced collapses the optional MFAEnforced override into a
+// concrete column value. nil keeps the secure default (true): a freshly
+// bootstrapped operator must run `inventario backoffice mfa setup` before they
+// can sign in — the login flow returns 501 (`backoffice.mfa_not_implemented`)
+// while MFAEnforced=true but no secret row exists, matching the schema default.
+// A non-nil false (demo/preview auto-provisioning) provisions a password-only
+// operator that can sign in without TOTP enrolment — see BootstrapRequest.
+func resolveMFAEnforced(override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return true
 }
 
 // nowInUTC returns the current time in UTC. Tiny helper so MFA code

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -88,6 +88,36 @@ spec:
                 exit 1
               fi
 
+              # Auto-provision the back-office (platform-operator) identity for
+              # /backoffice/login when enabled (#1967). Demo/preview only —
+              # gated by backofficeUser.enabled. Idempotent on email: a re-run
+              # prints "already exists" and exits 0. The bootstrap command
+              # reuses the INVENTARIO_DB_DSN exported above (migrator DSN).
+              if [ "${BACKOFFICE_USER_ENABLED:-false}" = "true" ]; then
+                if [ -z "${INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD:-}" ]; then
+                  echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
+                  exit 1
+                fi
+                k=1
+                while [ "$k" -le 15 ]; do
+                  if inventario backoffice bootstrap \
+                    --email="$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL" \
+                    --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
+                    --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
+                    --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
+                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED"; then
+                    break
+                  fi
+                  echo "Back-office bootstrap attempt $k failed, retrying in 2 seconds..."
+                  k=$((k + 1))
+                  sleep 2
+                done
+                if [ "$k" -gt 15 ]; then
+                  echo "Back-office bootstrap failed after 15 attempts"
+                  exit 1
+                fi
+              fi
+
               if [ "${SEED_DATABASE:-false}" != "true" ]; then
                 echo "Skipping database seeding"
                 exit 0
@@ -195,6 +225,28 @@ spec:
                   key: SETUP_ADMIN_PASSWORD
             - name: INVENTARIO_MIGRATE_DATA_ADMIN_NAME
               value: {{ .Values.setupJob.initData.adminName | quote }}
+            # Back-office (platform-operator) auto-provisioning (#1967). The
+            # shell step above only runs when BACKOFFICE_USER_ENABLED=true.
+            # Demo/preview overlays flip backofficeUser.enabled on; production
+            # leaves it false and provisions operators manually.
+            - name: BACKOFFICE_USER_ENABLED
+              value: {{ ternary "true" "false" .Values.backofficeUser.enabled | quote }}
+            {{- if .Values.backofficeUser.enabled }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL
+              value: {{ .Values.backofficeUser.email | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME
+              value: {{ .Values.backofficeUser.name | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE
+              value: {{ .Values.backofficeUser.role | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED
+              value: {{ ternary "true" "false" .Values.backofficeUser.mfaEnforced | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: BACKOFFICE_USER_PASSWORD
+                  optional: true
+            {{- end }}
             - name: SEED_DATABASE
               value: {{ ternary "true" "false" .Values.setupJob.initData.seedDatabase | quote }}
             # SETUP_SKIP_SEED_ON_UPGRADE: in non-argocdMode this was driven by

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -235,6 +235,36 @@ spec:
                 exit 1
               fi
 
+              # Auto-provision the back-office (platform-operator) identity for
+              # /backoffice/login when enabled (#1967). Demo/preview only —
+              # gated by backofficeUser.enabled. Idempotent on email: a re-run
+              # prints "already exists" and exits 0. The bootstrap command
+              # reuses the INVENTARIO_DB_DSN exported above (migrator DSN).
+              if [ "${BACKOFFICE_USER_ENABLED:-false}" = "true" ]; then
+                if [ -z "${INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD:-}" ]; then
+                  echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
+                  exit 1
+                fi
+                k=1
+                while [ "$k" -le 15 ]; do
+                  if inventario backoffice bootstrap \
+                    --email="$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL" \
+                    --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
+                    --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
+                    --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
+                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED"; then
+                    break
+                  fi
+                  echo "Back-office bootstrap attempt $k failed, retrying in 2 seconds..."
+                  k=$((k + 1))
+                  sleep 2
+                done
+                if [ "$k" -gt 15 ]; then
+                  echo "Back-office bootstrap failed after 15 attempts"
+                  exit 1
+                fi
+              fi
+
               if [ "${SEED_DATABASE:-false}" != "true" ]; then
                 echo "Skipping database seeding"
                 exit 0
@@ -338,6 +368,28 @@ spec:
                   key: SETUP_ADMIN_PASSWORD
             - name: INVENTARIO_MIGRATE_DATA_ADMIN_NAME
               value: {{ .Values.setupJob.initData.adminName | quote }}
+            # Back-office (platform-operator) auto-provisioning (#1967). The
+            # shell step above only runs when BACKOFFICE_USER_ENABLED=true.
+            # Demo/preview overlays flip backofficeUser.enabled on; production
+            # leaves it false and provisions operators manually.
+            - name: BACKOFFICE_USER_ENABLED
+              value: {{ ternary "true" "false" .Values.backofficeUser.enabled | quote }}
+            {{- if .Values.backofficeUser.enabled }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL
+              value: {{ .Values.backofficeUser.email | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME
+              value: {{ .Values.backofficeUser.name | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE
+              value: {{ .Values.backofficeUser.role | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED
+              value: {{ ternary "true" "false" .Values.backofficeUser.mfaEnforced | quote }}
+            - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: BACKOFFICE_USER_PASSWORD
+                  optional: true
+            {{- end }}
             - name: SEED_DATABASE
               value: {{ ternary "true" "false" .Values.setupJob.initData.seedDatabase | quote }}
             # See job-init-data.yaml — opt the seed into writing bundled

--- a/helm/inventario/templates/secret.yaml
+++ b/helm/inventario/templates/secret.yaml
@@ -26,6 +26,9 @@ data:
   AWS_ACCESS_KEY_ID: {{ ternary .Values.demo.minio.rootUser .Values.secrets.awsAccessKeyId .Values.demo.minio.enabled | b64enc | quote }}
   AWS_SECRET_ACCESS_KEY: {{ ternary .Values.demo.minio.rootPassword .Values.secrets.awsSecretAccessKey .Values.demo.minio.enabled | b64enc | quote }}
   SETUP_ADMIN_PASSWORD: {{ .Values.setupJob.initData.adminPassword | b64enc | quote }}
+  {{- if .Values.backofficeUser.enabled }}
+  BACKOFFICE_USER_PASSWORD: {{ .Values.setupJob.initData.backofficeUserPassword | b64enc | quote }}
+  {{- end }}
   {{- if .Values.setupJob.bootstrap.superuserDsn }}
   SETUP_SUPERUSER_DSN: {{ .Values.setupJob.bootstrap.superuserDsn | b64enc | quote }}
   {{- end }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -547,6 +547,7 @@ secrets:
   #   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY (required when aivision.provider=anthropic)
   #   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY    (required when aivision.provider=openai)
   #   SETUP_ADMIN_PASSWORD                       (required by job-setup if setupJob.enabled)
+  #   BACKOFFICE_USER_PASSWORD                   (required by setup/init-data Job when backofficeUser.enabled; maps to setupJob.initData.backofficeUserPassword; min 8 chars + upper + lower + digit)
   #   SETUP_SUPERUSER_DSN                        (optional; used when setupJob.bootstrap.superuserDsn is managed outside the chart)
   #   AWS_ACCESS_KEY_ID                          (required for S3/MinIO upload)
   #   AWS_SECRET_ACCESS_KEY                      (required for S3/MinIO upload)

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -737,6 +737,44 @@ setupJob:
     # Env: INVENTARIO_SEED_ALLOW_BLOB_UPLOADS
     seedBlobUploads: false
 
+    # Back-office (platform-operator) login password for /backoffice/login,
+    # consumed by the setup / init-data Job's `inventario backoffice bootstrap
+    # --password` step ONLY when backofficeUser.enabled=true (below). It is the
+    # BACKOFFICE_USER_PASSWORD value the chart bakes into its Secret, the exact
+    # mirror of adminPassword above. Empty by default; provide via
+    # --set setupJob.initData.backofficeUserPassword=<value> or via
+    # secrets.existingSecret key BACKOFFICE_USER_PASSWORD. Must satisfy the
+    # password policy (8+ chars, upper, lower, digit). Production never enables
+    # backofficeUser, so this stays empty there.
+    backofficeUserPassword: ""
+
+# ============================================================
+# Back-office user auto-provisioning (#1967)
+# ------------------------------------------------------------
+# Auto-creates the platform-operator identity used by /backoffice/login, the
+# same way setupJob.initData seeds the app admin. When enabled, the setup /
+# init-data Job runs `inventario backoffice bootstrap` (idempotent on email).
+#
+# DISABLED by default and gated to demo/preview overlays ONLY. NEVER enable in
+# production: there, operators are created manually via `inventario backoffice
+# bootstrap` so the one-time password is never written to a Secret, and MFA is
+# enrolled out-of-band via `inventario backoffice mfa setup`.
+# ============================================================
+backofficeUser:
+  enabled: false
+  # Operator login email + display name (non-secret; passed as --email/--name).
+  email: "operator@example.com"
+  name: "Platform Operator"
+  # Role: platform_admin (full mutation rights) or support_agent.
+  role: "platform_admin"
+  # mfaEnforced=false provisions a PASSWORD-ONLY operator so the seeded account
+  # can sign in on a demo env with no authenticator app. A Helm Job has no
+  # interactive terminal to complete TOTP enrollment, and an MFA-enforced
+  # operator with no secret row fails closed with HTTP 501 at /backoffice/login
+  # (the #1967 demo lockout). Leave false for demo; production never enables
+  # this block at all.
+  mfaEnforced: false
+
 # ============================================================
 # Namespace ResourceQuota + LimitRange (#1866)
 # ------------------------------------------------------------

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -227,6 +227,25 @@ openssl rand -base64 24
 
 Stash both for "Filling the bundle".
 
+The `backoffice.password` field seeds the back-office (platform-operator)
+login for `/backoffice/login` on the demo/preview envs (#1967), in the same
+flow as `admin.password`: `apply-secrets.sh` writes it into the
+`inventario-admin` Secret under key `BACKOFFICE_USER_PASSWORD`, and the chart's
+setup / init-data Job reads it via `secretKeyRef` to run
+`inventario backoffice bootstrap --password` (idempotent on email) when
+`backofficeUser.enabled=true` — which `preview-base.values.yaml` sets on master
++ longevity, with `mfaEnforced=false` so the operator can sign in password-only
+(a Helm Job can't complete interactive TOTP enrollment, and an MFA-enforced
+operator with no secret row fails closed with HTTP 501 at login). Same
+complexity rule as the admin password (min 8 chars + upper + lower + digit).
+Per-PR previews inline a dev value (`setupJob.initData.backofficeUserPassword`)
+in `applicationset-pr.yaml` instead. Leave `backoffice.password` empty only if
+you do NOT want a back-office operator on these envs — the Job's bootstrap step
+then fails loudly until it is set. Production never enables `backofficeUser`, so
+the field is inert there (operators are created by hand so the one-time password
+is never stored, and MFA is enrolled out-of-band via
+`inventario backoffice mfa setup`).
+
 ### 4b. Generate the stable signing keys (recommended for master + longevity)
 
 Three runtime keys pin the apiserver's signing material on the persistent envs.

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -404,6 +404,10 @@ chmod 600 infra/vm/secrets/secrets.local.yaml
 #    master + longevity, optional),
 #    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
 #    github.{app_id, app_installation_id, app_private_key, url}.
+#    Fill backoffice.password (step 4 above) ONLY for the demo/preview
+#    /backoffice/login operator on master + longevity (8+ chars + upper +
+#    lower + digit); leave it empty to skip the back-office operator there
+#    (per-PR previews inline their own via setupJob.initData.backofficeUserPassword).
 #    Fill anthropic.api_key (step 7 above) ONLY to turn the AI-vision feature
 #    on for master + longevity — and mind the boot-ordering hazard noted there.
 #    Fill the velero.* block (step 6 above) ONLY if you want the daily R2

--- a/infra/argocd/applicationset-pr.yaml
+++ b/infra/argocd/applicationset-pr.yaml
@@ -82,6 +82,10 @@ spec:
               setupJob:
                 initData:
                   adminPassword: "PreviewAdmin123"
+                  # Well-known dev back-office operator login for tailnet-gated PR previews (#1967).
+                  # Per-PR namespaces can't pull the sops inventario-admin Secret, so the chart
+                  # renders its own Secret from this value (mirrors adminPassword above).
+                  backofficeUserPassword: "PreviewOperator123"
               # AI-vision photo-scan (#1976): PR previews run the REAL Anthropic
               # provider so reviewers can test extraction on actual uploaded
               # photos. The key is NOT inlined here (public repo) — emberstack/

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -107,6 +107,29 @@ setupJob:
     # INVENTARIO_SEED_ALLOW_BLOB_UPLOADS on the Job's temporary seed server.
     seedBlobUploads: true
 
+# Auto-provision the back-office (platform-operator) identity for
+# /backoffice/login on every preview/demo env (#1967). Shared by PR previews,
+# master, and longevity (all layer this file). Password-only (mfaEnforced:
+# false) so it can sign in without an authenticator app — a Helm Job can't
+# complete interactive TOTP enrollment, and an MFA-enforced no-secret operator
+# fails closed with HTTP 501 at login.
+#
+# The BACKOFFICE_USER_PASSWORD the bootstrap step consumes is sourced per
+# Application, exactly like SETUP_ADMIN_PASSWORD:
+#   - PR previews (applicationset-pr.yaml): inlined dev value under
+#     setupJob.initData.backofficeUserPassword (the chart renders its own
+#     Secret there).
+#   - master + longevity (secrets.existingSecret: inventario-admin): the
+#     sops bundle's backoffice.password, materialized into inventario-admin
+#     under key BACKOFFICE_USER_PASSWORD by infra/vm/scripts/apply-secrets.sh.
+# This is demo/preview ONLY — production never layers this overlay.
+backofficeUser:
+  enabled: true
+  email: "operator@inventario.example"
+  name: "Demo Operator"
+  role: "platform_admin"
+  mfaEnforced: false
+
 # AI-vision photo-scan provider is intentionally NOT set in this shared overlay
 # — it's pinned per-Application to `anthropic` everywhere: master + longevity
 # (applicationset-{master,longevity}.yaml, key via inventario-admin) AND PR

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -97,6 +97,19 @@ remote_apply() {
 # script ensures the missing field is surfaced loudly to bootstrap.sh
 # (which runs under `set -e` and will halt the whole bootstrap).
 ADMIN_PASSWORD=$(lookup "admin.password")
+# Optional back-office (platform-operator) password for the demo/preview envs
+# (#1967). When present it is injected into the inventario-admin Secret below as
+# BACKOFFICE_USER_PASSWORD so the chart's setup/init-data Job can run
+# `inventario backoffice bootstrap --password` (the Job references it via
+# secretKeyRef when backofficeUser.enabled=true, which preview-base sets on
+# master + longevity). Absent it, warn (don't fail) — the persistent envs ran
+# without a back-office operator for a long time, so this stays best-effort; the
+# bootstrap step's secretKeyRef then points at a missing key and that init
+# container fails loudly in the Job logs (it does not block the app Deployment).
+BACKOFFICE_USER_PASSWORD=$(lookup "backoffice.password")
+if [ -z "$BACKOFFICE_USER_PASSWORD" ]; then
+    warn "backoffice.password missing in secrets bundle; inv-vcl01-master/longevity layer backofficeUser.enabled=true (preview-base, #1967), so their setup Job's 'inventario backoffice bootstrap' step will fail until BACKOFFICE_USER_PASSWORD is present. Set backoffice.password (8+ chars, upper, lower, digit) to auto-provision the /backoffice/login operator."
+fi
 # Optional runtime JWT signing key for the persistent envs (master + longevity).
 # When present it is injected into the inventario-admin Secret below as
 # INVENTARIO_RUN_JWT_SECRET so the apiserver stops minting a fresh random secret
@@ -184,6 +197,12 @@ stringData:
   SETUP_ADMIN_PASSWORD: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
+            if [ -n "$BACKOFFICE_USER_PASSWORD" ]; then
+                cat <<EOF
+  BACKOFFICE_USER_PASSWORD: |-
+$(printf '%s' "$BACKOFFICE_USER_PASSWORD" | sed 's/^/    /')
+EOF
+            fi
             if [ -n "$JWT_SECRET" ]; then
                 cat <<EOF
   INVENTARIO_RUN_JWT_SECRET: |-

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -24,6 +24,33 @@ admin:
   email: admin@example.invalid
   password: ""
 
+backoffice:
+  # Back-office (platform-operator) login password for /backoffice/login,
+  # auto-provisioned on the DEMO/PREVIEW envs only (#1967). Materialized by
+  # infra/vm/scripts/apply-secrets.sh into inv-vcl01-master/longevity
+  # inventario-admin under key BACKOFFICE_USER_PASSWORD; the chart's setup /
+  # init-data Job reads it via secretKeyRef to run
+  # `inventario backoffice bootstrap --password` (idempotent on email). The
+  # operator is provisioned with MFA OFF (preview-base sets
+  # backofficeUser.mfaEnforced=false) so it can sign in without an authenticator
+  # app — a Helm Job can't complete interactive TOTP enrollment, and an
+  # MFA-enforced operator with no secret row fails closed with HTTP 501 at login.
+  #
+  # OPTIONAL. When empty, apply-secrets.sh omits BACKOFFICE_USER_PASSWORD from
+  # inventario-admin and the master/longevity setup Job's bootstrap step fails
+  # (the value is referenced via secretKeyRef). Set it whenever the back-office
+  # operator should exist — must satisfy the password policy (8+ chars, upper,
+  # lower, digit). Generate e.g. with `openssl rand -base64 18`.
+  #
+  # Production does NOT use this — backofficeUser stays disabled there and
+  # operators are created by hand so the one-time password is never stored.
+  #
+  # `email`/`name` are informational — the chart sources the operator's email +
+  # name from values (backofficeUser.email / .name), not from the bundle.
+  email: operator@example.invalid
+  name: Demo Operator
+  password: ""
+
 jwt:
   # Runtime JWT signing key for the Inventario app on the PERSISTENT envs
   # (inv-vcl01-master + inv-vcl01-longevity). Materialized by


### PR DESCRIPTION
Closes #1967.

## What

Auto-provisions the back-office (platform-operator) user — the identity for `/backoffice/login` — on demo/preview deploys, the same way the app admin is already seeded. Removes the per-environment manual chore of `kubectl exec … inventario backoffice bootstrap` + copying the printed one-time password.

Gated to demo/preview only via a new `backofficeUser` Helm block (`enabled: false` by default). **Never enabled in production.**

## How

- **CLI — `inventario backoffice bootstrap` gains `--mfa-enforced`** (`go/cmd/inventario/backoffice/bootstrap/bootstrap.go`, `go/services/backoffice/service.go`). Default `true` (secure posture preserved); threaded as `BootstrapRequest.MFAEnforced *bool` where `nil` keeps the secure default, so every existing caller is unchanged.
  - **Why:** the operator was created with `MFAEnforced=true`, and `/backoffice/login` fails closed with **HTTP 501** (`backoffice.mfa_not_implemented`) for an MFA-enforced operator that has no enrolled TOTP secret. A Helm Job can't complete interactive TOTP enrollment, so a password-only auto-provisioned operator would be locked out — the exact lockout this issue warns about. Demo overlays pass `--mfa-enforced=false`.
- **Helm** — new `backofficeUser` values block + `BACKOFFICE_USER_PASSWORD` secret key (both gated by `backofficeUser.enabled`); an idempotent `inventario backoffice bootstrap` step added to both `job-init-data.yaml` (argocd wave +5) and `job-setup.yaml`, mirroring the existing `inventario db migrate data` admin wiring (DSN reuse, retry loop).
- **Overlays** — enabled on the shared `infra/helm-overlays/preview-base.values.yaml` (PR previews + master + longevity). PR previews inline a dev password in `applicationset-pr.yaml` (mirrors the existing `adminPassword: PreviewAdmin123`); master/longevity source it from the sops bundle (`backoffice.password`) materialized into the `inventario-admin` Secret by `apply-secrets.sh`.
- **Fail-loud safety** — Job-side empty-password guard + `optional: true` on the secretKeyRef, so a missing/empty password reds the Job with a clear message instead of silently minting an uncapturable random password.
- **Docs** — `infra/SECRETS.md` + `infra/vm/secrets/secrets.example.yaml`.

## Production safety

With chart defaults (`backofficeUser.enabled: false`): no operator is created, no `BACKOFFICE_USER_PASSWORD` key renders, and no real password is committed anywhere. Gating is enforced at the Helm `{{- if }}` (template) level in all three templates, not just a runtime shell guard.

## Verification (run during development)

- Go: `go build ./...`, `go test ./cmd/inventario/backoffice/...`, `golangci-lint` on the changed packages — reported green. The later review fixes touched only `applicationset-pr.yaml` + the two Job templates (no Go), so the Go results stand.
- Helm: `helm lint` — 0 failures. `helm template` with defaults renders no backoffice env/secret; with `backofficeUser.enabled=true` it renders the bootstrap step, the env block, the empty-password guard, and `optional: true` on the secretKeyRef, in the wave +5 init-data Job under argocdMode.
- `applicationset-pr.yaml` re-parsed as valid YAML; rendered Job shell passes `sh -n`.

A reviewer should re-confirm CI (build/test/lint + helm render) on the branch.

## ⚠️ Rollout ordering (reviewer note)

Because `backofficeUser.enabled: true` lives in the **shared** `preview-base` overlay, master + longevity will run the bootstrap step on their next sync. Add `backoffice.password` (8+ chars, upper/lower/digit) to the sops bundle **before/with** merge so `apply-secrets.sh` materializes `BACKOFFICE_USER_PASSWORD` into `inventario-admin`; otherwise the wave +5 init-data Job fails loudly (by design) until the key exists. PR previews need nothing extra (dev password inlined).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added back-office operator auto-provisioning during deployment with configurable MFA enforcement settings
  * New Helm configuration options for back-office user setup (email, name, role)
  * Back-office password management integrated into deployment secrets workflow

* **Documentation**
  * Updated setup guides documenting back-office operator provisioning and password configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->