### PR TITLE
[#1988] e2e: anonymous first-item journey (logged-out → login → replay)

### DIFF
--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Anonymous "add your first item before login" journey (#1988).
+ *
+ * Exercises the no-data-loss guarantee end-to-end: a logged-out visitor
+ * fills the create form on the public landing page, is sent to log in, and
+ * after auth the drafted item is replayed into their group with nothing lost.
+ *
+ * The landing "Add New Item" card is gated on the `public_scan` feature flag
+ * (the public AI-scan endpoint is mounted only when the operator opts in).
+ * Rather than coordinate that backend env across the whole e2e job matrix —
+ * the same call ai-scan.spec.ts made for the mock provider — we stub
+ * GET /api/v1/feature-flags to report `public_scan: true`. The AI scan itself
+ * is skipped via "Fill manually", so the flow has NO dependency on the scan
+ * endpoint; the post-login replay POSTs to the REAL backend, so the item is
+ * genuinely created and verified.
+ *
+ * Plain @playwright/test (no app-fixture) so the page starts logged OUT —
+ * RootGate only renders the landing surface for an anonymous visitor.
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  fillCommodityWizardAndSubmit,
+  verifyCommodityDetails,
+  type TestCommodity,
+} from './includes/commodities.js';
+import { TEST_CREDENTIALS } from './includes/auth.js';
+
+const MARKER_KEY = 'inventario_pending_first_item';
+const DRAFT_KEY = 'commodity-draft:anon:create';
+const DETAIL_URL = /\/g\/[^/]+\/commodities\/[0-9a-fA-F-]{36}/;
+
+// Stub /feature-flags so the landing Add card renders without touching the
+// backend's PUBLIC_AI_VISION_SCAN_ENABLED config. route.fetch() pulls the
+// real envelope first and only flips public_scan, so any other (or future)
+// flags keep their real values.
+async function enablePublicScanFlag(page: import('@playwright/test').Page) {
+  await page.route('**/api/v1/feature-flags', async (route) => {
+    let body: Record<string, unknown>;
+    try {
+      const res = await route.fetch();
+      body = (await res.json()) as Record<string, unknown>;
+    } catch {
+      body = { currency_migration: false, magic_link_login: false };
+    }
+    body.public_scan = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+test.describe('Anonymous first-item journey (#1988)', () => {
+  test('logged-out → fill → login → item replayed into the group, nothing lost', async ({
+    page,
+  }) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    // Currency is the seeded e2e group's currency (CZK) on purpose: the
+    // anonymous dialog infers USD from the browser locale, so picking CZK
+    // exercises the foreign-currency converted-price field pre-login, and
+    // the post-login replay (toRequest re-run against the real CZK group)
+    // collapses to same-currency — no cross-currency validation surprise.
+    const commodity: TestCommodity = {
+      name: `Anon First Item ${suffix}`,
+      shortName: `Anon-${suffix.slice(-6)}`,
+      type: 'electronics',
+      count: 1,
+      originalPrice: 42,
+      originalPriceCurrency: 'CZK',
+      convertedOriginalPrice: 42,
+      currentPrice: 42,
+      purchaseDate: '2026-01-15',
+    };
+
+    await enablePublicScanFlag(page);
+
+    // 1. Logged out, "/" is the landing CTA (RootGate → LandingPage).
+    await page.goto('/');
+    await expect(page.getByTestId('landing-page')).toBeVisible();
+    await expect(page.getByTestId('landing-add-item')).toBeVisible();
+
+    // 2. Open the anonymous create dialog and skip the AI offer.
+    await page.getByTestId('landing-add-item').click();
+    await page.waitForSelector('[data-testid="commodity-form-dialog"]');
+    await page.waitForSelector('[data-testid="commodity-form-ai-step"]', {
+      state: 'visible',
+      timeout: 10000,
+    });
+    await page.click('[data-testid="commodity-form-ai-fill-manually"]');
+
+    // 3. Fill the wizard and submit. The anonymous submit is a pure hand-off:
+    //    it stashes the draft + the pending-first-item marker and redirects to
+    //    login — it does NOT POST, so we land back on /login, not a detail page.
+    await fillCommodityWizardAndSubmit(page, commodity);
+    await page.waitForURL(/\/login(\?.*)?$/, { timeout: 15000 });
+
+    // The hand-off marker is set before the redirect.
+    expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).not.toBeNull();
+
+    // 4. Log in. LoginPage sees the marker and routes to /welcome instead of
+    //    the dashboard (peek, not consume — the resolver owns consumption).
+    await page.getByTestId('email').fill(TEST_CREDENTIALS.email);
+    await page.getByTestId('password').fill(TEST_CREDENTIALS.password);
+    await page.getByTestId('login-button').click();
+
+    // 5. FirstItemResolver replays the stash. The seeded admin has >1 group,
+    //    so it shows the in-page picker; pick the first group. (Resilient to a
+    //    single-group seed too, where it would silently skip straight to the
+    //    detail page.)
+    const picker = page.getByTestId('first-item-resolver-picker');
+    await Promise.race([
+      picker.waitFor({ state: 'visible', timeout: 30000 }),
+      page.waitForURL(DETAIL_URL, { timeout: 30000 }),
+    ]);
+    if (await picker.isVisible().catch(() => false)) {
+      await page.getByTestId('first-item-resolver-group').first().click();
+    }
+
+    // 6. Land on the new item's detail page with the entered values intact.
+    await page.waitForURL(DETAIL_URL, { timeout: 30000 });
+    await verifyCommodityDetails(page, commodity);
+
+    // 7. After a successful replay the marker + anonymous draft are cleared.
+    expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).toBeNull();
+    expect(await page.evaluate((k) => localStorage.getItem(k), DRAFT_KEY)).toBeNull();
+  });
+});

--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -24,6 +24,7 @@ import {
   verifyCommodityDetails,
   type TestCommodity,
 } from './includes/commodities.js';
+import { deleteCommodityViaAPI, extractApiAuth } from './includes/commodities-api.js';
 import { TEST_CREDENTIALS } from './includes/auth.js';
 
 const MARKER_KEY = 'inventario_pending_first_item';
@@ -31,30 +32,25 @@ const DRAFT_KEY = 'commodity-draft:anon:create';
 const DETAIL_URL = /\/g\/[^/]+\/commodities\/[0-9a-fA-F-]{36}/;
 
 // Stub /feature-flags so the landing Add card renders without touching the
-// backend's PUBLIC_AI_VISION_SCAN_ENABLED config. route.fetch() pulls the
-// real envelope first and only flips public_scan, so any other (or future)
-// flags keep their real values.
+// backend's PUBLIC_AI_VISION_SCAN_ENABLED config. We pass the REAL upstream
+// response through (status + headers via `response`) and only flip
+// public_scan in the body — so any other (or future) flags keep their real
+// values, AND a broken /feature-flags still surfaces: a non-200 upstream
+// leaves the flag false, the Add card stays hidden, and the test fails,
+// rather than being masked by a synthetic 200.
 async function enablePublicScanFlag(page: import('@playwright/test').Page) {
   await page.route('**/api/v1/feature-flags', async (route) => {
-    let body: Record<string, unknown>;
-    try {
-      const res = await route.fetch();
-      body = (await res.json()) as Record<string, unknown>;
-    } catch {
-      body = { currency_migration: false, magic_link_login: false };
-    }
+    const response = await route.fetch();
+    const body = (await response.json()) as Record<string, unknown>;
     body.public_scan = true;
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
+    await route.fulfill({ response, json: body });
   });
 }
 
 test.describe('Anonymous first-item journey (#1988)', () => {
   test('logged-out → fill → login → item replayed into the group, nothing lost', async ({
     page,
+    request,
   }) => {
     const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     // Currency is the seeded e2e group's currency (CZK) on purpose: the
@@ -120,10 +116,27 @@ test.describe('Anonymous first-item journey (#1988)', () => {
 
     // 6. Land on the new item's detail page with the entered values intact.
     await page.waitForURL(DETAIL_URL, { timeout: 30000 });
+    const detail = new URL(page.url()).pathname.match(
+      /\/g\/([^/]+)\/commodities\/([0-9a-fA-F-]{36})/,
+    );
     await verifyCommodityDetails(page, commodity);
 
     // 7. After a successful replay the marker + anonymous draft are cleared.
     expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).toBeNull();
     expect(await page.evaluate((k) => localStorage.getItem(k), DRAFT_KEY)).toBeNull();
+
+    // Cleanup: the replay created a REAL commodity in the shared seeded
+    // backend. Delete it via the API so it can't perturb later specs
+    // (counts / ordering) or make local re-runs noisier. Best-effort —
+    // a failed delete must not fail an otherwise-green test.
+    if (detail) {
+      const auth = await extractApiAuth(page);
+      await deleteCommodityViaAPI(
+        request,
+        auth,
+        decodeURIComponent(detail[1]),
+        detail[2],
+      ).catch(() => {});
+    }
   });
 });

--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -26,6 +26,7 @@ import {
 } from './includes/commodities.js';
 import { deleteCommodityViaAPI, extractApiAuth } from './includes/commodities-api.js';
 import { TEST_CREDENTIALS } from './includes/auth.js';
+import { SEEDED_TEST_USERS } from './includes/user-isolation-auth.js';
 
 const MARKER_KEY = 'inventario_pending_first_item';
 const DRAFT_KEY = 'commodity-draft:anon:create';
@@ -119,44 +120,46 @@ test.describe('Anonymous first-item journey (#1988)', () => {
     const detail = new URL(page.url()).pathname.match(
       /\/g\/([^/]+)\/commodities\/([0-9a-fA-F-]{36})/,
     );
+    // waitForURL(DETAIL_URL) just passed, so the match is guaranteed — assert
+    // it (rather than `if (detail)`) so a future URL-shape change fails loudly
+    // here instead of silently skipping the isolation probe + cleanup below.
+    expect(detail, 'replay should land on /g/<slug>/commodities/<id>').not.toBeNull();
+    const slug = decodeURIComponent(detail![1]);
+    const id = detail![2];
     await verifyCommodityDetails(page, commodity);
 
     // 7. After a successful replay the marker + anonymous draft are cleared.
     expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).toBeNull();
     expect(await page.evaluate((k) => localStorage.getItem(k), DRAFT_KEY)).toBeNull();
 
-    if (detail) {
-      const slug = decodeURIComponent(detail[1]);
-      const id = detail[2];
-
-      // 8. Tenant/group isolation (AGENTS.md "multi-tenant isolation
-      //    testing"): a different seeded user — user2, who is NOT a member
-      //    of the owner's group — must not be able to read the replayed
-      //    item. The generic case lives in group-data-isolation.spec.ts;
-      //    this keeps the assertion attached to the #1988 replay path, which
-      //    lands a real row inside the owner's RLS boundary.
-      const otherLogin = await request.post('/api/v1/auth/login', {
-        data: { email: 'user2@test-org.com', password: 'TestPassword123' },
-      });
-      expect(otherLogin.ok()).toBeTruthy();
-      const otherToken = (await otherLogin.json()).access_token as string;
-      const probe = await request.get(
-        `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`,
-        {
-          headers: {
-            Accept: 'application/vnd.api+json',
-            Authorization: `Bearer ${otherToken}`,
-          },
+    // 8. Tenant/group isolation (AGENTS.md "multi-tenant isolation testing"):
+    //    a different seeded user — SEEDED_TEST_USERS[1] (user2), NOT a member
+    //    of the owner's group — must not be able to read the replayed item.
+    //    The generic case lives in group-data-isolation.spec.ts; this keeps
+    //    the assertion attached to the #1988 replay path, which lands a real
+    //    row inside the owner's RLS boundary.
+    const otherUser = SEEDED_TEST_USERS[1];
+    const otherLogin = await request.post('/api/v1/auth/login', {
+      data: { email: otherUser.email, password: otherUser.password },
+    });
+    expect(otherLogin.ok()).toBeTruthy();
+    const otherToken = (await otherLogin.json()).access_token as string;
+    const probe = await request.get(
+      `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`,
+      {
+        headers: {
+          Accept: 'application/vnd.api+json',
+          Authorization: `Bearer ${otherToken}`,
         },
-      );
-      expect([403, 404]).toContain(probe.status());
+      },
+    );
+    expect([403, 404]).toContain(probe.status());
 
-      // Cleanup: the replay created a REAL commodity in the shared seeded
-      // backend. Delete it (as the owner) so it can't perturb later specs
-      // (counts / ordering) or make local re-runs noisier. Best-effort —
-      // a failed delete must not fail an otherwise-green test.
-      const auth = await extractApiAuth(page);
-      await deleteCommodityViaAPI(request, auth, slug, id).catch(() => {});
-    }
+    // Cleanup: the replay created a REAL commodity in the shared seeded
+    // backend. Delete it (as the owner) so it can't perturb later specs
+    // (counts / ordering) or make local re-runs noisier. Best-effort —
+    // a failed delete must not fail an otherwise-green test.
+    const auth = await extractApiAuth(page);
+    await deleteCommodityViaAPI(request, auth, slug, id).catch(() => {});
   });
 });

