### PR TITLE
[#1967] Make backoffice bootstrap idempotent for provisioning (--ensure) + fix *bool env spam

### DIFF
--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
@@ -28,6 +28,13 @@ type Config struct {
 	Role     string `yaml:"role" env:"ROLE"`
 	Password string `yaml:"password" env:"PASSWORD"`
 	Force    bool   `yaml:"force" env:"FORCE"`
+	// Ensure relaxes the "a backoffice user already exists" refusal for
+	// non-interactive provisioning (the Helm init-data Job, #1967): when an
+	// operator already exists under a DIFFERENT email, --ensure makes the
+	// command a benign no-op (exit 0) instead of exiting 1. It NEVER creates a
+	// second operator (that's --force) and never weakens the interactive
+	// safety net — it is strictly opt-in. See services/backoffice.BootstrapRequest.
+	Ensure bool `yaml:"ensure" env:"ENSURE"`
 	// MFAEnforced is a *bool so an OMITTED value (nil) stays distinct from an
 	// explicit false. nil flows to the service, which applies the secure
 	// default of true (see services/backoffice.resolveMFAEnforced): the
@@ -41,7 +48,19 @@ type Config struct {
 	// partially-populated config section insecurely false. The pointer makes the
 	// unset/true/false states explicit; demo/preview pass --mfa-enforced=false
 	// to provision a password-only operator (issue #1967).
-	MFAEnforced *bool `yaml:"mfa-enforced" env:"MFA_ENFORCED"`
+	//
+	// NOTE: there is intentionally NO `env:` tag here. cleanenv (the env reader
+	// behind shared.ReadSection) has no case for pointer kinds in its
+	// parseValue switch, so a `*bool` falls through to the default arm and
+	// returns `unsupported type .` — a logged-and-swallowed error
+	// (TryReadSection is non-fatal) that spammed every Helm Job run. Nothing
+	// relies on the Go-side env binding: the Helm Jobs read
+	// INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED in shell and forward it as
+	// the --mfa-enforced CLI flag (job-init-data.yaml / job-setup.yaml), and the
+	// flag path (Flags().Changed) already gives flag > config/env > default. The
+	// yaml tag is kept so a config.yaml `backoffice.bootstrap.mfa-enforced` key
+	// still works; only the dead, error-spamming env binding is dropped.
+	MFAEnforced *bool `yaml:"mfa-enforced"`
 }
 
 // Command is the cobra wrapper around `backoffice bootstrap`.
@@ -81,6 +100,11 @@ IDEMPOTENCY:
     exits 0 (safe to call from provisioning scripts).
   • Re-running with a different --email refuses unless --force is
     passed, so a deployment can't accidentally accumulate operators.
+  • For non-interactive provisioning that only needs to guarantee an
+    operator exists (the Helm init-data Job, issue #1967), pass --ensure:
+    when any operator already exists it prints "nothing to do" and exits 0
+    instead of refusing. --ensure NEVER creates a second operator (that is
+    --force) — it only converts the refusal into a benign no-op.
 
 PASSWORD:
 
@@ -126,6 +150,7 @@ func (c *Command) registerFlags() {
 	c.Cmd().Flags().StringVar(&c.config.Role, "role", c.config.Role, "Back-office role: platform_admin (default) or support_agent")
 	c.Cmd().Flags().StringVar(&c.config.Password, "password", c.config.Password, "Password (auto-generated if omitted)")
 	c.Cmd().Flags().BoolVar(&c.config.Force, "force", c.config.Force, "Allow adding a second+ back-office user when one already exists")
+	c.Cmd().Flags().BoolVar(&c.config.Ensure, "ensure", c.config.Ensure, "Non-interactive provisioning (#1967): when any operator already exists, exit 0 without creating another instead of refusing. Does NOT add a second (use --force)")
 	c.Cmd().Flags().BoolVar(&c.mfaEnforcedFlag, "mfa-enforced", true, "Require TOTP enrollment before the operator can sign in (default true; set --mfa-enforced=false for demo/preview where password-only login is wanted)")
 }
 
@@ -187,6 +212,7 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 		Role:        role,
 		Password:    cfg.Password,
 		Force:       cfg.Force,
+		Ensure:      cfg.Ensure,
 		MFAEnforced: mfaEnforced,
 	})
 	if err != nil {
@@ -196,6 +222,19 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 	if result.AlreadyExisted {
 		fmt.Fprintf(out, "ℹ️  Back-office user %s (%s) already exists; no changes made.\n",
 			result.User.Name, result.User.Email)
+		return nil
+	}
+
+	// --ensure no-op: an operator already exists under a different email and
+	// the caller only wanted to guarantee one exists. result.User MAY be nil
+	// here (best-effort fetch), so never dereference it on this branch.
+	if result.EnsuredExisting {
+		if result.User != nil {
+			fmt.Fprintf(out, "ℹ️  A back-office operator already exists (%s); --ensure: nothing to do.\n",
+				result.User.Email)
+		} else {
+			fmt.Fprintln(out, "ℹ️  A back-office operator already exists; --ensure: nothing to do.")
+		}
 		return nil
 	}
 

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
@@ -178,6 +178,83 @@ func TestBootstrap_ForceAllowsSecond(t *testing.T) {
 	c.Assert(users, qt.HasLen, 2)
 }
 
+// TestBootstrap_EnsureNoOpOnDifferentEmail pins the #1967 self-heal: when an
+// operator ALREADY exists under a different email, --ensure makes the second
+// invocation a benign no-op (exit 0, no new row) instead of the count>0
+// refusal. This is what stops the Helm init-data Job from red-lining ArgoCD on
+// master/longevity, where the live operator's email differs from the chart's.
+func TestBootstrap_EnsureNoOpOnDifferentEmail(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=existing@example.com",
+		"--name=Existing Op",
+	)
+	c.Assert(err, qt.IsNil)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=operator@inventario.example",
+		"--name=Chart Operator",
+		"--ensure",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "nothing to do")
+
+	// No second operator was created — the existing one is untouched.
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+	c.Assert(users[0].Email, qt.Equals, "existing@example.com")
+}
+
+// TestBootstrap_EnsureCreatesOnFreshInstall pins that --ensure does NOT regress
+// PR previews: a fresh install (count=0) still CREATES the operator. --ensure
+// only relaxes the count>0 refusal, never the create path.
+func TestBootstrap_EnsureCreatesOnFreshInstall(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=operator@inventario.example",
+		"--name=Chart Operator",
+		"--ensure",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Created back-office user")
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+	c.Assert(users[0].Email, qt.Equals, "operator@inventario.example")
+}
+
+// TestBootstrap_EnsureSameEmailStillIdempotent pins that --ensure leaves the
+// existing same-email idempotency intact: a same-email re-run still reports
+// "already exists" (not the ensure no-op message) and stays a single row.
+func TestBootstrap_EnsureSameEmailStillIdempotent(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNil)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+		"--ensure",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "already exists")
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
 // TestBootstrap_RejectsMemoryDSN pins the persistence guard: a
 // memory:// DSN is rejected by the shared DatabaseConfig.Validate at
 // the database-config layer (cmd/inventario/shared/database.go: "only

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
@@ -48,8 +48,10 @@ func setupMemoryAsPostgres(c *qt.C) *registry.FactorySet {
 }
 
 // runBootstrap is a one-liner around the cobra command — captures
