### PR TITLE
[#1968] Render the impersonation banner during a live session (credential the probe from the tenant plane)

### DIFF
--- a/frontend/src/components/__tests__/ImpersonationBanner.test.tsx
+++ b/frontend/src/components/__tests__/ImpersonationBanner.test.tsx
@@ -12,6 +12,7 @@ import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
 import {
   clearAuth,
+  getAccessToken,
   getImpersonationReturn,
   setAccessToken,
   setImpersonationReturn,
@@ -196,6 +197,10 @@ describe("ImpersonationBanner", () => {
     await waitFor(() => expect(endCalls).toBe(1))
     await waitFor(() => expect(redirect).toHaveBeenCalledWith("/admin/users/t1"))
     expect(getImpersonationReturn()).toBeNull()
+    // #1968: the stale impersonated tenant session is torn down so the
+    // /admin/* page we redirect to doesn't boot the tenant AuthProvider into
+    // a /auth/me 401 → tenant /login bounce that would hijack the admin return.
+    expect(getAccessToken()).toBeNull()
   })
 
   it("on End failure: clears auth and redirects to /backoffice/login with the session_expired reason", async () => {

--- a/frontend/src/features/admin/api.ts
+++ b/frontend/src/features/admin/api.ts
@@ -402,6 +402,16 @@ export async function updateAdminGroupMemberRole(
 // returns `{ active: false }` with no other fields when no session is in
 // progress; the banner uses `active` as its sole render gate.
 //
+// Credential plane (#1968): the BE reports `active: true` ONLY when the
+// request carries the impersonation token (the tenant JWT with `imp=true`) —
+// a back-office operator token is dispatched to the plain back-office branch
+// and reports `active: false`. The http client normally routes every /admin/*
+// path to the back-office token, so inside an impersonated session it would
+// probe with the wrong plane and the banner would never render. The http
+// layer therefore credentials this path (and `end`) from the TENANT plane
+// while an impersonation return slot is set — see `usesImpersonationCredential`
+// in lib/http.ts. No flag is needed here: the routing is keyed off the slot.
+//
 // The endpoint sits on `RequireBackofficeAuthOrImpersonating` (#1785 Phase
 // 5), so a plain tenant token — the vast majority of authenticated callers
 // — gets a 401, NOT a 403. That 401 is a definitive "you are not signed

--- a/frontend/src/features/admin/api.ts
+++ b/frontend/src/features/admin/api.ts
@@ -8,7 +8,7 @@
 // prefix in GROUP_SCOPED_PREFIXES).
 import { http, HttpError } from "@/lib/http"
 import {
-  clearImpersonationReturn,
+  clearAuth,
   getImpersonationReturn,
   setAccessToken,
   setCsrfToken,
@@ -491,16 +491,23 @@ export interface EndImpersonationResult {
 // cookie is non-refreshable).
 //
 // The token swap writes the operator's back-office tokens through the
-// back-office storage keys (NOT the tenant ones); the impersonation access
-// token that was previously sitting in tenant storage stays there but is
-// no longer used because the next /admin/* request reads the back-office
-// token via the plane-aware http client. The page hard-redirects to
-// /admin/users/<targetUserId> (or /admin/tenants) immediately after, which
-// rebuilds every cache from scratch.
+// back-office storage keys (NOT the tenant ones), and `clearAuth()` tears
+// down the impersonated TENANT session: the imp token sitting in tenant
+// storage is now blacklisted server-side, and although the next /admin/*
+// request correctly reads the back-office token, the GLOBAL tenant
+// AuthProvider still boots on the /admin/* page we hard-redirect to and
+// would probe /auth/me with that stale token — a user-initiated 401 that
+// the http client turns into a tenant /login "session expired" bounce,
+// hijacking the intended return to the admin panel (#1968). Clearing it
+// makes the boot probe a no-op (the query is `enabled: !!getAccessToken()`)
+// so the operator lands cleanly on /admin/users/<targetUserId>. Nothing of
+// value is lost: startImpersonation already overwrote any prior tenant
+// session with the imp token at start, and the operator lives on the
+// back-office plane now.
 //
-// The token swap, the return-target capture, and `clearImpersonationReturn`
-// all happen here, inside the mutationFn — so they are atomic with respect
-// to React Query's call-site `onSuccess` callbacks (which are skipped if the
+// The token swap, the return-target capture, and the tenant teardown all
+// happen here, inside the mutationFn — so they are atomic with respect to
+// React Query's call-site `onSuccess` callbacks (which are skipped if the
 // caller component unmounts before the mutation settles). A missed callback
 // can therefore never leave the admin live under the wrong identity or
 // orphan the return-slot.
@@ -519,9 +526,9 @@ export async function endImpersonation(): Promise<EndImpersonationResult> {
   // BackofficeLoginResponse has no `csrf_token` field on the wire; the BE
   // rotates CSRF via the X-CSRF-Token response header which the http
   // client picks up and persists to back-office storage automatically.
-  // Capture the return target, then clear the slot atomically with the
-  // token swap above — see the function comment.
+  // Capture the return target BEFORE tearing down the tenant session
+  // (clearAuth also clears the return slot) — see the function comment.
   const targetUserId = getImpersonationReturn()?.targetUserId ?? null
-  clearImpersonationReturn()
+  clearAuth()
   return { targetUserId }
 }

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -684,13 +684,15 @@ describe("impersonation auto-expiry (#1757)", () => {
     expect(endCalls).toBe(1)
     expect(refreshCalls).toBe(0)
     // The operator's restored BACK-OFFICE tokens land in back-office
-    // storage (Phase 5/6 #1785) — the expired impersonation token stays
-    // in tenant storage but is no longer used because the page is about
-    // to hard-redirect anyway. The return-slot was cleared and the
-    // browser hard-redirected back to the impersonated user's admin
-    // detail page.
+    // storage (Phase 5/6 #1785). The stale impersonation TENANT session is
+    // torn down (#1968): leaving the now-blacklisted imp token in tenant
+    // storage made the /admin/* page we redirect to boot the global tenant
+    // AuthProvider into a /auth/me 401 → tenant /login "session expired"
+    // bounce, hijacking the intended return to the admin panel. The
+    // return-slot is cleared and the browser hard-redirects to the
+    // impersonated user's admin detail page.
     expect(getBackofficeAccessToken()).toBe("admin-token")
-    expect(getAccessToken()).toBe("expired-impersonation-token")
+    expect(getAccessToken()).toBeNull()
     expect(getImpersonationReturn()).toBeNull()
     expect(redirect).toHaveBeenCalledWith("/admin/users/t1")
   })

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -13,6 +13,7 @@ import {
   clearBackofficeAuth,
   getBackofficeAccessToken,
   setBackofficeAccessToken,
+  setBackofficeCsrfToken,
 } from "@/features/backoffice/auth/storage"
 import { __resetGroupContextForTests, setCurrentGroupSlug } from "@/lib/group-context"
 import {
@@ -295,6 +296,83 @@ describe("auth + CSRF headers", () => {
     )
     await http.get("/auth/me", { authCheck: "user-initiated" })
     expect(header).toBe("user-initiated")
+  })
+})
+
+// #1968: the two impersonation self-service endpoints live under /admin/*
+// (so isBackofficePath would route them to the back-office token), but inside
+// an active impersonation session the live credential is the imp token parked
+// in TENANT storage. The BE reports active=true / accepts `end` ONLY for that
+// imp token — a back-office token is dispatched to the plain back-office
+// branch (active=false) or rejected (401). The http client therefore flips
+// these two paths to the tenant plane while a return slot is set.
+describe("impersonation credential plane (#1968)", () => {
+  it("GET /admin/impersonation/current uses the tenant imp token when a return slot is set", async () => {
+    // Both planes hold a token — the imp token (tenant) is the live identity,
+    // the operator's back-office token still sits in back-office storage.
+    setAccessToken("imp-token")
+    setBackofficeAccessToken("operator-token")
+    setImpersonationReturn({ targetUserId: "t1" })
+    let auth: string | null = null
+    server.use(
+      msw.get(api("/admin/impersonation/current"), ({ request }) => {
+        auth = request.headers.get("authorization")
+        return HttpResponse.json({ active: true })
+      })
+    )
+    await http.get("/admin/impersonation/current")
+    expect(auth).toBe("Bearer imp-token")
+  })
+
+  it("POST /admin/impersonation/end uses the tenant imp token + tenant CSRF when a return slot is set", async () => {
+    setAccessToken("imp-token")
+    setCsrfToken("tenant-csrf")
+    setBackofficeAccessToken("operator-token")
+    setBackofficeCsrfToken("operator-csrf")
+    setImpersonationReturn({ targetUserId: "t1" })
+    let auth: string | null = null
+    let csrf: string | null = null
+    server.use(
+      msw.post(api("/admin/impersonation/end"), ({ request }) => {
+        auth = request.headers.get("authorization")
+        csrf = request.headers.get("x-csrf-token")
+        return HttpResponse.json({ access_token: "back-to-operator" })
+      })
+    )
+    await http.post("/admin/impersonation/end", undefined, { skipAuthRefresh: true })
+    expect(auth).toBe("Bearer imp-token")
+    expect(csrf).toBe("tenant-csrf")
+  })
+
+  it("GET /admin/impersonation/current uses the back-office token when NO return slot is set (operator browsing admin)", async () => {
+    // No impersonation session — an operator probing from the admin shell.
+    setBackofficeAccessToken("operator-token")
+    let auth: string | null = null
+    server.use(
+      msw.get(api("/admin/impersonation/current"), ({ request }) => {
+        auth = request.headers.get("authorization")
+        return HttpResponse.json({ active: false })
+      })
+    )
+    await http.get("/admin/impersonation/current")
+    expect(auth).toBe("Bearer operator-token")
+  })
+
+  it("other /admin/* paths still use the back-office token even during an impersonation session", async () => {
+    // The slot-based override is scoped to the two impersonation endpoints —
+    // any other /admin/* request stays on the back-office plane.
+    setAccessToken("imp-token")
+    setBackofficeAccessToken("operator-token")
+    setImpersonationReturn({ targetUserId: "t1" })
+    let auth: string | null = null
+    server.use(
+      msw.get(api("/admin/tenants"), ({ request }) => {
+        auth = request.headers.get("authorization")
+        return HttpResponse.json({ data: [], meta: {} })
+      })
+    )
+    await http.get("/admin/tenants")
+    expect(auth).toBe("Bearer operator-token")
   })
 })
 

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -173,6 +173,38 @@ let impersonationEndInFlight: Promise<void> | null = null
 // recognise (and skip recovery for) the `end` call itself.
 const IMPERSONATION_END_PATH = "/admin/impersonation/end"
 
+// The /admin/impersonation/current probe — paired with the `end` path below
+// as the two impersonation self-service endpoints (see usesImpersonationCredential).
+const IMPERSONATION_CURRENT_PATH = "/admin/impersonation/current"
+
+// usesImpersonationCredential reports whether a request must be credentialed
+// from the TENANT plane (the impersonation access token) rather than the
+// back-office plane, despite living under /admin/* (which isBackofficePath
+// otherwise routes to the back-office token).
+//
+// The two impersonation self-service endpoints are reachable from INSIDE an
+// impersonated tenant session, where the live credential is the imp token (a
+// tenant JWT carrying `imp=true`) that startImpersonation parked in tenant
+// storage — NOT the operator's back-office token, which also still sits in
+// back-office storage. The BE keys BOTH endpoints off that `imp=true` claim:
+//   - GET  /admin/impersonation/current reports active=true ONLY for the imp
+//     token; RequireBackofficeAuthOrImpersonating dispatches a back-office
+//     token to its own branch, where currentImpersonation returns active=false
+//     (so the banner would never render — the #1968 bug),
+//   - POST /admin/impersonation/end self-validates the imp token off the
+//     Authorization header and 401s a back-office token outright.
+// So while a session is active these must carry the tenant token + tenant
+// CSRF. The persisted return slot is the "session active" signal — the same
+// one handle401 uses to route impersonation auto-expiry recovery, and the
+// same credential pair (tenant access + tenant CSRF) recoverFromImpersonationExpiry
+// sends on its manual `end` fetch.
+function usesImpersonationCredential(path: string): boolean {
+  return (
+    (path === IMPERSONATION_CURRENT_PATH || path === IMPERSONATION_END_PATH) &&
+    getImpersonationReturn() !== null
+  )
+}
+
 function applyGroupRewrite(path: string): string {
   const slug = getCurrentGroupSlug()
   if (!slug) {
@@ -218,7 +250,12 @@ function buildHeaders(method: HttpMethod, path: string, init: HttpRequestInit): 
     // arrives at the BE empty.
     headers.set("Content-Type", "application/vnd.api+json")
   }
-  const backoffice = isBackofficePath(path)
+  // While an impersonation session is active the two impersonation
+  // self-service endpoints are credentialed from the tenant plane (the imp
+  // token), not the back-office plane — see usesImpersonationCredential. This
+  // flips both the Authorization bearer and the CSRF token below to the
+  // tenant pair for those requests.
+  const backoffice = isBackofficePath(path) && !usesImpersonationCredential(path)
   const accessToken = backoffice ? getBackofficeAccessToken() : getAccessToken()
   if (accessToken) {
     headers.set("Authorization", `Bearer ${accessToken}`)

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -14,7 +14,6 @@
 // refresh endpoint without callers having to think about it.
 import {
   clearAuth,
-  clearImpersonationReturn,
   getAccessToken,
   getCsrfToken,
   getImpersonationReturn,
@@ -413,11 +412,14 @@ interface ImpersonationEndResponse {
 // now a BackofficeLoginResponse: a fresh BACK-OFFICE access token + the
 // rotated CSRF in the X-CSRF-Token header. We write through the
 // back-office storage keys (not the tenant ones) so the next /admin/*
-// request lands with the right credentials. The stale impersonation
-// token in tenant storage is left in place; the next tenant request
-// either gets re-issued through the tenant refresh path or 401s into a
-// /login redirect — neither matters here, because the page is about to
-// hard-redirect anyway.
+// request lands with the right credentials. We then clear the stale
+// impersonated TENANT session (clearAuth, in the success branch below):
+// the /admin/* page we hard-redirect to still boots the GLOBAL tenant
+// AuthProvider, which would probe /auth/me with the now-blacklisted imp
+// token — a user-initiated 401 that turns into a tenant /login "session
+// expired" bounce, hijacking the intended return to the admin panel
+// (#1968). Clearing it makes that boot probe a no-op so the operator lands
+// on /admin/users/<target>.
 //
 // On failure the operator session is unrecoverable, so we clear BOTH
 // planes and bounce to /backoffice/login. Either way this throws — the
@@ -484,10 +486,11 @@ async function recoverFromImpersonationExpiry(url: string): Promise<never> {
       setBackofficeAccessToken(payload.access_token)
       const newCsrf = response.headers.get("X-CSRF-Token") ?? response.headers.get("x-csrf-token")
       if (newCsrf) setBackofficeCsrfToken(newCsrf)
-      // Read the return target BEFORE clearing the slot. With no stored
-      // target, fall back to the admin landing route.
+      // Read the return target BEFORE tearing down the tenant session
+      // (clearAuth also clears the return slot). With no stored target,
+      // fall back to the admin landing route.
       const targetUserId = getImpersonationReturn()?.targetUserId
-      clearImpersonationReturn()
+      clearAuth()
       hardRedirect(
         targetUserId ? `/admin/users/${encodeURIComponent(targetUserId)}` : "/admin/tenants"
       )


### PR DESCRIPTION
Fixes #1968.

## Root cause (commit 1)

The banner code, the `current` probe, and the `end` exit are all already wired (#1752 / #1757 / #1785). The bug was a plane-routing slip in the http client, introduced when **#1785 Phase 6** made `lib/http` route every `/admin/*` request to the **back-office** auth plane (Authorization + CSRF read from back-office storage).

The two impersonation self-service endpoints are reachable from **inside an impersonated tenant session**, where the live credential is the **impersonation access token** — a tenant JWT carrying `imp=true` that `startImpersonation` parks in **tenant** storage via `setAccessToken`. The operator's back-office token also still sits in back-office storage, so during a session both tokens coexist. The BE keys both endpoints off the `imp=true` claim:

- **`GET /admin/impersonation/current`** — `RequireBackofficeAuthOrImpersonating` dispatches a `aud=backoffice` token to the plain back-office branch, where `currentImpersonation` returns `active:false` (`claimsAreImpersonation` is false for a back-office token). The probe was sending the operator's back-office token → always `active:false` → **banner never rendered** (the reported bug).
- **`POST /admin/impersonation/end`** — mounted bare, self-validates the imp token off the `Authorization` header and **401s** a back-office token outright.

**Fix:** in `buildHeaders`, when an impersonation **return slot** is set, credential `/admin/impersonation/current` and `/end` from the **tenant plane** (imp token + tenant CSRF) instead of the back-office plane — the same credential pair `recoverFromImpersonationExpiry` already uses on its manual `end` fetch. Scoped to those two endpoints only; every other `/admin/*` request stays on the back-office plane, and with no active session (operator browsing admin) the probe still uses the back-office token.

## Post-End landing (commit 2)

Found while running a live end-to-end verification of commit 1: with the banner finally rendering, clicking **End impersonation** (POST 200, operator restored server-side) bounced the operator to the **tenant `/login`** "session expired" screen instead of the admin panel.

Cause: `end`/recovery write the operator's restored credentials to back-office storage but deliberately left the now-blacklisted imp token in **tenant** storage ("no longer used, the page is about to hard-redirect anyway"). That assumption was wrong — the `/admin/*` page we redirect to still mounts the **global tenant `AuthProvider`**, whose boot probe is `enabled: !!getAccessToken()` and calls `GET /auth/me` with `authCheck: "user-initiated"`. The stale token 401s → tenant `/auth/refresh` (no tenant refresh cookie exists for an impersonation session) → fails → bounce to tenant `/login`, hijacking the intended return to the admin panel that #1968 asks for.

**Fix:** on a successful end — both `endImpersonation` and the `recoverFromImpersonationExpiry` auto-expiry path — clear the tenant session via `clearAuth()` instead of only clearing the return slot. With no tenant token the boot probe is a no-op, so the operator lands cleanly on `/admin/users/<target>`. Nothing of value is lost: `startImpersonation` already overwrote any prior tenant session with the imp token at start, and the operator now lives purely on the back-office plane.

No backend change — the BE already behaves correctly (`TestImpersonateCurrent_AcceptsBothBackofficeAndImpersonatingTenant` proves `current` returns `active:true` for the imp token, `false` for the back-office one).

## Why CI didn't catch it

- The banner **unit** tests mock the `/admin/impersonation/current` *response* via MSW, so they never asserted *which token* was sent.
- The **e2e** integration guard (`impersonation: start, banner, navigate, end` in `e2e/tests/admin/system-admin.spec.ts`) is in a `.skip`'d describe — it was written for the pre-#1785 tenant-plane model and the back-office-plane rewrite is tracked as a #1785 follow-up. So the one test that would have caught this isn't running.

This PR adds the missing unit-level guards in `http.test.ts` (correct token + CSRF for `current`/`end` with a slot set; back-office token otherwise; other `/admin/*` unaffected; the auto-expiry path now clears the tenant token) and `ImpersonationBanner.test.tsx` (End tears down the tenant session). Un-skipping the e2e remains the #1785 follow-up.

## Verification

Frontend gates all green in the worktree: `typecheck`, `lint`, `format:check`, `i18n:check`, `vitest` (**1274/1274**).

Drove the full flow against a postgres-backed `with_frontend` build of this branch (back-office operator bootstrapped, MFA off):
**back-office login → `/admin/users/{id}` → Impersonate (confirm) → hard-redirect to `/` → banner renders (*"Impersonating Test Administrator · admin@test-org.com · Session ends in 29:58"* + End button) → banner persists across navigation → End → restored back-office admin user-detail page.** Observed `GET /admin/impersonation/current` → 200, `POST …/impersonate` → 200, `POST …/end` → 200.