--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -125,18 +125,38 @@ test.describe('Anonymous first-item journey (#1988)', () => {
     expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).toBeNull();
     expect(await page.evaluate((k) => localStorage.getItem(k), DRAFT_KEY)).toBeNull();
 
-    // Cleanup: the replay created a REAL commodity in the shared seeded
-    // backend. Delete it via the API so it can't perturb later specs
-    // (counts / ordering) or make local re-runs noisier. Best-effort —
-    // a failed delete must not fail an otherwise-green test.
     if (detail) {
+      const slug = decodeURIComponent(detail[1]);
+      const id = detail[2];
+
+      // 8. Tenant/group isolation (AGENTS.md "multi-tenant isolation
+      //    testing"): a different seeded user — user2, who is NOT a member
+      //    of the owner's group — must not be able to read the replayed
+      //    item. The generic case lives in group-data-isolation.spec.ts;
+      //    this keeps the assertion attached to the #1988 replay path, which
+      //    lands a real row inside the owner's RLS boundary.
+      const otherLogin = await request.post('/api/v1/auth/login', {
+        data: { email: 'user2@test-org.com', password: 'TestPassword123' },
+      });
+      expect(otherLogin.ok()).toBeTruthy();
+      const otherToken = (await otherLogin.json()).access_token as string;
+      const probe = await request.get(
+        `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`,
+        {
+          headers: {
+            Accept: 'application/vnd.api+json',
+            Authorization: `Bearer ${otherToken}`,
+          },
+        },
+      );
+      expect([403, 404]).toContain(probe.status());
+
+      // Cleanup: the replay created a REAL commodity in the shared seeded
+      // backend. Delete it (as the owner) so it can't perturb later specs
+      // (counts / ordering) or make local re-runs noisier. Best-effort —
+      // a failed delete must not fail an otherwise-green test.
       const auth = await extractApiAuth(page);
-      await deleteCommodityViaAPI(
-        request,
-        auth,
-        decodeURIComponent(detail[1]),
-        detail[2],
-      ).catch(() => {});
+      await deleteCommodityViaAPI(request, auth, slug, id).catch(() => {});
     }
   });
 });

