### PR TITLE
Fix master sync: demo-redis must not pin Recreate (invalid manifest regression from #2003)

### DIFF
--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -517,20 +517,3 @@ Usage (caller passes a dict so the helper knows which store's persistence to che
 checksum/recreate-on-deploy: {{ $imageTag | quote }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-demoRecreateStrategy — Deployment .spec.strategy for an emptyDir demo datastore.
-
-When recreateOnDeploy is on we WANT `Recreate`: a RollingUpdate would briefly run
-the old (data-bearing) pod alongside the new empty one, and the Service could route
-to the stale pod mid-roll. `Recreate` tears the old pod down first, so the wipe is
-clean. Postgres/MinIO already pin `Recreate` unconditionally (single-writer
-emptyDir); this helper exists so Redis (no strategy block) also flips to Recreate
-when it is being roll-wiped, and to keep the intent self-documenting.
-*/}}
-{{- define "inventario.demoRecreateStrategy" -}}
-{{- if .Values.demo.recreateOnDeploy -}}
-strategy:
-  type: Recreate
-{{- end -}}
-{{- end -}}

--- a/helm/inventario/templates/demo/redis-deployment.yaml
+++ b/helm/inventario/templates/demo/redis-deployment.yaml
@@ -11,12 +11,19 @@ spec:
   {{- /*
     recreateOnDeploy (master only): demo Redis is ALWAYS emptyDir (--save "",
     --appendonly no — there is no demo.redis.persistence option), so the
-    image-tag-keyed annotation below recreates the pod every master merge and
-    its strategy flips to Recreate to avoid a two-pod overlap during the roll.
-    Redis carries only ephemeral rate-limit / blacklist / CSRF state, so wiping
-    it on master is harmless; the helper is a no-op unless recreateOnDeploy=true.
+    image-tag-keyed annotation on the pod template below recreates the pod every
+    master merge, wiping it. Redis holds only ephemeral rate-limit / blacklist /
+    CSRF state, so a brief two-pod overlap during the roll (and the wipe itself)
+    is harmless — it keeps the default RollingUpdate strategy.
+
+    It deliberately does NOT pin `type: Recreate`: this Deployment originally
+    shipped with no `spec.strategy`, so the live object carries K8s's defaulted
+    `rollingUpdate`. Switching such an object to `type: Recreate` leaves that
+    defaulted `rollingUpdate` behind, which the API rejects ("may not be
+    specified when strategy type is 'Recreate'") and fails every master sync.
+    Postgres/MinIO can pin Recreate only because they shipped that way from the
+    start (no defaulted rollingUpdate to collide with).
   */}}
-  {{- include "inventario.demoRecreateStrategy" . | nindent 2 }}
   selector:
     matchLabels:
       {{- include "inventario.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Problem

`inv-vcl01-master` sync fails on every run (Healthy pods, but `OutOfSync` / op `Failed`):

```
Deployment "inv-vcl01-master-inventario-demo-redis" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
(retried 10 times).
```

Regression from #2003 (`demo.recreateOnDeploy`).

**Root cause:** the demo-redis Deployment originally shipped with **no `spec.strategy`**, so the live object carries Kubernetes' **defaulted `rollingUpdate`** block. #2003 added `strategy: type: Recreate` to redis (via the `demoRecreateStrategy` helper). Applying `type: Recreate` over an object that still has the defaulted `rollingUpdate` produces an **invalid** object — the API rejects it, so the whole master sync fails and retries forever. (It's also why demo-redis hadn't rolled in 8 days while demo-postgres/minio rolled fine: those two pinned `Recreate` *from the start*, so they never made the RollingUpdate→Recreate transition that leaves the stale `rollingUpdate` behind.)

## Fix

Don't pin `Recreate` on redis. It keeps the default **RollingUpdate** strategy and is **still wiped every master merge** by the image-tag-keyed `checksum/recreate-on-deploy` pod annotation (unchanged). A brief two-pod overlap during redis's roll is harmless — it holds only ephemeral rate-limit / blacklist / CSRF state. Removed the now-unused `demoRecreateStrategy` helper.

Postgres/MinIO are untouched: their unconditional `type: Recreate` is valid because they never carried a defaulted `rollingUpdate`.

## Validation
- `helm template` (`recreateOnDeploy=true`): demo-redis has **no** strategy block but keeps the recreate annotation; demo-postgres/minio keep `type: Recreate`. `helm lint` clean. No dangling reference to the removed helper.

Master is GitOps-managed via the `master-pin`, so **merging restores master sync automatically** — once the new master image builds and the pin flips, ArgoCD applies the corrected (valid) redis manifest and master goes `Synced/Healthy`. No manual cluster step (unlike the cluster-extras watchdog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Helm chart documentation regarding pod recreation and deployment strategy behavior during updates.

* **Chores**
  * Refined Helm template conditional logic for demo environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->