-// stdout for assertion and returns the run error.
-func runBootstrap(c *qt.C, dsn string, args ...string) (string, error) {
+// stdout for assertion and returns the run error. The *qt.C parameter is
+// accepted for call-site symmetry with the other helpers but intentionally
+// unused (callers own their assertions).
+func runBootstrap(_ *qt.C, dsn string, args ...string) (string, error) {
 	dbConfig := &shared.DatabaseConfig{DBDSN: dsn}
 	cmd := bootstrap.New(dbConfig).Cmd()
 

--- a/go/cmd/inventario/shared/config_test.go
+++ b/go/cmd/inventario/shared/config_test.go
@@ -1,0 +1,86 @@
+package shared_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+)
+
+// captureSlog swaps the default slog logger for one writing to a buffer for the
+// duration of the test, returning the buffer. ReadSection logs its cleanenv
+// failures (the "Failed to read config" / "unsupported type" error) through the
+// default logger and swallows them, so capturing the default logger is the only
+// way to assert the error is gone.
+func captureSlog(c *qt.C) *bytes.Buffer {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	c.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// ptrBoolSectionFixed mirrors the production bootstrap.Config shape AFTER the
+// Fix 2 change: the *bool field carries ONLY a yaml tag (no env tag), and a
+// sibling string field keeps an env binding. This locks in that a *bool with no
+// env tag does not trip cleanenv's "unsupported type ." default arm while the
+// sibling env binding still resolves (precedence preserved).
+type ptrBoolSectionFixed struct {
+	MFAEnforced *bool  `yaml:"mfa-enforced"`
+	Email       string `yaml:"email" env:"EMAIL"`
+}
+
+// ptrBoolSectionBuggy mirrors the pre-fix shape: the *bool field carries an env
+// tag. This reproduces the bug so the test documents exactly what was wrong.
+type ptrBoolSectionBuggy struct {
+	MFAEnforced *bool `yaml:"mfa-enforced" env:"MFA_ENFORCED"`
+}
+
+// TestReadSection_PtrBoolNoEnvTag_NoError pins Fix 2: reading a section whose
+// *bool field has no env tag emits no cleanenv parse error, leaves the pointer
+// nil (so the secure-default-true resolution downstream is preserved), and
+// still binds the sibling string field from the environment (precedence intact).
+func TestReadSection_PtrBoolNoEnvTag_NoError(t *testing.T) {
+	c := qt.New(t)
+	buf := captureSlog(c)
+
+	t.Setenv("INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL", "ops@example.com")
+	// Set the env var the buggy binding used to read; with the env tag dropped
+	// it must simply be ignored rather than fail to parse.
+	t.Setenv("INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED", "false")
+
+	var section ptrBoolSectionFixed
+	err := shared.ReadSection("backoffice.bootstrap", &section)
+	c.Assert(err, qt.IsNil)
+
+	// No cleanenv parse error was logged-and-swallowed.
+	c.Assert(buf.String(), qt.Not(qt.Contains), "Failed to read config")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "unsupported type")
+
+	// The *bool stays nil (no env binding), so resolveMFAEnforced applies the
+	// secure default (true) downstream rather than a silent env-driven false.
+	c.Assert(section.MFAEnforced, qt.IsNil)
+	// The sibling string field still binds from env: the read did not abort.
+	c.Assert(section.Email, qt.Equals, "ops@example.com")
+}
+
+// TestReadSection_PtrBoolWithEnvTag_LogsError documents the regression Fix 2
+// removes: a *bool WITH an env tag falls through cleanenv's default arm and
+// logs the "unsupported type ." error on every read. Kept as a guard so a
+// future re-add of the env tag is caught by an explicit, named test.
+func TestReadSection_PtrBoolWithEnvTag_LogsError(t *testing.T) {
+	c := qt.New(t)
+	buf := captureSlog(c)
+
+	t.Setenv("INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED", "false")
+
+	var section ptrBoolSectionBuggy
+	err := shared.ReadSection("backoffice.bootstrap", &section)
+	// ReadSection swallows the cleanenv error (TryReadSection is non-fatal), so
+	// it still returns nil — but the error is logged.
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "unsupported type")
+}

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -91,7 +91,10 @@ type BootstrapRequest struct {
 	// creates an extra operator and never weakens the interactive Force gate;
 	// it only converts the count>0/!Force refusal into a benign exit-0 for
 	// callers that opt in. Distinct from Force: Force ADDS another operator,
-	// Ensure leaves the existing one untouched. See BootstrapResult.
+	// Ensure leaves the existing one untouched — and because they are opposites,
+	// Bootstrap rejects a request that sets BOTH (a fail-closed guard against a
+	// provisioning Job accidentally creating a second operator). See
+	// BootstrapResult.
 	Ensure bool
 	// MFAEnforced controls the new operator's MFAEnforced column. nil keeps
 	// the secure default (true): the operator must enrol TOTP via
@@ -118,6 +121,48 @@ type BootstrapResult struct {
 	// dereference User on this branch. Distinct from AlreadyExisted, which means
 	// the SAME email was already present (an idempotent same-email re-run).
 	EnsuredExisting bool
+}
+
+// validateBootstrapRequest normalizes and validates the request fields shared
+// by every Bootstrap path, returning the trimmed email/name and the resolved
+// role. Extracted from Bootstrap to keep that function under the gocyclo budget.
+//
+// The Force/Ensure mutual-exclusion check lives here so the contradiction is
+// rejected up front, before any registry read or write: Force ADDS an operator
+// even when the table is non-empty, while Ensure's contract is to leave any
+// existing operator UNTOUCHED. Setting both is a config/env mistake (e.g. a Job
+// inheriting a stray --force); failing closed prevents it from silently creating
+// a second operator via the force gate — the "never creates an extra" promise
+// Ensure makes.
+func validateBootstrapRequest(req BootstrapRequest) (validatedBootstrap, error) {
+	if req.Force && req.Ensure {
+		return validatedBootstrap{}, errors.New("Force and Ensure are mutually exclusive (Force adds an operator; Ensure leaves any existing operator untouched)")
+	}
+
+	email := strings.TrimSpace(req.Email)
+	if email == "" {
+		return validatedBootstrap{}, errors.New("email is required")
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return validatedBootstrap{}, errors.New("name is required")
+	}
+	role := req.Role
+	if role == "" {
+		role = models.BackofficeRolePlatformAdmin
+	}
+	if !role.IsValid() {
+		return validatedBootstrap{}, fmt.Errorf("invalid role %q (must be one of: support_agent, platform_admin)", string(role))
+	}
+	return validatedBootstrap{email: email, name: name, role: role}, nil
+}
+
+// validatedBootstrap holds the normalized, validated inputs shared by every
+// Bootstrap path (the trimmed email/name and the resolved role).
+type validatedBootstrap struct {
+	email string
+	name  string
+	role  models.BackofficeRole
 }
 
 // Bootstrap creates the first (or, with --force, an additional) back-
@@ -147,21 +192,11 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		return nil, errors.New("backoffice user registry not configured")
 	}
 
