### PR TITLE
[#1987] Drop location from the create dialog; assign it afterwards via a banner

### DIFF
--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -153,6 +153,26 @@ async function waitForStep(
   });
 }
 
+// selectLocationArea drives the Location → Area paired selects when they
+// are present. The Area trigger is `disabled` until a Location is chosen,
+// so Location goes first. When the caller supplied `locationName`, drive
+// the Location combobox by name; otherwise auto-pick the first option
+// (every fixture only creates one location). #1987 removed this picker
+// from the *create* dialog — items are created unassigned and filed
+// afterwards — so this no-ops in create mode: the `count() === 0` guard
+// keeps create-mode callers from stalling on a trigger that never mounts.
+// In edit mode the picker is still present and this assigns it.
+async function selectLocationArea(page: Page, c: TestCommodity) {
+  if (!c.areaName) return;
+  if ((await page.locator("#commodity-location").count()) === 0) return;
+  if (c.locationName) {
+    await selectByPartialOptionText(page, "commodity-location", c.locationName);
+  } else {
+    await pickFirstSelectOption(page, "commodity-location");
+  }
+  await selectByPartialOptionText(page, "commodity-area", c.areaName);
+}
+
 async function fillBasicsStep(page: Page, c: TestCommodity) {
   await page.fill("#commodity-name", c.name);
   await page.fill("#commodity-short-name", c.shortName);
@@ -160,25 +180,7 @@ async function fillBasicsStep(page: Page, c: TestCommodity) {
   if (c.type) {
     await selectByPartialOptionText(page, "commodity-type", c.type);
   }
-  // PR #1621 split Location/Area: the Area select is `disabled` until
-  // a Location is chosen, so picking an area without first picking a
-  // location stalls the helper on a permanently-not-enabled trigger.
-  // When the caller supplied `locationName`, drive the Location
-  // combobox by name. Otherwise auto-pick the first available option
-  // — every existing test only ever creates one location for its own
-  // fixture, so the first option IS the location they want.
-  if (c.areaName) {
-    if (c.locationName) {
-      await selectByPartialOptionText(
-        page,
-        "commodity-location",
-        c.locationName,
-      );
-    } else {
-      await pickFirstSelectOption(page, "commodity-location");
-    }
-    await selectByPartialOptionText(page, "commodity-area", c.areaName);
-  }
+  await selectLocationArea(page, c);
   // PR #1621 moved Product URLs onto the Basics step (a UrlList of
   // single-input rows, NOT a ChipInput). Each row gets
   // `data-testid="commodity-urls-row-N"`. The first row is always
@@ -425,7 +427,48 @@ export async function createCommodity(
   await page.waitForLoadState("networkidle");
   await recorder.takeScreenshot("commodity-create-05-created");
 
+  // The create dialog no longer assigns a location (#1987): the item was
+  // created unassigned. When the test wants it filed under an area, assign
+  // it now via the edit dialog (which still hosts the Location/Area picker)
+  // so downstream "commodity appears under <location>" assertions hold.
+  if (testCommodity.areaName) {
+    await assignCommodityLocation(page, recorder, testCommodity);
+  }
+
   return page.url();
+}
+
+// assignCommodityLocation files an already-created commodity under a
+// location/area via the edit dialog — the post-create counterpart to the
+// location picker the create dialog dropped (#1987). It opens edit, selects
+// Location → Area, then advances through the remaining (already-valid)
+// steps without re-filling and submits.
+async function assignCommodityLocation(
+  page: Page,
+  recorder: TestRecorder,
+  c: TestCommodity,
+) {
+  await page.click('[data-testid="commodity-detail-edit"]');
+  await page.waitForSelector('[data-testid="commodity-form-dialog"]');
+  await waitForStep(page, "basics");
+  await selectLocationArea(page, c);
+  await recorder.takeScreenshot("commodity-create-06-assign-location");
+  await gotoNext(page);
+  await waitForStep(page, "purchase");
+  await gotoNext(page);
+  await waitForStep(page, "warranty");
+  await gotoNext(page);
+  await waitForStep(page, "extras");
+  await gotoNext(page);
+  await page.waitForSelector('[data-testid="commodity-form-files-step"]', {
+    state: "visible",
+    timeout: 5000,
+  });
+  await page.click('[data-testid="commodity-form-submit"]');
+  await page
+    .locator('[data-testid="commodity-form-dialog"]')
+    .waitFor({ state: "hidden", timeout: 30000 });
+  await page.waitForLoadState("networkidle");
 }
 
 export async function verifyCommodityDetails(

--- a/frontend/src/components/items/AssignLocationBanner.tsx
+++ b/frontend/src/components/items/AssignLocationBanner.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react"
+import { ArrowRight, MapPin, X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+
+interface AssignLocationBannerProps {
+  // Whether the prompt applies: the commodity has no area AND the group
+  // has at least one location to file it under. False hides the banner.
+  show: boolean
+  // Opens the assignment surface — the edit dialog, where the
+  // location/area picker lives (#1987).
+  onAssign: () => void
+}
+
+// Non-blocking, dismissible notice shown on an unassigned commodity's
+// detail page (#1987). After the create dialog stops asking for a
+// location, this offers to file the item under one — without forcing the
+// choice. In-session dismiss only (returns on the next mount); a brand-new
+// item lands here straight after create, which is exactly when the nudge
+// is most useful.
+export function AssignLocationBanner({ show, onAssign }: AssignLocationBannerProps) {
+  const [dismissed, setDismissed] = useState(false)
+  const { t } = useTranslation()
+
+  if (!show || dismissed) return null
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl border border-border bg-primary/5 px-4 py-2.5"
+      role="status"
+      data-testid="assign-location-banner"
+    >
+      <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15">
+        <MapPin className="size-3.5 text-primary" />
+      </div>
+      <p className="flex-1 text-sm text-foreground">
+        {t("commodities:form.assignLocationBanner.title")}
+      </p>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 shrink-0 gap-1.5 text-xs"
+        onClick={onAssign}
+        data-testid="assign-location-banner-cta"
+      >
+        {t("commodities:form.assignLocationBanner.cta")}
+        <ArrowRight className="size-3" />
+      </Button>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={t("commodities:form.assignLocationBanner.dismiss")}
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -152,10 +152,11 @@ type StepKey = "ai" | FormStepKey
 // #1398/#1399.
 const STEP_FIELDS: Record<StepKey, (keyof CommodityFormInput)[]> = {
   ai: [],
-  // area_id is intentionally absent: the create dialog no longer asks
-  // for a location (#1987) and area is optional (#1986). Edit mode shows
-  // the picker but it never blocks step validation.
-  basics: ["name", "short_name", "urls", "type", "status", "count", "draft"],
+  // area_id stays in the Basics set so a server-side area_id error (only
+  // reachable in edit mode now) still maps back to Basics via the 422
+  // handler — but it never blocks Next: area is optional (#1986/#1987) so
+  // its schema is a bare z.string() that always passes step validation.
+  basics: ["name", "short_name", "urls", "type", "area_id", "status", "count", "draft"],
   purchase: [
     "purchase_date",
     "original_price",
@@ -1245,7 +1246,11 @@ function BasicsStep(props: any) {
                   onValueChange={field.onChange}
                   disabled={!selectedLocationId}
                 >
-                  <SelectTrigger id="commodity-area" className="w-full">
+                  <SelectTrigger
+                    id="commodity-area"
+                    className="w-full"
+                    aria-invalid={!!errors.area_id}
+                  >
                     <SelectValue
                       placeholder={
                         selectedLocationId
@@ -1264,6 +1269,7 @@ function BasicsStep(props: any) {
                 </Select>
               )}
             />
+            <FieldError error={errors.area_id} />
           </div>
         </div>
       ) : null}

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -152,7 +152,10 @@ type StepKey = "ai" | FormStepKey
 // #1398/#1399.
 const STEP_FIELDS: Record<StepKey, (keyof CommodityFormInput)[]> = {
   ai: [],
-  basics: ["name", "short_name", "urls", "type", "area_id", "status", "count", "draft"],
+  // area_id is intentionally absent: the create dialog no longer asks
+  // for a location (#1987) and area is optional (#1986). Edit mode shows
+  // the picker but it never blocks step validation.
+  basics: ["name", "short_name", "urls", "type", "status", "count", "draft"],
   purchase: [
     "purchase_date",
     "original_price",
@@ -827,6 +830,7 @@ export function CommodityFormDialog({
                 areas={areas}
                 locations={locations}
                 showStatus={mode === "edit"}
+                showLocationPicker={mode === "edit"}
               />
             ) : null}
             {step === "purchase" ? (
@@ -1001,8 +1005,18 @@ function FieldLabel({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RHF types thread generics through every helper; concrete types here are noisy.
 function BasicsStep(props: any) {
   const { t } = useTranslation()
-  const { register, control, errors, watch, setValue, trigger, areas, locations, showStatus } =
-    props
+  const {
+    register,
+    control,
+    errors,
+    watch,
+    setValue,
+    trigger,
+    areas,
+    locations,
+    showStatus,
+    showLocationPicker,
+  } = props
   // Mock AddItemDialog L1074-L1091: Location and Area are paired
   // selects. The form schema only carries `area_id` (the BE resolves
   // location via the area), so the location_id lives in local UI
@@ -1176,73 +1190,83 @@ function BasicsStep(props: any) {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1.5">
-          <FieldLabel htmlFor="commodity-location" required>
-            {t("commodities:fields.location")}
-          </FieldLabel>
-          <Select value={selectedLocationId || undefined} onValueChange={handleLocationChange}>
-            <SelectTrigger id="commodity-location" className="w-full" aria-required>
-              <SelectValue placeholder={t("commodities:fields.locationPlaceholder")} />
-            </SelectTrigger>
-            <SelectContent>
-              {visibleLocations.map((l) => (
-                <SelectItem key={l.id} value={l.id ?? ""}>
-                  {l.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <FieldLabel htmlFor="commodity-area" required>
-            {t("commodities:fields.area")}
-          </FieldLabel>
-          <Controller
-            control={control}
-            name="area_id"
-            render={({ field }) => (
-              <Select
-                // Re-key on selectedLocationId so a location swap
-                // remounts the Select with a clean Radix internal
-                // state — without this, Radix keeps the previously-
-                // selected label visible in the trigger even though
-                // the controlled value has been reset to "" and the
-                // option is no longer in the list, leaving the field
-                // looking blank rather than restoring the
-                // "Pick an area" placeholder.
-                key={selectedLocationId || "no-location"}
-                value={field.value || undefined}
-                onValueChange={field.onChange}
-                disabled={!selectedLocationId}
-              >
-                <SelectTrigger
-                  id="commodity-area"
-                  className="w-full"
-                  aria-required
-                  aria-invalid={!!errors.area_id}
+      {/* Location/Area picker — edit mode only (#1987). The create
+          dialog no longer asks for a location; items can be created
+          unassigned and a location offered afterwards via a banner.
+          In edit mode the picker also lets the user un-assign (Clear)
+          since area is now optional (#1986). */}
+      {showLocationPicker ? (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <FieldLabel htmlFor="commodity-location">
+                {t("commodities:fields.location")}
+              </FieldLabel>
+              {selectedLocationId ? (
+                <button
+                  type="button"
+                  onClick={() => handleLocationChange("")}
+                  className="text-xs text-muted-foreground transition-colors hover:text-foreground"
                 >
-                  <SelectValue
-                    placeholder={
-                      selectedLocationId
-                        ? t("commodities:fields.areaPlaceholder")
-                        : t("commodities:fields.areaPlaceholderNoLocation")
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {visibleAreas.map((a) => (
-                    <SelectItem key={a.id} value={a.id ?? ""}>
-                      {a.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-          <FieldError error={errors.area_id} />
+                  {t("commodities:fields.clearLocation")}
+                </button>
+              ) : null}
+            </div>
+            <Select value={selectedLocationId || undefined} onValueChange={handleLocationChange}>
+              <SelectTrigger id="commodity-location" className="w-full">
+                <SelectValue placeholder={t("commodities:fields.locationPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {visibleLocations.map((l) => (
+                  <SelectItem key={l.id} value={l.id ?? ""}>
+                    {l.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <FieldLabel htmlFor="commodity-area">{t("commodities:fields.area")}</FieldLabel>
+            <Controller
+              control={control}
+              name="area_id"
+              render={({ field }) => (
+                <Select
+                  // Re-key on selectedLocationId so a location swap
+                  // remounts the Select with a clean Radix internal
+                  // state — without this, Radix keeps the previously-
+                  // selected label visible in the trigger even though
+                  // the controlled value has been reset to "" and the
+                  // option is no longer in the list, leaving the field
+                  // looking blank rather than restoring the
+                  // "Pick an area" placeholder.
+                  key={selectedLocationId || "no-location"}
+                  value={field.value || undefined}
+                  onValueChange={field.onChange}
+                  disabled={!selectedLocationId}
+                >
+                  <SelectTrigger id="commodity-area" className="w-full">
+                    <SelectValue
+                      placeholder={
+                        selectedLocationId
+                          ? t("commodities:fields.areaPlaceholder")
+                          : t("commodities:fields.areaPlaceholderNoLocation")
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {visibleAreas.map((a) => (
+                      <SelectItem key={a.id} value={a.id ?? ""}>
+                        {a.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
         </div>
-      </div>
+      ) : null}
 
       {showStatus ? (
         <div className="flex flex-col gap-1.5">
@@ -2468,7 +2492,10 @@ function toRequest(
     name: values.name.trim(),
     short_name: values.short_name.trim(),
     type: values.type as CommodityTypeValue,
-    area_id: values.area_id,
+    // Omit when empty so the BE creates/leaves the item unassigned
+    // (#1986) rather than rejecting "" as a missing area FK. An explicit
+    // clear in edit mode (area_id = "") therefore un-assigns the item.
+    area_id: values.area_id || undefined,
     status: values.status as CommodityStatusValue,
     count: Number(values.count),
     original_price: original,

--- a/frontend/src/components/items/__tests__/AssignLocationBanner.test.tsx
+++ b/frontend/src/components/items/__tests__/AssignLocationBanner.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { AssignLocationBanner } from "@/components/items/AssignLocationBanner"
+import { renderWithProviders } from "@/test/render"
+
+describe("AssignLocationBanner", () => {
+  it("renders nothing when show is false", () => {
+    renderWithProviders({ children: <AssignLocationBanner show={false} onAssign={() => {}} /> })
+    expect(screen.queryByTestId("assign-location-banner")).toBeNull()
+  })
+
+  it("shows the prompt when show is true", () => {
+    renderWithProviders({ children: <AssignLocationBanner show onAssign={() => {}} /> })
+    expect(screen.getByTestId("assign-location-banner")).toHaveTextContent(
+      "Place this item in a location?"
+    )
+  })
+
+  it("fires onAssign when the CTA is clicked", async () => {
+    const user = userEvent.setup()
+    const onAssign = vi.fn()
+    renderWithProviders({ children: <AssignLocationBanner show onAssign={onAssign} /> })
+    await user.click(screen.getByTestId("assign-location-banner-cta"))
+    expect(onAssign).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismisses on click of the X button (in-session only)", async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ children: <AssignLocationBanner show onAssign={() => {}} /> })
+    expect(screen.getByTestId("assign-location-banner")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /dismiss/i }))
+    expect(screen.queryByTestId("assign-location-banner")).toBeNull()
+  })
+})

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
@@ -128,11 +128,6 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
     await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
     await pickSelect(user, /^Type$/i, /^Furniture$/i)
-    // Location → Area is a paired select: Area is disabled until a
-    // Location is selected (CommodityFormDialog L1208-L1212), so the
-    // walk must pick "Home" first.
-    await pickSelect(user, /^Location$/i, /^Home$/i)
-    await pickSelect(user, /^Area$/i, /^Garage$/i)
     // Tick the draft toggle so the schema's whenNotDraft block doesn't
     // require purchase_date + the price triad — keeps this test focused
     // on step navigation rather than every field.
@@ -154,7 +149,6 @@ describe("<CommodityFormDialog />", () => {
       name: "Couch",
       short_name: "Couch",
       type: "furniture",
-      area_id: "a1",
       status: "in_use",
       count: 1,
       original_price_currency: "USD",
@@ -183,8 +177,6 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "Stand")
     await user.type(screen.getByLabelText(/^Short name$/i), "Stand")
     await pickSelect(user, /^Type$/i, /^Furniture$/i)
-    await pickSelect(user, /^Location$/i, /^Home$/i)
-    await pickSelect(user, /^Area$/i, /^Garage$/i)
     await user.click(screen.getByLabelText(/Save as draft/i))
     await user.click(screen.getByTestId("commodity-form-next"))
     await screen.findByLabelText(/Purchase date/i)
@@ -221,8 +213,6 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "X")
     await user.type(screen.getByLabelText(/^Short name$/i), "X")
     await pickSelect(user, /^Type$/i, /^Other$/i)
-    await pickSelect(user, /^Location$/i, /^Home$/i)
-    await pickSelect(user, /^Area$/i, /^Garage$/i)
     await user.click(screen.getByLabelText(/Save as draft/i))
     await user.click(screen.getByTestId("commodity-form-next"))
     await screen.findByLabelText(/Purchase date/i)
@@ -260,6 +250,74 @@ describe("<CommodityFormDialog />", () => {
     // Radix Select trigger reflects the current value as its accessible
     // text content rather than a `value` attribute.
     expect(screen.getByLabelText(/^Status$/i)).toHaveTextContent(/Sold/i)
+  })
+
+  it("does not render the Location/Area picker in create mode (#1987)", async () => {
+    const user = userEvent.setup()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="create"
+          areas={areas}
+          locations={locations}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+        />
+      ),
+    })
+    await walkPastAi(user)
+    // The create flow no longer asks for a location — items are created
+    // unassigned and a location is offered afterwards via a banner.
+    expect(screen.queryByRole("combobox", { name: /^Location$/i })).toBeNull()
+    expect(screen.queryByRole("combobox", { name: /^Area$/i })).toBeNull()
+  })
+
+  it("clears the location in edit mode and omits area_id on submit (#1986/#1987)", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="edit"
+          initialValues={{
+            id: "c1",
+            name: "Lamp",
+            short_name: "Lamp",
+            type: "other",
+            area_id: "a1",
+            status: "in_use",
+            count: 1,
+            draft: true,
+          }}
+          areas={areas}
+          locations={locations}
+          defaultCurrency="USD"
+          onSubmit={onSubmit}
+        />
+      ),
+    })
+    // Edit opens on Basics with the picker populated (area a1 → Home).
+    expect(await screen.findByRole("combobox", { name: /^Location$/i })).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /clear location/i }))
+    // Clearing un-assigns: the Clear affordance disappears with the value.
+    expect(screen.queryByRole("button", { name: /clear location/i })).toBeNull()
+    // Walk Basics → Purchase → Warranty → Extras → Files → submit.
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByLabelText(/Purchase date/i)
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-warranty-step")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-tags-input")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-submit")
+    await user.click(screen.getByTestId("commodity-form-submit"))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    // area_id is omitted (undefined) so the BE clears the assignment.
+    expect(onSubmit.mock.calls[0][0].area_id).toBeUndefined()
   })
 
   it("removes a tag chip with Backspace on an empty input", async () => {
@@ -541,8 +599,6 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
     await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
     await pickSelect(user, /^Type$/i, /^Furniture$/i)
-    await pickSelect(user, /^Location$/i, /^Home$/i)
-    await pickSelect(user, /^Area$/i, /^Garage$/i)
     await user.click(screen.getByLabelText(/Save as draft/i))
     // Step through Basics → Purchase → Warranty → Extras → Files.
     await user.click(screen.getByTestId("commodity-form-next"))

--- a/frontend/src/features/commodities/api.ts
+++ b/frontend/src/features/commodities/api.ts
@@ -227,11 +227,11 @@ export async function getCommodity(
 
 // CreateCommodityRequest mirrors the BE's CommodityRequest envelope's
 // `attributes` shape. Optional fields can be omitted; required ones
-// (name, type, area_id, status) match the model's NOT NULL columns.
+// (name, type, status, count) match the model's NOT NULL columns.
+// area_id is optional (#1986/#1987): an item may be created unassigned.
 export type CreateCommodityRequest = Partial<Commodity> & {
   name: string
   type: string
-  area_id: string
   status: string
   count: number
 }

--- a/frontend/src/features/commodities/schemas.ts
+++ b/frontend/src/features/commodities/schemas.ts
@@ -17,7 +17,6 @@ const NAME_TOO_LONG = "commodities:validation.nameTooLong"
 const SHORT_NAME_REQUIRED = "commodities:validation.shortNameRequired"
 const SHORT_NAME_TOO_LONG = "commodities:validation.shortNameTooLong"
 const TYPE_REQUIRED = "commodities:validation.typeRequired"
-const AREA_REQUIRED = "commodities:validation.areaRequired"
 const STATUS_REQUIRED = "commodities:validation.statusRequired"
 const COUNT_MIN = "commodities:validation.countMin"
 const CURRENCY_REQUIRED = "commodities:validation.currencyRequired"
@@ -114,7 +113,10 @@ const baseCommoditySchema = z
     // unconditional in models.Commodity.ValidateWithContext).
     short_name: z.string().trim().min(1, SHORT_NAME_REQUIRED).max(20, SHORT_NAME_TOO_LONG),
     type: z.string().min(1, TYPE_REQUIRED),
-    area_id: z.string().min(1, AREA_REQUIRED),
+    // Area is optional (#1987): the create dialog no longer asks for a
+    // location, and an item can be left unassigned (#1986). Edit mode
+    // still exposes the picker but never requires it.
+    area_id: z.string(),
     status: z.string().min(1, STATUS_REQUIRED),
     count: z.string().refine((v) => /^\d+$/.test(v) && Number(v) >= 1, { message: COUNT_MIN }),
     original_price: optionalNumberString,

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -193,6 +193,7 @@
     "area": "Area",
     "areaPlaceholder": "Pick an area",
     "areaPlaceholderNoLocation": "Pick a location first",
+    "clearLocation": "Clear location",
     "comments": "Notes",
     "commentsPlaceholder": "Maintenance tips, filter models, anything useful…",
     "convertedOriginalPrice": "Converted Purchase Price ({{groupCurrency}})",
@@ -253,6 +254,11 @@
     "warranty": "Warranty"
   },
   "form": {
+    "assignLocationBanner": {
+      "cta": "Place in location",
+      "dismiss": "Dismiss",
+      "title": "Place this item in a location?"
+    },
     "back": "Back",
     "closeConfirm": {
       "description": "You have unsaved changes. Save them as a draft to finish later, or discard them and start over next time.",

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -493,6 +493,11 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
             same edit dialog the main Edit button gates on the lock, so
             hiding it keeps the banner from being a lock-bypass path. */}
         <AssignLocationBanner
+          // Key by commodity id so the banner remounts when the user
+          // navigates between items on the same CommodityDetailContent
+          // instance — its in-session dismiss is per-item ("returns on the
+          // next mount"), not sticky across commodities.
+          key={id}
           show={!commodity.area_id && (locations.data?.length ?? 0) > 0 && !migrationLock.locked}
           onAssign={() => setEditOpen(true)}
         />

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -45,6 +45,7 @@ import { CommodityFilesTab } from "@/components/files/CommodityFilesTab"
 import { DropOverlay } from "@/components/files/DropOverlay"
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
 import { useFileDropZone } from "@/components/files/useFileDropZone"
+import { AssignLocationBanner } from "@/components/items/AssignLocationBanner"
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
 import {
   StatusTransitionDialog,
@@ -485,6 +486,14 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
             hint={t("files:entityPanel.dropHint")}
           />
         ) : null}
+        {/* Non-blocking nudge to file an unassigned item under a
+            location (#1987). Shows only when the item has no area and
+            the group actually has locations to choose from. The CTA
+            opens the edit dialog, which hosts the location/area picker. */}
+        <AssignLocationBanner
+          show={!commodity.area_id && (locations.data?.length ?? 0) > 0}
+          onAssign={() => setEditOpen(true)}
+        />
         {/* The Sheet variant renders its own X close button (top-right
             of the panel), so the explicit "Back to list" Link is
             page-only — clicking the X dismisses the overlay and lands

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -488,10 +488,12 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
         ) : null}
         {/* Non-blocking nudge to file an unassigned item under a
             location (#1987). Shows only when the item has no area and
-            the group actually has locations to choose from. The CTA
-            opens the edit dialog, which hosts the location/area picker. */}
+            the group actually has locations to choose from. Hidden while
+            a currency migration holds the group lock — its CTA opens the
+            same edit dialog the main Edit button gates on the lock, so
+            hiding it keeps the banner from being a lock-bypass path. */}
         <AssignLocationBanner
-          show={!commodity.area_id && (locations.data?.length ?? 0) > 0}
+          show={!commodity.area_id && (locations.data?.length ?? 0) > 0 && !migrationLock.locked}
           onAssign={() => setEditOpen(true)}
         />
         {/* The Sheet variant renders its own X close button (top-right

--- a/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
@@ -489,7 +489,7 @@ describe("<CommoditiesListPage />", () => {
   it("submits a new item via the create dialog and clears the form", async () => {
     // Replays the regression that motivated #1629: walk past the
     // initial AI placeholder step, fill Basics (Name + Short name +
-    // Type + Location → Area), skip Save-as-draft so the schema's
+    // Type), skip Save-as-draft so the schema's
     // whenNotDraft fields stay optional, walk Purchase → Warranty →
     // Extras → Files, then submit. After 201 the dialog closes and
     // the page navigates to /commodities/:newId.
@@ -559,8 +559,6 @@ describe("<CommoditiesListPage />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
     await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
     await pickRadixSelect(user, /^Type$/i, { optionLabel: /^Furniture$/i })
-    await pickRadixSelect(user, /^Location$/i, { optionLabel: /^Home$/i })
-    await pickRadixSelect(user, /^Area$/i, { optionLabel: /^Garage$/i })
     // Save-as-draft so purchase_date + price triad stay optional —
     // the test asserts the navigation contract, not the schema.
     await user.click(screen.getByLabelText(/Save as draft/i))
@@ -590,7 +588,6 @@ describe("<CommoditiesListPage />", () => {
           name: "Couch",
           short_name: "Couch",
           type: "furniture",
-          area_id: "a1",
           status: "in_use",
           draft: true,
         },


### PR DESCRIPTION
Closes #1987. Second of three sequential PRs.

> **Rebased onto `master`** now that #1992 (the unassigned-commodities prerequisite) has merged — the diff is PR2-only (10 files, frontend + e2e).

## What

Picking a location up front is friction most users don't want. The create dialog no longer asks for one — items are created **unassigned** (#1986) — and a location is offered **afterwards** via a non-blocking, dismissible banner.

## Changes (frontend only)

- **Optional area in the form** — `schemas.ts`: `area_id` is no longer `.min(1)`; `api.ts`: dropped from `CreateCommodityRequest`'s required set; `toRequest` emits `area_id: values.area_id || undefined` so an empty value is omitted (the BE then creates/leaves the item unassigned, and an explicit clear in edit **un-assigns** it). `area_id` removed from the Basics step's validation set so it never blocks **Next**.
- **`CommodityFormDialog`** — the Location/Area picker is gated to **edit mode only** (`showLocationPicker={mode === "edit"}`); create mode shows nothing. Edit mode gains a **"Clear location"** affordance to un-assign.
- **`AssignLocationBanner`** (new, mirrors `InviteBanner`) — rendered on the commodity **detail page** (where create navigates) when the item has no area **and** the group has ≥1 location. The CTA opens the existing **edit dialog** (one location-assign surface, no duplicate popover). In-session dismiss.
- **i18n** — `commodities:fields.clearLocation`, `commodities:form.assignLocationBanner.{title,cta,dismiss}` added to en (cs/ru fall back, matching the existing `filter.*` convention).

## Tests

- New `AssignLocationBanner.test.tsx` (show/hide/dismiss/CTA).
- New dialog tests: create mode renders **no** Location/Area combobox; edit-mode **Clear** → `area_id` omitted on submit.
- Updated the create-flow tests in `CommodityFormDialog.test.tsx` + `CommoditiesListPage.test.tsx` that previously walked the location picker; updated the shared e2e `createCommodity` helper to assign the area post-create via the edit dialog (the create dialog no longer has the picker).

## Verification (local)

Full frontend suite green: **1221/1221** vitest, plus `typecheck`, `lint`, and `format:check`; e2e reproduced locally on this worktree's stack (commodity-simple-crud + bulk-and-filter + warranties + lent-out). Re-verified typecheck + affected tests after the rebase onto `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a location assignment banner that appears on items without assigned locations, prompting users to assign one.

* **Improvements**
  * Item location assignment is now optional during creation.
  * Users can assign or modify item locations anytime via the edit view.
  * Streamlined the create workflow by deferring location selection to a later step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->