--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -139,11 +139,17 @@ test.describe('Anonymous first-item journey (#1988)', () => {
     //    the assertion attached to the #1988 replay path, which lands a real
     //    row inside the owner's RLS boundary.
     const otherUser = SEEDED_TEST_USERS[1];
+    // Guard that the probe genuinely uses a different identity than the owner
+    // (TEST_CREDENTIALS === SEEDED_TEST_USERS[0]) — a same-user probe would
+    // return 200 and silently invalidate the isolation assertion.
+    expect(otherUser.email).not.toBe(TEST_CREDENTIALS.email);
     const otherLogin = await request.post('/api/v1/auth/login', {
       data: { email: otherUser.email, password: otherUser.password },
     });
     expect(otherLogin.ok()).toBeTruthy();
     const otherToken = (await otherLogin.json()).access_token as string;
+    // Fail fast if the login-response token contract ever changes.
+    expect(otherToken).toBeTruthy();
     const probe = await request.get(
       `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`,
       {

--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -444,13 +444,21 @@ export async function createCommodity(
 // button, does NOT skip an AI step, and does NOT assert any post-submit URL —
 // the caller owns the entry surface (e.g. the anonymous landing dialog, whose
 // submit redirects to /login rather than to a detail page) and whatever
-// navigation the submit triggers. Pass a commodity with no chip fields
-// (tags / extra serials / part numbers) to avoid the webkit Enter-leak quirk
-// that can submit the form early from the Extras step.
+// navigation the submit triggers.
+//
+// It mirrors createCommodity's webkit Enter-leak mitigation, but in a
+// flow-agnostic way: createCommodity detects an early submit by the detail
+// URL appearing, which only fits the authenticated create. Here we key off
+// the dialog unmounting instead, so the helper is robust whether the submit
+// lands on a detail page (authenticated) or bounces to /login (anonymous) —
+// callers no longer have to avoid chip fields for stability.
 export async function fillCommodityWizardAndSubmit(
   page: Page,
   c: TestCommodity,
 ): Promise<void> {
+  const dialog = page.locator('[data-testid="commodity-form-dialog"]');
+  const dialogStillOpen = () => dialog.isVisible().catch(() => false);
+
   await waitForStep(page, "basics");
   await fillBasicsStep(page, c);
   await gotoNext(page);
@@ -465,10 +473,24 @@ export async function fillCommodityWizardAndSubmit(
 
   await waitForStep(page, "extras");
   await fillExtrasStep(page, c);
-  await gotoNext(page);
 
-  await waitForStep(page, "files");
-  await page.click('[data-testid="commodity-form-submit"]');
+  // A webkit chip-input Enter-leak on the Extras step can submit the form
+  // early, unmounting the dialog before we reach Files. Only advance/submit
+  // while the dialog is still mounted; treat an already-closed dialog as an
+  // early submit and fall through.
+  if (await dialogStillOpen()) {
+    await gotoNext(page);
+  }
+  await Promise.race([
+    page.waitForSelector('[data-testid="commodity-form-files-step"]', {
+      state: "visible",
+      timeout: 10000,
+    }),
+    dialog.waitFor({ state: "hidden", timeout: 10000 }),
+  ]);
+  if (await dialogStillOpen()) {
+    await page.click('[data-testid="commodity-form-submit"]');
+  }
 }
 
 // assignCommodityLocation files an already-created commodity under a

--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -438,6 +438,39 @@ export async function createCommodity(
   return page.url();
 }
 
+// fillCommodityWizardAndSubmit walks the create wizard from the Basics step
+// through a submit click, reusing the same per-step fillers as
+// createCommodity. Unlike createCommodity it does NOT click the list "Add"
+// button, does NOT skip an AI step, and does NOT assert any post-submit URL —
+// the caller owns the entry surface (e.g. the anonymous landing dialog, whose
+// submit redirects to /login rather than to a detail page) and whatever
+// navigation the submit triggers. Pass a commodity with no chip fields
+// (tags / extra serials / part numbers) to avoid the webkit Enter-leak quirk
+// that can submit the form early from the Extras step.
+export async function fillCommodityWizardAndSubmit(
+  page: Page,
+  c: TestCommodity,
+): Promise<void> {
+  await waitForStep(page, "basics");
+  await fillBasicsStep(page, c);
+  await gotoNext(page);
+
+  await waitForStep(page, "purchase");
+  await fillPurchaseStep(page, c);
+  await gotoNext(page);
+
+  await waitForStep(page, "warranty");
+  await fillWarrantyStep(page, c);
+  await gotoNext(page);
+
+  await waitForStep(page, "extras");
+  await fillExtrasStep(page, c);
+  await gotoNext(page);
+
+  await waitForStep(page, "files");
+  await page.click('[data-testid="commodity-form-submit"]');
+}
+
 // assignCommodityLocation files an already-created commodity under a
 // location/area via the edit dialog — the post-create counterpart to the
 // location picker the create dialog dropped (#1987). It opens edit, selects


### PR DESCRIPTION
Follow-up to #2000 (merged): adds the end-to-end Playwright coverage for the anonymous first-item flow that #2000 shipped. It landed on the PR branch just after #2000 was merged, so it's split out here.

## What it covers
`e2e/tests/anonymous-first-item.spec.ts` walks the **no-data-loss guarantee** against the real backend:
1. logged-out → `/` renders the landing CTA (`RootGate` → `LandingPage`);
2. open the anonymous "Add New Item" dialog, skip the AI offer ("Fill manually");
3. fill the wizard and submit — the anonymous submit is a **pure hand-off** (stash draft + marker, redirect to `/login`, no POST);
4. log in → `LoginPage` routes to `/welcome`;
5. `FirstItemResolver` replays the draft into the resolved group and lands on the new item's detail page with the entered values intact;
6. asserts the localStorage marker **and** the anonymous draft are cleared after a successful replay.

## Notes
- Stubs `GET /api/v1/feature-flags` → `public_scan: true` so the landing Add card renders without coordinating `PUBLIC_AI_VISION_SCAN_ENABLED` across the e2e job matrix — the same approach `ai-scan.spec.ts` took for the mock provider. The AI scan is skipped, so the flow has **no dependency on the public scan endpoint**; the post-login POST hits the real (in-memory) backend.
- Drives the **>1-group resolver picker** (the seeded admin has 2 groups), and is resilient to a single-group seed too.
- Uses **CZK** (the seeded group currency) so the post-login `toRequest` re-run collapses to same-currency — avoids a cross-currency converted-price 422.
- New reusable `fillCommodityWizardAndSubmit` in `e2e/tests/includes/commodities.ts` (Basics→Files→submit, no entry click / no post-submit URL assertion) so the anonymous landing dialog reuses the same proven per-step fillers as `createCommodity`.

## Test plan
Validated locally against the dev stack: **chromium + firefox + webkit** green, webkit **3× repeat stable** (~11s each).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test covering the anonymous "first item" journey: submitting a manual commodity draft while logged out, persisting it through login, verifying replay and cleanup of local draft state, and asserting cross-tenant access restrictions and cleanup via API.
  * Extended test helpers to robustly drive and submit the commodity creation wizard across browsers, handling dialog lifecycle and input quirks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->