-	email := strings.TrimSpace(req.Email)
-	if email == "" {
-		return nil, errors.New("email is required")
+	v, err := validateBootstrapRequest(req)
+	if err != nil {
+		return nil, err
 	}
-	name := strings.TrimSpace(req.Name)
-	if name == "" {
-		return nil, errors.New("name is required")
-	}
-	role := req.Role
-	if role == "" {
-		role = models.BackofficeRolePlatformAdmin
-	}
-	if !role.IsValid() {
-		return nil, fmt.Errorf("invalid role %q (must be one of: support_agent, platform_admin)", string(role))
-	}
+	email, name, role := v.email, v.name, v.role
 
 	// 1. Idempotency check by email. GetByEmail is case-insensitive at
 	// the registry layer, so re-running with the same email in a

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -78,6 +78,21 @@ type BootstrapRequest struct {
 	Role     models.BackofficeRole
 	Password string // optional; auto-generated when empty
 	Force    bool   // allow creating an additional user when the table is non-empty
+	// Ensure relaxes the fresh-deployment refusal for non-interactive
+	// provisioning (the Helm init-data Job, #1967). When an operator already
+	// exists under a DIFFERENT email than this request's, the default behaviour
+	// is to refuse unless Force is passed (so an interactive operator can't
+	// silently accumulate a sprawl of back-office users). A provisioning Job,
+	// however, only wants to guarantee "at least one operator exists" and must
+	// NOT red-line just because the existing operator was seeded with a
+	// different email. With Ensure=true that case is treated as a success no-op:
+	// the existing operator is reported back (BootstrapResult.EnsuredExisting)
+	// and no second row is created. Ensure is strictly additive — it never
+	// creates an extra operator and never weakens the interactive Force gate;
+	// it only converts the count>0/!Force refusal into a benign exit-0 for
+	// callers that opt in. Distinct from Force: Force ADDS another operator,
+	// Ensure leaves the existing one untouched. See BootstrapResult.
+	Ensure bool
 	// MFAEnforced controls the new operator's MFAEnforced column. nil keeps
 	// the secure default (true): the operator must enrol TOTP via
 	// `inventario backoffice mfa setup` before the login handler will issue a
@@ -94,6 +109,15 @@ type BootstrapResult struct {
 	User              *models.BackofficeUser
 	GeneratedPassword string // populated only when the caller did NOT supply Password
 	AlreadyExisted    bool   // true when an existing user with the same email was found (idempotent re-run)
+	// EnsuredExisting is true when Ensure=true short-circuited the count>0/!Force
+	// refusal: a back-office operator already exists (under any email) and the
+	// caller only wanted to guarantee one exists, so nothing was created. User
+	// carries the existing operator that satisfied the guarantee when one could
+	// be fetched; it MAY be nil if the operator could not be re-listed (e.g. a
+	// concurrent delete between the count and the list), so the CLI must NOT
+	// dereference User on this branch. Distinct from AlreadyExisted, which means
+	// the SAME email was already present (an idempotent same-email re-run).
+	EnsuredExisting bool
 }
 
 // Bootstrap creates the first (or, with --force, an additional) back-
@@ -104,8 +128,14 @@ type BootstrapResult struct {
 //     this to "ℹ️  user already exists" + exit 0 so re-running the
 //     command is safe.
 //   - Else, if at least one back-office user already exists AND the
-//     caller did not pass Force, refuse with a fail-closed error. The
-//     CLI surfaces this with a hint to pass --force.
+//     caller did not pass Force:
+//   - With Ensure=true, return EnsuredExisting=true with no error and
+//     no mutation. A provisioning Job (#1967) only wants "an operator
+//     exists"; it must not red-line because the existing operator was
+//     seeded with a different email. The CLI maps this to an
+//     informational "operator already exists; nothing to do" + exit 0.
+//   - Without Ensure, refuse with a fail-closed error. The CLI surfaces
+//     this with a hint to pass --force (interactive safety net).
 //   - Else, generate (or accept) a password, bcrypt it at DefaultCost
 //     (matching models.User.SetPassword), and insert the row.
 //
@@ -146,16 +176,10 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		return nil, errxtrace.Wrap("failed to check existing backoffice user", lookupErr)
 	}
 
-	// 2. Force gate. Counting is cheap on a tiny table; doing it under a
-	// transaction is overkill for a CLI run that has no concurrent writer.
-	if !req.Force {
-		count, countErr := s.factorySet.BackofficeUserRegistry.Count(ctx)
-		if countErr != nil {
-			return nil, errxtrace.Wrap("failed to count existing backoffice users", countErr)
-		}
-		if count > 0 {
-			return nil, fmt.Errorf("a backoffice user already exists; pass --force to add another (current count: %d)", count)
-		}
+	// 2. Force gate. A non-nil result (or error) short-circuits Bootstrap;
+	// a nil/nil pair means "proceed to create".
+	if gateResult, gateErr := s.applyForceGate(ctx, req); gateErr != nil || gateResult != nil {
+		return gateResult, gateErr
 	}
 
 	// 3. Password: explicit or generated. Generated passwords are
@@ -219,6 +243,64 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		User:              created,
 		GeneratedPassword: generated,
 	}, nil
+}
+
+// applyForceGate enforces the fresh-deployment refusal that protects against
+// silently accumulating back-office operators. It is reached only after the
+// same-email idempotency check has missed, so any existing row is necessarily a
+// DIFFERENT operator. The return contract is:
+//
+//   - (nil, nil)    → proceed to create (Force, or an empty table).
+//   - (result, nil) → short-circuit Bootstrap with this result. The only such
+//     case is the Ensure-mode no-op (EnsuredExisting), which never creates a
+//     second row.
+//   - (nil, err)    → short-circuit with an error: a Count failure, or the
+//     interactive count>0/!Force/!Ensure refusal.
+//
+// Extracted from Bootstrap to keep that function under the gocyclo budget; the
+// branching here is the gate's entire decision table.
+func (s *Service) applyForceGate(ctx context.Context, req BootstrapRequest) (*BootstrapResult, error) {
+	if req.Force {
+		return nil, nil
+	}
+
+	// Counting is cheap on a tiny table; a transaction is overkill for a CLI run
+	// that has no concurrent writer.
+	count, countErr := s.factorySet.BackofficeUserRegistry.Count(ctx)
+	if countErr != nil {
+		return nil, errxtrace.Wrap("failed to count existing backoffice users", countErr)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+
+	// An operator already exists under a different email.
+	if req.Ensure {
+		// Ensure mode (provisioning Jobs, #1967): the caller only wants to
+		// guarantee an operator exists. Treat as a benign no-op instead of the
+		// interactive fail-closed refusal — never create a second row.
+		return &BootstrapResult{
+			User:            firstExistingOperator(ctx, s.factorySet.BackofficeUserRegistry),
+			EnsuredExisting: true,
+		}, nil
+	}
+	return nil, fmt.Errorf("a backoffice user already exists; pass --force to add another (current count: %d)", count)
+}
+
+// firstExistingOperator returns one existing back-office operator for the
+// Ensure-mode no-op return, or nil if none can be fetched. It is best-effort:
+// the EnsuredExisting branch is reached only after Count reported > 0, but a
+// concurrent delete (or a List error) can still leave the list empty, so the
+// caller must treat a nil result as "exists but unidentified" rather than a
+// contradiction. Errors are swallowed deliberately — the guarantee ("an
+// operator exists") was already satisfied by the count; failing to also name it
+// must not turn a successful no-op into a CLI failure.
+func firstExistingOperator(ctx context.Context, reg registry.BackofficeUserRegistry) *models.BackofficeUser {
+	users, err := reg.List(ctx)
+	if err != nil || len(users) == 0 {
+		return nil
+	}
+	return users[0]
 }
 
 // resolveMFAEnforced collapses the optional MFAEnforced override into a

--- a/go/services/backoffice/service_test.go
+++ b/go/services/backoffice/service_test.go
@@ -192,3 +192,28 @@ func TestService_BootstrapRefusesWithoutEnsureOrForce(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(users, qt.HasLen, 1)
 }
+
+// TestService_BootstrapRejectsForceAndEnsure pins the mutual-exclusion guard:
+// Force and Ensure are opposites, so combining them is a fail-closed error and
+// must NOT fall through to Force's create-an-extra path (which would defeat
+// Ensure's "never creates a second operator" contract).
+func TestService_BootstrapRejectsForceAndEnsure(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	_, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email:  "first@example.com",
+		Name:   "First",
+		Force:  true,
+		Ensure: true,
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "mutually exclusive")
+
+	// The contradiction is rejected before any write — the table stays empty.
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 0)
+}

