### PR TITLE
Reset the disposable master env's demo data each merge (demo.recreateOnDeploy)

### DIFF
--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -272,6 +272,7 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | `setupJob.initData.adminEmail` | `admin@example.com` | Set the initial admin login name. |
 | `setupJob.initData.adminPassword` | `""` | Required on first install unless provided by `secrets.existingSecret`. |
 | `setupJob.initData.seedDatabase` | `false` | Enable only for demo/sample data seeding. |
+| `demo.recreateOnDeploy` | `false` | Wipe the emptyDir-backed demo Postgres/MinIO/Redis on every deploy by keying a pod-template annotation to the resolved app image tag (so a changing `sha-<7>` tag rolls the pod → fresh DB/bucket → setup + init-data Jobs re-seed). For the disposable master env ONLY. **Hard render error if combined with demo persistence** — it can never roll-wipe a PVC-backed (longevity) store. NEVER enable in production; PR previews leave it `false`. |
 | `demo.postgresql.enabled` | `false` | Turn on in-cluster demo PostgreSQL. |
 | `demo.redis.enabled` | `false` | Turn on in-cluster demo Redis. |
 | `demo.minio.enabled` | `false` | Turn on in-cluster demo MinIO and S3-style uploads. |

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -471,3 +471,66 @@ The caller is expected to render this list item under `initContainers:`.
 {{- printf "http://%s" (include "inventario.minioEndpoint" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+demoRecreatePodAnnotations — pod-template annotations that force an emptyDir-backed
+demo datastore (Postgres / MinIO / Redis) to be RECREATED, and thereby WIPED, on
+every deploy whose resolved app image tag changes.
+
+Why this exists (the disposable-master model):
+  The preview platform runs two long-lived envs off the SAME master image pin:
+    * inv-vcl01-master    — meant to be DISPOSABLE: a fresh, empty demo dataset
+                            each merge (so stale rows — e.g. an old back-office
+                            operator — never linger).
+    * inv-vcl01-longevity — DURABLE: PVC-backed + Velero-backed; its data MUST
+                            survive every deploy.
+  A master push only rolls the app Deployment + setup/init-data Jobs; the
+  demo-postgres / demo-minio pods survive app redeploys, so on emptyDir their
+  state ACCUMULATES across merges and master never actually resets. Keying a
+  pod-template annotation to the per-commit image tag (`sha-<7>` on master)
+  changes the pod template every merge → the pod is recreated → its emptyDir is
+  wiped → the wave -5 setup Job + wave +5 init-data Job re-migrate, re-seed, and
+  (via #2001's idempotent `--ensure`) re-create the sops-sourced operator on the
+  clean store.
+
+Hard safety guard (impossible to wipe durable data):
+  This annotation is emitted ONLY when persistence is DISABLED for that store. If
+  a caller is configured with `demo.recreateOnDeploy: true` AND persistence on
+  (the longevity profile, gated by demo.<store>.persistence.enabled), rendering
+  FAILS LOUDLY — a roll-wipe of a PVC-backed store would be silent data loss, so
+  we refuse to render rather than annotate. Net effect: even an accidental
+  recreateOnDeploy=true on longevity can NEVER roll-wipe its Velero-backed PVCs.
+
+Usage (caller passes a dict so the helper knows which store's persistence to check):
+  {{- include "inventario.demoRecreatePodAnnotations"
+        (dict "root" $ "store" "postgresql" "persistenceEnabled" .Values.demo.postgresql.persistence.enabled) }}
+  Render under the pod template's `metadata.annotations:`; emits nothing (a no-op)
+  unless recreateOnDeploy is true on an emptyDir-backed store.
+*/}}
+{{- define "inventario.demoRecreatePodAnnotations" -}}
+{{- $root := .root -}}
+{{- if $root.Values.demo.recreateOnDeploy -}}
+{{- if .persistenceEnabled -}}
+{{- fail (printf "demo.recreateOnDeploy=true is incompatible with demo persistence: store %q has persistence.enabled=true. recreateOnDeploy rolls the demo pod on every deploy, which WIPES an emptyDir store — on a PVC-backed (e.g. longevity) store that would be silent data loss. Disable recreateOnDeploy for any env with demo persistence on; it is intended ONLY for the disposable, emptyDir-backed master env." .store) -}}
+{{- end -}}
+{{- $imageTag := default $root.Chart.AppVersion $root.Values.image.tag -}}
+checksum/recreate-on-deploy: {{ $imageTag | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+demoRecreateStrategy — Deployment .spec.strategy for an emptyDir demo datastore.
+
+When recreateOnDeploy is on we WANT `Recreate`: a RollingUpdate would briefly run
+the old (data-bearing) pod alongside the new empty one, and the Service could route
+to the stale pod mid-roll. `Recreate` tears the old pod down first, so the wipe is
+clean. Postgres/MinIO already pin `Recreate` unconditionally (single-writer
+emptyDir); this helper exists so Redis (no strategy block) also flips to Recreate
+when it is being roll-wiped, and to keep the intent self-documenting.
+*/}}
+{{- define "inventario.demoRecreateStrategy" -}}
+{{- if .Values.demo.recreateOnDeploy -}}
+strategy:
+  type: Recreate
+{{- end -}}
+{{- end -}}

--- a/helm/inventario/templates/demo/minio-deployment.yaml
+++ b/helm/inventario/templates/demo/minio-deployment.yaml
@@ -24,6 +24,20 @@ spec:
       app.kubernetes.io/component: demo-minio
   template:
     metadata:
+      {{- /*
+        recreateOnDeploy (master only): an image-tag-keyed annotation that
+        changes every master merge so this pod (and its emptyDir bucket) is
+        recreated — wiping demo objects so master is fresh each merge. Emits
+        nothing unless demo.recreateOnDeploy=true, and FAILS rendering if
+        persistence is on (PVC-backed longevity must never be roll-wiped). See
+        _helpers.tpl. spec.strategy is already Recreate above (single-writer
+        emptyDir; the wave -6 bucket-create Job re-creates the bucket).
+      */}}
+      {{- $recreate := include "inventario.demoRecreatePodAnnotations" (dict "root" $ "store" "minio" "persistenceEnabled" .Values.demo.minio.persistence.enabled) }}
+      {{- if $recreate }}
+      annotations:
+        {{- $recreate | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "inventario.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: demo-minio

--- a/helm/inventario/templates/demo/postgresql-deployment.yaml
+++ b/helm/inventario/templates/demo/postgresql-deployment.yaml
@@ -28,6 +28,19 @@ spec:
       app.kubernetes.io/component: demo-postgresql
   template:
     metadata:
+      {{- /*
+        recreateOnDeploy (master only): an image-tag-keyed annotation that
+        changes every master merge so this pod (and its emptyDir) is recreated
+        — wiping demo state so master is fresh each merge. Emits nothing unless
+        demo.recreateOnDeploy=true, and FAILS rendering if persistence is on
+        (PVC-backed longevity must never be roll-wiped). See _helpers.tpl.
+        spec.strategy is already Recreate above (single-writer emptyDir).
+      */}}
+      {{- $recreate := include "inventario.demoRecreatePodAnnotations" (dict "root" $ "store" "postgresql" "persistenceEnabled" .Values.demo.postgresql.persistence.enabled) }}
+      {{- if $recreate }}
+      annotations:
+        {{- $recreate | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "inventario.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: demo-postgresql

--- a/helm/inventario/templates/demo/redis-deployment.yaml
+++ b/helm/inventario/templates/demo/redis-deployment.yaml
@@ -8,12 +8,26 @@ metadata:
     app.kubernetes.io/component: demo-redis
 spec:
   replicas: 1
+  {{- /*
+    recreateOnDeploy (master only): demo Redis is ALWAYS emptyDir (--save "",
+    --appendonly no — there is no demo.redis.persistence option), so the
+    image-tag-keyed annotation below recreates the pod every master merge and
+    its strategy flips to Recreate to avoid a two-pod overlap during the roll.
+    Redis carries only ephemeral rate-limit / blacklist / CSRF state, so wiping
+    it on master is harmless; the helper is a no-op unless recreateOnDeploy=true.
+  */}}
+  {{- include "inventario.demoRecreateStrategy" . | nindent 2 }}
   selector:
     matchLabels:
       {{- include "inventario.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: demo-redis
   template:
     metadata:
+      {{- $recreate := include "inventario.demoRecreatePodAnnotations" (dict "root" $ "store" "redis" "persistenceEnabled" false) }}
+      {{- if $recreate }}
+      annotations:
+        {{- $recreate | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "inventario.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: demo-redis

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -904,6 +904,26 @@ containerSecurityContext:
 # You do NOT need to set the matching secrets.* fields manually.
 # ============================================================
 demo:
+  # Recreate (WIPE) the emptyDir-backed demo Postgres / MinIO / Redis pods on
+  # every deploy, so the demo dataset is FRESH each time.
+  #
+  # When true, each demo deployment template gets a pod-template annotation
+  # (`checksum/recreate-on-deploy`) keyed to the resolved app image tag. On the
+  # master preview that tag is the per-commit `sha-<7>`, so it changes every
+  # merge → the pod template changes → the pod is recreated → its emptyDir is
+  # WIPED → the wave -5 setup Job + wave +5 init-data Job re-migrate, re-seed,
+  # and (via #2001's idempotent `--ensure`) re-create the sops operator on the
+  # clean store. The demo Deployment strategy is `Recreate` so the old
+  # data-bearing pod is torn down before the new one starts (no mid-roll Service
+  # hit on stale data).
+  #
+  # ⚠️  This WIPES demo data on every deploy. Intended ONLY for the disposable
+  # master env (inv-vcl01-master). NEVER enable it where demo persistence (PVC)
+  # is on — doing so is a hard render error: the chart FAILS `helm template`
+  # rather than risk roll-wiping a PVC-backed store (the durable, Velero-backed
+  # longevity env). NEVER enable in production. PR previews leave it false.
+  recreateOnDeploy: false
+
   postgresql:
     # Enable an in-cluster PostgreSQL instance
     enabled: false

--- a/infra/CHEATSHEET.md
+++ b/infra/CHEATSHEET.md
@@ -1,0 +1,271 @@
+# Inventario preview-infra troubleshooting cheat-sheet
+
+Fast, copy-pasteable commands for debugging the single-VM ArgoCD preview
+cluster (`inv-vcl01`: the `inv-vcl01-master`, `inv-vcl01-longevity`, and
+`inv-vcl01-pr<N>` environments).
+
+This is the **quick reference**. For scenario walkthroughs (preview not
+appearing, TS-operator issues, ArgoCD admin password reset, ingress, …) see
+[README §5 Troubleshooting](./README.md#5-troubleshooting); for the secret
+model see [SECRETS.md](./SECRETS.md).
+
+The golden rules from real incidents are called out as **💡 Lesson** —
+read those first; they're what actually saves time.
+
+## 0. Access
+
+The cluster lives on a Tailscale-reachable VM. There is **no `argocd` CLI**
+installed locally — drive ArgoCD through `kubectl` against the Application
+CRD.
+
+```bash
+export KUBECONFIG=~/.kube/inv-vcl01.config   # set once per shell
+
+# Is the cluster reachable at all?
+tailscale status | grep inv-vcl01            # expect argocd-inv-vcl01 + the env nodes
+kubectl get ns | grep inv-vcl01              # sanity: API answers
+```
+
+> 💡 **Lesson.** If `kubectl` hangs with `TLS handshake timeout`, you're
+> almost certainly pointed at the wrong context (e.g. a local `kind`
+> cluster). `kubectl config current-context` — the VM cluster is **only**
+> reachable via `~/.kube/inv-vcl01.config`, not your default kubeconfig.
+
+## 1. ArgoCD at a glance
+
+```bash
+# All apps with both status axes (the view that's usually enough):
+kubectl -n argocd get applications.argoproj.io -A \
+  -o custom-columns='NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status,REV:.status.sync.revision'
+
+# One app — sync result + any blocking conditions:
+kubectl -n argocd get application.argoproj.io <app> \
+  -o jsonpath='SYNC={.status.sync.status} HEALTH={.status.health.status}{"\n"}OP={.status.operationState.phase} msg={.status.operationState.message}{"\n"}'
+
+# App-level conditions (rendering/auth errors, comparison errors):
+kubectl -n argocd get application.argoproj.io <app> \
+  -o jsonpath='{range .status.conditions[*]}{.type}: {.message}{"\n"}{end}'
+
+# ApplicationSet generator problems (preview never appears):
+kubectl -n argocd describe appset inventario-pr-previews   # look at .status.conditions
+kubectl -n argocd logs deploy/argocd-applicationset-controller --tail=100
+```
+
+### Sync vs Health — internalize this
+
+Two **orthogonal** axes:
+
+- **Sync**: `Synced` / `OutOfSync` — does the live cluster match git?
+- **Health**: `Healthy` / `Progressing` / `Degraded` / `Missing` /
+  `Suspended` — are the live resources actually well?
+
+`Synced + Degraded` is the classic confusing state: **the manifests applied
+correctly, but a live child resource is unhealthy.** Don't go hunting in git
+or the chart — go look at the resources.
+
+How ArgoCD decides `Degraded`:
+
+| Resource   | `Degraded` when…                                                        |
+| ---------- | ----------------------------------------------------------------------- |
+| Deployment | `progressDeadlineSeconds` exceeded — pods never became Ready            |
+| Job        | the Job has a `Failed` condition (backoffLimit or activeDeadline hit)   |
+| Pod        | the pod is in a failed phase                                            |
+
+## 2. Drill into a Degraded app
+
+```bash
+ns=inv-vcl01-master   # the namespace == the app name for these envs
+
+kubectl -n $ns get pods -o wide
+kubectl -n $ns get jobs
+```
+
+> 💡 **Lesson.** If the app pod is `Running 1/1` but the Application is
+> `Degraded`, the culprit is usually a **Job** (`setup` or `init-data`)
+> showing `Failed`/`0/1`. A failed Job drags the whole Application to
+> `Degraded` even though the app itself is perfectly healthy.
+
+## 3. Crash-looping pods (the high-value section)
+
+```bash
+ns=inv-vcl01-master
+pod=$(kubectl -n $ns get pods -l app.kubernetes.io/component=init-data \
+  --sort-by=.metadata.creationTimestamp -o name | tail -1)
+
+# Current attempt:
+kubectl -n $ns logs $pod -c init-data
+# The crashed PREVIOUS attempt (restartPolicy: OnFailure restarts in place):
+kubectl -n $ns logs $pod -c init-data --previous
+
+# Exit code + reason of the last crash (works even while it loops):
+kubectl -n $ns get pod ${pod#pod/} \
+  -o jsonpath='{.status.initContainerStatuses[0].lastState.terminated}'
+```
+
+> 💡 **Lesson (this one cracked the case twice).** When you see
+> `Back-off restarting failed container`, **immediately grab a live pod's
+> logs with `--previous`** before theorizing. With `restartPolicy: OnFailure`
+> the container restarts *in place*, so `logs` (no `-p`) is often empty while
+> `logs --previous` shows the real error. If the Job already finished
+> (`failed=1`) its pod is GC'd and the logs are gone — so catch a looping pod
+> while it's alive.
+
+Events persist ~1h even after pods are gone — a good fallback:
+
+```bash
+kubectl -n $ns get events --sort-by=.lastTimestamp | grep -iE 'init-data|backoff|error|unhealthy'
+```
+
+## 4. Jobs: `setup` and `init-data`
+
+```bash
+ns=inv-vcl01-master
+job=$ns-inventario-init-data
+
+# Why did it fail — BackoffLimitExceeded vs DeadlineExceeded:
+kubectl -n $ns get job $job -o jsonpath='{.status.conditions}' | python3 -m json.tool
+kubectl -n $ns get job $job -o jsonpath='failed={.status.failed} succeeded={.status.succeeded}{"\n"}'
+```
+
+These Jobs carry `argocd.argoproj.io/sync-options: "Force=true,Replace=true"`,
+so ArgoCD **delete-then-creates them on every sync** — they re-run each merge.
+That means anything they do must be **idempotent** (re-runnable against an
+already-provisioned env), or the env goes `Degraded` on the next sync.
+
+What the two Jobs do:
+
+- `…-setup` (wave −5): bootstrap DB + run migrations + seed the app admin.
+- `…-init-data` (wave +5): `inventario db migrate data` → optional
+  `backoffice bootstrap` (#1967) → optional `/api/v1/seed`.
+
+## 5. Read the **deployed** manifest, not your local tree
+
+> 💡 **Lesson.** The deployed chart + image can be **ahead of your local
+> checkout** (master/longevity track the `argocd/master-pin` branch, which
+> CI force-pushes on every master image build). Debugging against your local
+> files will mislead you. Always read the **live** object.
+
+```bash
+ns=inv-vcl01-master
+
+# Which image (= which master commit) is actually running?
+kubectl -n $ns get deploy $ns-inventario \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'   # ghcr.io/...:sha-<7>
+
+# The rendered init-data script + env, straight from the cluster:
+kubectl -n $ns get job $ns-inventario-init-data \
+  -o jsonpath='{.spec.template.spec.initContainers[0].args[0]}'
+kubectl -n $ns get job $ns-inventario-init-data -o json \
+  | python3 -c 'import json,sys; [print(e["name"],"=",e.get("value","<from-secret>")) for e in json.load(sys.stdin)["spec"]["template"]["spec"]["initContainers"][0]["env"]]'
+```
+
+Map a `sha-<7>` back to a commit (GitHub MCP / `gh`), and read the pin:
+
+```bash
+gh api repos/denisvmedia/inventario/contents/infra/argocd/master-image.json?ref=argocd/master-pin \
+  --jq '.content' | base64 -d        # -> { "sha": "...", "imageTag": "sha-<7>" }
+```
+
+## 6. Images & the `master-pin` flow
+
+`inv-vcl01-master` **and** `inv-vcl01-longevity` both read the **same**
+`argocd/master-pin` file, so they roll forward together on every master push:
+
+```text
+merge to master → .github/workflows/docker.yml builds + publishes sha-<7>
+               → force-pushes argocd/master-pin (sha + imageTag)
+               → both ApplicationSets re-generate at the new sha (poll 60s)
+               → ArgoCD auto-syncs (Replace recreates the immutable Jobs)
+```
+
+`helm/**`, `infra/helm-overlays/**`, and `infra/argocd/**` are in the image
+build's path filter, so even a **chart-only** change triggers a rebuild +
+pin flip.
+
+Stuck on `ImagePullBackOff`? The `sha-<7>` image isn't in GHCR yet:
+
+```bash
+crane manifest ghcr.io/denisvmedia/inventario:sha-<7>   # or docker manifest inspect …
+# "manifest unknown" → the build hasn't published yet; wait/check Actions.
+```
+
+## 7. Secrets — inspect safely
+
+```bash
+ns=inv-vcl01-master
+
+# KEY NAMES only — never dump values:
+kubectl -n $ns get secret inventario-admin -o json \
+  | python3 -c 'import json,sys; print("\n".join(sorted(json.load(sys.stdin)["data"].keys())))'
+```
+
+> 💡 **Lesson.** In a **sops** bundle the **keys are plaintext** and only the
+> **values** are encrypted, so you can `grep` the encrypted file to check
+> structure without decrypting anything:
+>
+> ```bash
+> grep -nE '^[a-z_]+:|password|api_key|email' infra/vm/secrets/secrets.enc.yaml
+> ```
+
+`apply-secrets.sh` runs **out of band** — ArgoCD does **not** manage these
+Secrets. After you add a key to the bundle (or a chart feature starts needing
+one), re-run it or the env stays broken:
+
+```bash
+git pull origin master                       # get the latest apply-secrets.sh
+make -C infra bootstrap VM=<user@vm>          # decrypts sops + applies Secrets over SSH
+```
+
+> 💡 **Lesson (recurring trap).** A chart feature that **fails loud** on a
+> missing secret key (e.g. AI-vision `provider=anthropic` needs the API key
+> #1976; back-office bootstrap needs `BACKOFFICE_USER_PASSWORD` #1967) will
+> deploy via ArgoCD **before** `apply-secrets.sh` has materialized the key →
+> the workload CrashLoops / the Job fails → app `Degraded`. The fix is
+> almost never in the chart: re-run `apply-secrets`. When adding such a
+> feature, run it **before** the commit syncs.
+
+## 8. Postgres / DB poking (read-only first)
+
+```bash
+ns=inv-vcl01-master
+pg="kubectl -n $ns exec deploy/$ns-inventario-demo-postgres -- psql -U inventario -d inventario"
+
+$pg -c "select email, role, created_at from backoffice_users order by created_at;"
+```
+
+> 💡 **Lesson.** Before deleting a row, discover what references it — a blind
+> `DELETE` trips foreign keys (`update or delete … violates foreign key
+> constraint`):
+>
+> ```bash
+> $pg -At -c "SELECT conrelid::regclass FROM pg_constraint
+>             WHERE confrelid='backoffice_users'::regclass AND contype='f';"
+> # e.g. backoffice_refresh_tokens, backoffice_user_mfa_secrets
+> # → delete children first, then the parent row:
+> $pg -c "DELETE FROM backoffice_refresh_tokens;
+>         DELETE FROM backoffice_user_mfa_secrets;
+>         DELETE FROM backoffice_users;"
+> ```
+
+Note the env split: `master` uses `emptyDir` demo stores (disposable);
+`longevity` puts them on PVCs + Velero backup (**durable** — never wipe its
+data wholesale). Treat destructive DB ops on `longevity` surgically.
+
+## 9. Symptom → likely cause
+
+| Symptom                                                            | Likely cause / next step                                                                 |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `Synced` + `Degraded`, app pod `Running`                           | a Job is `Failed` → `kubectl get jobs`, then §3 logs `--previous`                         |
+| init-data Job fails: `a backoffice user already exists`            | bootstrap not idempotent for that email → ensure `--ensure` is deployed (#1967)          |
+| init-data Job fails: `BACKOFFICE_USER_PASSWORD is empty`           | secret key missing → re-run `apply-secrets` (§7)                                         |
+| app pod CrashLoops: `database schema lags …`                       | `setup` Job hasn't migrated yet → check `kubectl get jobs` / its logs                    |
+| app pod CrashLoops on boot, `aivision`/`wireCommodityScan`         | `provider=anthropic` but API key missing → `apply-secrets` (#1976)                       |
+| `ImagePullBackOff` on `sha-<7>`                                    | image not published yet → check Actions / `crane manifest` (§6)                          |
+| Preview never appears after labeling/merge                         | ApplicationSet generator → `describe appset` + controller logs (§1, README §5)           |
+| ArgoCD UI returns 401 after a secret rotation                      | re-patch `argocd-secret` admin hash → README §5                                          |
+
+## 10. See also
+
+- [README §5 Troubleshooting](./README.md#5-troubleshooting) — full scenario
+  walkthroughs.
+- [SECRETS.md](./SECRETS.md) — the sops bundle schema + `apply-secrets` flow.

--- a/infra/README.md
+++ b/infra/README.md
@@ -628,6 +628,11 @@ with kubectl" is self-correcting; no manual re-sync needed.
 
 ## 5. Troubleshooting
 
+> For a fast, copy-pasteable command reference (inspecting ArgoCD, reading
+> crash-looping pod logs, the `master-pin` flow, safe secret/DB inspection),
+> see the [**troubleshooting cheat-sheet**](./CHEATSHEET.md). The sections
+> below are the longer scenario walkthroughs.
+
 ### Preview not appearing after labeling
 
 1. Confirm the label is exactly `preview` (case-sensitive — `Preview` won't match).

--- a/infra/README.md
+++ b/infra/README.md
@@ -510,6 +510,30 @@ next 60 s poll → pods roll. No manual `rollout restart` needed. The
 `inv-vcl01-longevity` ApplicationSet reads the same pin file (it tracks
 master too).
 
+**Disposable master vs durable longevity.** Both envs run off the *same*
+master image pin, but they are deliberately opposite in data lifecycle:
+
+- `inv-vcl01-master` is **disposable** — its demo Postgres/MinIO/Redis use
+  `emptyDir`, and the master ApplicationSet sets `demo.recreateOnDeploy: true`.
+  That makes the chart stamp an `image-tag-keyed` pod annotation
+  (`checksum/recreate-on-deploy: sha-<7>`) on each demo deployment. Because the
+  pin flips the tag every merge, the demo pod template changes → the pod (and
+  its `emptyDir`) is recreated → the DB/bucket is wiped → the wave -5 setup Job
+  + wave +5 init-data Job re-migrate, re-seed, and (idempotently, via #2001's
+  `backoffice bootstrap --ensure`) re-create the sops operator on a clean store.
+  This is what makes master genuinely *reset each merge* — without it the demo
+  pods survive app redeploys (only the app Deployment + Jobs roll) and stale
+  rows accumulate. The `Recreate` Deployment strategy tears the old
+  data-bearing pod down before the new one starts, so the Service never routes
+  to stale data mid-roll.
+- `inv-vcl01-longevity` is **durable** — `longevity-base.values.yaml` turns on
+  `demo.postgresql.persistence.enabled` / `demo.minio.persistence.enabled`
+  (PVC-backed, Velero-backed). It leaves `demo.recreateOnDeploy` at its `false`
+  default, so the annotation is never emitted and its pods are *not* roll-wiped.
+  As a hard guard, the chart **fails to render** if `recreateOnDeploy` is ever
+  combined with demo persistence, so an accidental enable on longevity can never
+  silently wipe its backed-up data.
+
 To check which commit is currently deployed:
 
 ```bash

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -132,6 +132,21 @@ spec:
               # this env CrashLoops. Flip to `none`/`mock` to defer the key.
               aivision:
                 provider: anthropic
+              # Disposable-master reset (the whole point of this env): wipe the
+              # emptyDir-backed demo Postgres / MinIO / Redis on every master
+              # merge so master starts FRESH each time. master's image tag is the
+              # per-commit `sha-<7>`, so the chart's image-tag-keyed pod
+              # annotation changes every merge → the demo pods are recreated →
+              # their emptyDir is wiped → the setup (wave -5) + init-data (wave
+              # +5) Jobs re-migrate, re-seed, and re-create the sops operator on
+              # the clean store. This is why stale rows (e.g. an old back-office
+              # operator) no longer linger on master. Complements #2001 (#2001
+              # made bootstrap idempotent so the re-create is a clean `--ensure`).
+              # ⚠️ master ONLY — preview-base/longevity keep it false; the chart
+              # FAILS to render if combined with demo persistence (PVC), so it
+              # can never roll-wipe the durable, Velero-backed longevity data.
+              demo:
+                recreateOnDeploy: true
               ingress:
                 annotations:
                   tailscale.com/hostname: inv-vcl01-master


### PR DESCRIPTION
## The disposable-master vs durable-longevity model

The preview platform runs two long-lived ArgoCD environments off the **same** master image pin:

- **`inv-vcl01-master`** — meant to be **disposable**: a fresh, empty demo dataset every merge, so stale rows never linger.
- **`inv-vcl01-longevity`** — **durable**: its demo Postgres + MinIO are PVC-backed and Velero-backed; its data **must** survive every deploy.

## Root issue: master never actually resets

master's demo Postgres/MinIO use `emptyDir`, but a master push only rolls the **app** Deployment + the setup/init-data **Jobs**. The `demo-postgres` / `demo-minio` pods are *not* rolled — they survive app redeploys. So their `emptyDir` state **accumulates across merges** and master never resets. That is why stale data (e.g. an old back-office operator row) lingered on master long after the commit that created it.

## The fix: an image-tag-keyed pod roll → emptyDir wipe → Jobs re-seed

New chart value **`demo.recreateOnDeploy`** (default `false`). When `true`, each demo deployment template gets a pod-template annotation keyed to the resolved app image tag:

```
checksum/recreate-on-deploy: <imageTag>   # imageTag = default .Chart.AppVersion .Values.image.tag
```

On master the tag is the per-commit `sha-<7>`, so it **changes every merge** → the demo pod template changes → the pod (and its `emptyDir`) is **recreated** → DB/bucket is **wiped** → the existing wave **-5** setup Job + wave **+5** init-data Job re-migrate, re-seed, and (via #2001's idempotent `backoffice bootstrap --ensure`) **re-create the sops operator** on the clean store. That is exactly the "reset each merge" the env was always meant to have.

The demo Deployment **strategy is `Recreate`** so the old data-bearing pod is torn down before the new one starts — no brief two-pod overlap where the Service could route to the stale pod mid-roll. (Postgres/MinIO already pinned `Recreate`; Redis — which is always `emptyDir`, `--save "" --appendonly no` — now flips to `Recreate` too under `recreateOnDeploy`.)

## Master-only enablement

`demo.recreateOnDeploy: true` is set **only** in the inline `values:` of `infra/argocd/applicationset-master.yaml`. Untouched, so they stay `false`:

- `infra/helm-overlays/preview-base.values.yaml` (shared base for PR previews + master + longevity)
- `infra/helm-overlays/longevity-base.values.yaml`
- `infra/argocd/applicationset-pr.yaml`
- `infra/argocd/applicationset-longevity.yaml`

So **PR previews and longevity are unaffected**.

## Explicit guard: it can never touch PVC-backed (longevity) data

The recreate annotation is emitted **only when the store's persistence is disabled**. If `recreateOnDeploy` is ever combined with demo persistence (the longevity profile, gated by `demo.<store>.persistence.enabled`), the chart **fails `helm template`** with a clear error rather than risk roll-wiping a PVC-backed store. So even an accidental enable on longevity can never silently wipe its Velero-backed data.

## Relationship to #2001

Complements #2001 (back-office `--ensure` bootstrap idempotency + sops-sourced operator identity). #2001 made the bootstrap a clean no-op-or-create; this PR makes the master demo store fresh each merge so that bootstrap runs against a clean slate every time.

## Proofs (`helm template` + grep)

**master-like** (`--set demo.recreateOnDeploy=true --set image.tag=sha-aaaaaaa`, demo Postgres/MinIO/Redis on emptyDir): annotation present on all three demo deployments + `strategy: Recreate`:

```
demo-minio:      type: Recreate   checksum/recreate-on-deploy: "sha-aaaaaaa"
demo-postgresql: type: Recreate   checksum/recreate-on-deploy: "sha-aaaaaaa"
demo-redis:      type: Recreate   checksum/recreate-on-deploy: "sha-aaaaaaa"
```

Re-render with `--set image.tag=sha-bbbbbbb` → all three annotations change to `"sha-bbbbbbb"` (pod template differs per tag → pod recreated → emptyDir wiped each merge).

**longevity-like** (real `preview-base` + `longevity-base` overlays, demo persistence ON, `recreateOnDeploy` stays `false`): `recreate-on-deploy` annotation count = **0**, both demo PVCs present → no roll-wipe. And `--set demo.recreateOnDeploy=true --set demo.postgresql.persistence.enabled=true` → render **fails loudly**:

```
Error: ... demo.recreateOnDeploy=true is incompatible with demo persistence:
store "postgresql" has persistence.enabled=true ... on a PVC-backed (e.g. longevity)
store that would be silent data loss ...
```

**default / PR-preview** (`recreateOnDeploy` false; default values and real `preview-base` overlay): `recreate-on-deploy` annotation count = **0**, Redis has no `Recreate` strategy block — no behavior change.

`helm lint` clean. Chart-only change (no Go). The default-values `helm template` requires `secrets.dbDsn` — a pre-existing required-value guard, identical on the unmodified base, unrelated to this PR.

## Design choice

Chose **`strategy: Recreate`** (not RollingUpdate) for the demo stores under `recreateOnDeploy`: a rolling update would briefly run the old data-bearing pod alongside the new empty one and the Service could serve stale data mid-roll. Postgres/MinIO already used `Recreate` unconditionally; this PR extends it to Redis only when `recreateOnDeploy` is on, via a small `inventario.demoRecreateStrategy` helper, keeping default behavior untouched.

## Files changed

- `helm/inventario/values.yaml` — new `demo.recreateOnDeploy` value + docs
- `helm/inventario/templates/_helpers.tpl` — `demoRecreatePodAnnotations` (annotation + hard guard) and `demoRecreateStrategy` helpers
- `helm/inventario/templates/demo/{postgresql,minio,redis}-deployment.yaml` — wire the annotation (+ Redis strategy)
- `helm/inventario/README.md` — values-table row
- `infra/argocd/applicationset-master.yaml` — enable for master only
- `infra/README.md` — document the disposable-master vs durable-longevity model