--- a/go/services/backoffice/service_test.go
+++ b/go/services/backoffice/service_test.go
@@ -1,0 +1,194 @@
+package backoffice_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services/backoffice"
+)
+
+// setupMemoryAsPostgres registers the in-memory registry under the `postgres`
+// scheme so backoffice.NewService — which routes through registry.GetRegistry —
+// resolves a working factory set without a real postgres instance. Returns the
+// factory set so a test can introspect post-conditions (row count, identities).
+// Mirrors the helper in cmd/inventario/backoffice/bootstrap/bootstrap_test.go.
+func setupMemoryAsPostgres(c *qt.C) *registry.FactorySet {
+	var captured *registry.FactorySet
+	newFn, _ := memory.NewMemoryRegistrySet()
+	wrappedNewFn := func(cfg registry.Config) (*registry.FactorySet, error) {
+		if captured != nil {
+			return captured, nil
+		}
+		fs, err := newFn(cfg)
+		if err != nil {
+			return nil, err
+		}
+		captured = fs
+		return fs, nil
+	}
+	registry.Register("postgres", wrappedNewFn)
+	c.Cleanup(func() {
+		registry.Unregister("postgres")
+	})
+
+	fs, err := wrappedNewFn(registry.Config("postgres://test"))
+	c.Assert(err, qt.IsNil)
+	return fs
+}
+
+// newService builds a backoffice.Service backed by the memory-as-postgres
+// registry registered by setupMemoryAsPostgres.
+func newService(c *qt.C) *backoffice.Service {
+	svc, err := backoffice.NewService(&shared.DatabaseConfig{DBDSN: "postgres://test"})
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_ = svc.Close()
+	})
+	return svc
+}
+
+// TestService_BootstrapEnsureNoOpOnDifferentEmail pins the #1967 self-heal at
+// the service seam: with an existing operator under a different email, Ensure
+// returns EnsuredExisting=true, no error, and no second row — and reports the
+// existing operator via result.User.
+func TestService_BootstrapEnsureNoOpOnDifferentEmail(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	first, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "existing@example.com",
+		Name:  "Existing Op",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(first.AlreadyExisted, qt.IsFalse)
+
+	res, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email:  "operator@inventario.example",
+		Name:   "Chart Operator",
+		Ensure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.EnsuredExisting, qt.IsTrue)
+	c.Assert(res.AlreadyExisted, qt.IsFalse)
+	c.Assert(res.User, qt.IsNotNil)
+	c.Assert(res.User.Email, qt.Equals, "existing@example.com")
+
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestService_BootstrapEnsureCreatesOnFreshInstall pins that Ensure does not
+// regress fresh installs (count=0): the operator is still created.
+func TestService_BootstrapEnsureCreatesOnFreshInstall(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	res, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email:  "operator@inventario.example",
+		Name:   "Chart Operator",
+		Ensure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.EnsuredExisting, qt.IsFalse)
+	c.Assert(res.AlreadyExisted, qt.IsFalse)
+	c.Assert(res.User, qt.IsNotNil)
+	c.Assert(res.User.Email, qt.Equals, "operator@inventario.example")
+
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestService_BootstrapSameEmailIdempotent pins that a same-email re-run still
+// reports AlreadyExisted (not the Ensure no-op), independent of Ensure.
+func TestService_BootstrapSameEmailIdempotent(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	_, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "admin@example.com",
+		Name:  "Ops Admin",
+	})
+	c.Assert(err, qt.IsNil)
+
+	res, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email:  "admin@example.com",
+		Name:   "Ops Admin",
+		Ensure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.AlreadyExisted, qt.IsTrue)
+	c.Assert(res.EnsuredExisting, qt.IsFalse)
+	c.Assert(res.User, qt.IsNotNil)
+
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestService_BootstrapForceAddsSecond pins that --force is unchanged: it still
+// ADDS a second operator (distinct from Ensure, which leaves one untouched).
+func TestService_BootstrapForceAddsSecond(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	_, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "first@example.com",
+		Name:  "First",
+	})
+	c.Assert(err, qt.IsNil)
+
+	res, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "second@example.com",
+		Name:  "Second",
+		Force: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.EnsuredExisting, qt.IsFalse)
+	c.Assert(res.AlreadyExisted, qt.IsFalse)
+
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 2)
+}
+
+// TestService_BootstrapRefusesWithoutEnsureOrForce pins the interactive safety
+// net: with an existing operator and neither Ensure nor Force, the count>0
+// refusal error is unchanged.
+func TestService_BootstrapRefusesWithoutEnsureOrForce(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+	svc := newService(c)
+	ctx := context.Background()
+
+	_, err := svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "first@example.com",
+		Name:  "First",
+	})
+	c.Assert(err, qt.IsNil)
+
+	_, err = svc.Bootstrap(ctx, backoffice.BootstrapRequest{
+		Email: "second@example.com",
+		Name:  "Second",
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--force")
+
+	users, err := fs.BackofficeUserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -103,10 +103,16 @@ spec:
                   echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
                   exit 1
                 fi
+                # Operator identity: prefer the sops-sourced BACKOFFICE_USER_EMAIL
+                # (apply-secrets.sh materializes it into inventario-admin from the
+                # bundle's backoffice.email on master/longevity) so /backoffice/login
+                # uses the bundle-defined address; fall back to the chart's
+                # backofficeUser.email when the Secret key is absent (PR previews). (#1967)
+                bo_email="${BACKOFFICE_USER_EMAIL:-$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL}"
                 k=1
                 while [ "$k" -le 15 ]; do
                   if inventario backoffice bootstrap \
-                    --email="$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL" \
+                    --email="$bo_email" \
                     --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
                     --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
                     --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
@@ -240,6 +246,17 @@ spec:
             {{- if .Values.backofficeUser.enabled }}
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL
               value: {{ .Values.backofficeUser.email | quote }}
+            # Optional sops-sourced override of the operator email. apply-secrets.sh
+            # materializes BACKOFFICE_USER_EMAIL into the existing Secret from the
+            # bundle's backoffice.email on master/longevity; the shell step above
+            # prefers it over INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL. optional:true so
+            # PR previews (no such key) transparently fall back to the value. (#1967)
+            - name: BACKOFFICE_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: BACKOFFICE_USER_EMAIL
+                  optional: true
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME
               value: {{ .Values.backofficeUser.name | quote }}
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -90,9 +90,14 @@ spec:
 
               # Auto-provision the back-office (platform-operator) identity for
               # /backoffice/login when enabled (#1967). Demo/preview only —
-              # gated by backofficeUser.enabled. Idempotent on email: a re-run
-              # prints "already exists" and exits 0. The bootstrap command
-              # reuses the INVENTARIO_DB_DSN exported above (migrator DSN).
+              # gated by backofficeUser.enabled. --ensure makes this a no-op
+              # (exit 0) whenever ANY operator already exists, including one
+              # seeded with a different email than this chart passes: a fresh
+              # install (count=0) still CREATES the operator, while an
+              # already-bootstrapped env (master/longevity) reports "nothing to
+              # do" instead of failing the Job (which would red ArgoCD Degraded).
+              # The bootstrap command reuses the INVENTARIO_DB_DSN exported above
+              # (migrator DSN).
               if [ "${BACKOFFICE_USER_ENABLED:-false}" = "true" ]; then
                 if [ -z "${INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD:-}" ]; then
                   echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
@@ -105,7 +110,8 @@ spec:
                     --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
                     --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
                     --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
-                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED"; then
+                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED" \
+                    --ensure; then
                     break
                   fi
                   echo "Back-office bootstrap attempt $k failed, retrying in 2 seconds..."

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -250,10 +250,16 @@ spec:
                   echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
                   exit 1
                 fi
+                # Operator identity: prefer the sops-sourced BACKOFFICE_USER_EMAIL
+                # (apply-secrets.sh materializes it into inventario-admin from the
+                # bundle's backoffice.email on master/longevity) so /backoffice/login
+                # uses the bundle-defined address; fall back to the chart's
+                # backofficeUser.email when the Secret key is absent (PR previews). (#1967)
+                bo_email="${BACKOFFICE_USER_EMAIL:-$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL}"
                 k=1
                 while [ "$k" -le 15 ]; do
                   if inventario backoffice bootstrap \
-                    --email="$INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL" \
+                    --email="$bo_email" \
                     --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
                     --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
                     --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
@@ -383,6 +389,17 @@ spec:
             {{- if .Values.backofficeUser.enabled }}
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL
               value: {{ .Values.backofficeUser.email | quote }}
+            # Optional sops-sourced override of the operator email. apply-secrets.sh
+            # materializes BACKOFFICE_USER_EMAIL into the existing Secret from the
+            # bundle's backoffice.email on master/longevity; the shell step above
+            # prefers it over INVENTARIO_BACKOFFICE_BOOTSTRAP_EMAIL. optional:true so
+            # PR previews (no such key) transparently fall back to the value. (#1967)
+            - name: BACKOFFICE_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: BACKOFFICE_USER_EMAIL
+                  optional: true
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME
               value: {{ .Values.backofficeUser.name | quote }}
             - name: INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -237,9 +237,14 @@ spec:
 
               # Auto-provision the back-office (platform-operator) identity for
               # /backoffice/login when enabled (#1967). Demo/preview only —
-              # gated by backofficeUser.enabled. Idempotent on email: a re-run
-              # prints "already exists" and exits 0. The bootstrap command
-              # reuses the INVENTARIO_DB_DSN exported above (migrator DSN).
+              # gated by backofficeUser.enabled. --ensure makes this a no-op
+              # (exit 0) whenever ANY operator already exists, including one
+              # seeded with a different email than this chart passes: a fresh
+              # install (count=0) still CREATES the operator, while an
+              # already-bootstrapped env (master/longevity) reports "nothing to
+              # do" instead of failing the Job (which would red ArgoCD Degraded).
+              # The bootstrap command reuses the INVENTARIO_DB_DSN exported above
+              # (migrator DSN).
               if [ "${BACKOFFICE_USER_ENABLED:-false}" = "true" ]; then
                 if [ -z "${INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD:-}" ]; then
                   echo "backofficeUser.enabled=true but BACKOFFICE_USER_PASSWORD is empty; refusing to provision an operator with an uncapturable auto-generated password (set setupJob.initData.backofficeUserPassword for PR previews, or the BACKOFFICE_USER_PASSWORD key in secrets.existingSecret / the sops bundle for master+longevity)"
@@ -252,7 +257,8 @@ spec:
                     --name="$INVENTARIO_BACKOFFICE_BOOTSTRAP_NAME" \
                     --role="$INVENTARIO_BACKOFFICE_BOOTSTRAP_ROLE" \
                     --password="$INVENTARIO_BACKOFFICE_BOOTSTRAP_PASSWORD" \
-                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED"; then
+                    --mfa-enforced="$INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED" \
+                    --ensure; then
                     break
                   fi
                   echo "Back-office bootstrap attempt $k failed, retrying in 2 seconds..."

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -557,6 +557,7 @@ secrets:
   #   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY    (required when aivision.provider=openai)
   #   SETUP_ADMIN_PASSWORD                       (required by job-setup if setupJob.enabled)
   #   BACKOFFICE_USER_PASSWORD                   (required by setup/init-data Job when backofficeUser.enabled; maps to setupJob.initData.backofficeUserPassword; min 8 chars + upper + lower + digit)
+  #   BACKOFFICE_USER_EMAIL                      (optional; when backofficeUser.enabled, overrides backofficeUser.email so the operator login identity comes from the Secret/sops bundle instead of the overlay; falls back to backofficeUser.email when absent)
   #   SETUP_SUPERUSER_DSN                        (optional; used when setupJob.bootstrap.superuserDsn is managed outside the chart)
   #   AWS_ACCESS_KEY_ID                          (required for S3/MinIO upload)
   #   AWS_SECRET_ACCESS_KEY                      (required for S3/MinIO upload)
@@ -772,7 +773,12 @@ setupJob:
 # ============================================================
 backofficeUser:
   enabled: false
-  # Operator login email + display name (non-secret; passed as --email/--name).
+  # Operator login email + display name (passed as --email/--name). The email
+  # here is the DEFAULT/fallback: when the Job's Secret carries a
+  # BACKOFFICE_USER_EMAIL key (apply-secrets.sh sources it from the sops bundle's
+  # backoffice.email on master/longevity), the Job PREFERS that so the real
+  # operator address can stay out of the overlay/git. PR previews have no such
+  # key and use this value as-is.
   email: "operator@example.com"
   name: "Platform Operator"
   # Role: platform_admin (full mutation rights) or support_agent.

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -110,6 +110,18 @@ BACKOFFICE_USER_PASSWORD=$(lookup "backoffice.password")
 if [ -z "$BACKOFFICE_USER_PASSWORD" ]; then
     warn "backoffice.password missing in secrets bundle; inv-vcl01-master/longevity layer backofficeUser.enabled=true (preview-base, #1967), so their setup Job's 'inventario backoffice bootstrap' step will fail until BACKOFFICE_USER_PASSWORD is present. Set backoffice.password (8+ chars, upper, lower, digit) to auto-provision the /backoffice/login operator."
 fi
+# Optional back-office operator EMAIL for the demo/preview envs (#1967). When
+# present it is injected into the inventario-admin Secret below as
+# BACKOFFICE_USER_EMAIL; the chart's Job prefers it over the hardcoded
+# backofficeUser.email so the /backoffice/login identity is the sops-defined one
+# (and the real address never has to live in the public overlay). Absent it the
+# Job falls back to the chart value (operator@inventario.example), so this is a
+# soft note, not a hard warning — but the login email then won't match the
+# bundle.
+BACKOFFICE_USER_EMAIL=$(lookup "backoffice.email")
+if [ -n "$BACKOFFICE_USER_PASSWORD" ] && [ -z "$BACKOFFICE_USER_EMAIL" ]; then
+    note "backoffice.email not set in the bundle; inv-vcl01-master/longevity will provision the operator under the chart default backofficeUser.email (operator@inventario.example) rather than a sops-defined address. Set backoffice.email to control the /backoffice/login identity."
+fi
 # Optional runtime JWT signing key for the persistent envs (master + longevity).
 # When present it is injected into the inventario-admin Secret below as
 # INVENTARIO_RUN_JWT_SECRET so the apiserver stops minting a fresh random secret
@@ -201,6 +213,12 @@ EOF
                 cat <<EOF
   BACKOFFICE_USER_PASSWORD: |-
 $(printf '%s' "$BACKOFFICE_USER_PASSWORD" | sed 's/^/    /')
+EOF
+            fi
+            if [ -n "$BACKOFFICE_USER_EMAIL" ]; then
+                cat <<EOF
+  BACKOFFICE_USER_EMAIL: |-
+$(printf '%s' "$BACKOFFICE_USER_EMAIL" | sed 's/^/    /')
 EOF
             fi
             if [ -n "$JWT_SECRET" ]; then

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -45,8 +45,13 @@ backoffice:
   # Production does NOT use this — backofficeUser stays disabled there and
   # operators are created by hand so the one-time password is never stored.
   #
-  # `email`/`name` are informational — the chart sources the operator's email +
-  # name from values (backofficeUser.email / .name), not from the bundle.
+  # `email` IS used (#1967): apply-secrets.sh materializes it into
+  # inv-vcl01-master/longevity inventario-admin under key BACKOFFICE_USER_EMAIL,
+  # and the chart's Job PREFERS it over backofficeUser.email so /backoffice/login
+  # uses this bundle-defined address (the real operator email never has to live
+  # in the public overlay). When empty, the Job falls back to the chart value
+  # (operator@inventario.example). `name` stays informational — the chart still
+  # sources the display name from values (backofficeUser.name).
   email: operator@example.invalid
   name: Demo Operator
   password: ""


### PR DESCRIPTION
## Root cause — ArgoCD Degraded on master + longevity

The Helm init-data Job (`helm/inventario/templates/job-init-data.yaml`, mirrored in `job-setup.yaml`), added by #1967 and shipped in PR #1994, runs `inventario backoffice bootstrap` on **every ArgoCD sync** (the Job carries `Force=true,Replace=true` sync-options).

On the long-lived `inv-vcl01-master` / `inv-vcl01-longevity` environments a back-office operator already exists, but with a **different email** than the chart passes. The service logic in `go/services/backoffice/service.go` `Bootstrap()` was idempotent **only for the same email**:

1. `GetByEmail(email)` → found → `AlreadyExisted=true` (exit 0). Misses, because the existing email differs.
2. else `!Force && Count() > 0` → error `"a backoffice user already exists; pass --force to add another"`. **Fires.**

So the CLI exits 1 → init-data container CrashLoopBackOff → Job `Failed` (BackoffLimitExceeded) → ArgoCD marks the Application **Degraded** (Sync stays Synced; it's a *health* failure on the Job child resource, so selfHeal can't fix it — there's no manifest drift). PR #1994's commit message claimed the step was "idempotent", but it was not for this case.

A second, non-fatal bug spammed every run:

```
msg="Failed to read config" error="parsing field MFAEnforced env INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED: unsupported type ."
```

The bootstrap `Config.MFAEnforced` field is a `*bool` with an `env:"MFA_ENFORCED"` tag, and cleanenv (the reader behind `shared.ReadSection`) has no `case reflect.Ptr` in its `parseValue` switch — a `*bool` falls through to the `default` arm (`unsupported type .`). It was logged-and-swallowed (`TryReadSection` is non-fatal) so it didn't block, but it was misleading noise and meant the env binding was dead.

## The fix

**Fix 1 (primary) — opt-in `--ensure` mode.** New `BootstrapRequest.Ensure` / `Config.Ensure`. When an operator already exists (any email) and the request isn't a same-email re-run and `--force` wasn't passed:
- `--ensure` → benign no-op, `BootstrapResult.EnsuredExisting=true`, exit 0 (`ℹ️  A back-office operator already exists; --ensure: nothing to do.`). **Never** creates a second operator.
- no `--ensure` → the existing fail-closed error is **unchanged** (interactive safety net).

`--ensure` is strictly additive/opt-in; default interactive behaviour is untouched. The force-gate logic was extracted into `applyForceGate` to keep `Bootstrap` under the gocyclo budget. `result.User` is populated best-effort from the existing operator and the CLI branch is nil-safe.

**Fix 2 — kill the `*bool` env-parse error.** Dropped the dead `env:"MFA_ENFORCED"` tag (kept `yaml:"mfa-enforced"`). Verified nothing relies on the Go-side env binding: the Helm Jobs read `INVENTARIO_BACKOFFICE_BOOTSTRAP_MFA_ENFORCED` in shell and forward it as the `--mfa-enforced` CLI flag. The nil-vs-false distinction (nil ⇒ secure default `true`) and the `flag > config/env > default` precedence #1994 built are both preserved. (See `go/cmd/inventario/shared/ZERO_VALUES_AND_CLEANENV.md`, which already documents cleanenv's lack of pointer support.)

**Fix 3 — chart wiring.** Both `job-init-data.yaml` and `job-setup.yaml` now pass `--ensure` to the bootstrap invocation, and the misleading "idempotent … exits 0" comments are corrected. Fresh PR previews (`count=0`) still **CREATE** the operator; only already-bootstrapped envs take the new no-op path.

## Self-heal on merge — no DB reconcile required

On merge, the new image + chart land on `inv-vcl01-master` and `inv-vcl01-longevity`. Their existing different-email operator now satisfies `--ensure` ⇒ bootstrap exits 0 ⇒ init-data Job completes ⇒ ArgoCD health returns to Healthy. **No database reconcile is needed.**

> Note: if the team specifically wants the canonical `operator@inventario.example` login on those long-lived envs, that is a separate one-time data reconcile (rename/insert the operator row) and is **out of scope** for this PR — the goal here is to stop the Job from red-lining ArgoCD.

## Tests & quality gates

- `go/services/backoffice/service_test.go` (new): ensure no-op on a different-email operator (no new row, `User` reports the existing one), ensure still creates on a fresh install, same-email still `AlreadyExisted`, `--force` still adds a second, no-ensure/no-force + existing still errors.
- `go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go`: CLI-level equivalents of the above through the full command stack.
- `go/cmd/inventario/shared/config_test.go` (new): `ReadSection` on a `*bool` with no env tag emits no cleanenv error and binds a sibling env field (precedence intact); a guard test reproduces the old `unsupported type` log when the env tag is present.
- `go build ./...`, `go vet ./...`, `go test ./cmd/... ./services/...` green.
- Full lint chain green: `go tool nolintguard ./...`, `go tool qtlint ./...`, `golangci-lint run` (whole module, **0 issues**).
- `helm template` renders both Jobs as valid YAML with `--ensure` emitted.
- No DB migration (no schema change). No swagger/`api.d.ts` change (CLI-only).

Refs #1967, and the regressing PR #1994.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--ensure` mode to bootstrap: idempotent, exits successfully with a “nothing to do” message when any operator already exists.

* **Behavior**
  * Bootstrap now reports an “ensured existing” success state instead of erroring when skipping creation.
  * MFA env binding removed to preserve secure default and avoid noisy config logs.

* **Documentation**
  * Help text, Helm job templates and chart comments updated to document idempotency and optional BACKOFFICE_USER_EMAIL override.

* **Tests**
  * Added tests covering `--ensure` scenarios and related config handling.

* **Chores**
  * Deployment scripts now support an optional BACKOFFICE_USER_EMAIL secret key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->