### PR TITLE
feat(ai-vision): accept PDFs for scan; Back on Basics returns to AI step

### DIFF
--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -3,10 +3,11 @@
 The Add-Item dialog can prefill the form from one or more product photos **or
 PDF documents** (a receipt, invoice, or manual): the user uploads the sources,
 the backend asks a vision model to extract structured fields (name, short name, type, price,
-currency, serial number, URLs, purchase date, warranty expiry date, comments), and the user
-reviews/accepts per-field before saving. When a receipt/invoice PDF is supplied
-the model is prompted to read the price, currency, and purchase date and to put
-the seller/vendor name into `comments` (there is no dedicated seller field).
+currency, serial number, URLs, purchase date, warranty expiry date, comments, tags), and the
+user reviews/accepts per-field before saving. A multi-product receipt/invoice returns one such
+field set per product (`items`), and the dialog lets the user pick which to add. When a
+receipt/invoice is supplied the model reads the price, currency, and purchase date and puts the
+seller/vendor name into `comments` (there is no dedicated seller field).
 
 Tracked under #1720 (feature), #1976 (deploy/config wiring), and #1983 Part B
 (accept PDFs as a prefill source — `application/pdf` joins the MIME allowlist and

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -66,7 +66,7 @@ All settings read from the `run` config section, i.e. the env var name is the
 | `AI_VISION_OPENAI_API_KEY` | `""` | Required when provider=`openai` |
 | `AI_VISION_OPENAI_MODEL` | `gpt-4o` | |
 | `AI_VISION_OPENAI_BASE_URL` | `""` | Empty = public `api.openai.com` |
-| `AI_VISION_TIMEOUT` | `20s` | Per-call upstream deadline |
+| `AI_VISION_TIMEOUT` | `60s` | Per-call upstream deadline. A PDF + multi-product invoice extraction can take 20–45s; the provider HTTP client cap sits above this (90s). |
 | `AI_VISION_MAX_PHOTOS` | `5` | Per scan request |
 | `AI_VISION_MAX_PHOTO_BYTES` | `10485760` | 10 MiB per photo |
 | `AI_VISION_RATE_LIMIT_PER_HOUR` | `30` | Per-user; `0` disables |

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -1,11 +1,16 @@
 # AI vision photo-scan
 
-The Add-Item dialog can prefill the form from one or more product photos: the
-user uploads photos, the backend asks a vision model to extract structured
-fields (name, type, price, currency, serial number, URLs, purchase date,
-comments), and the user reviews/accepts per-field before saving.
+The Add-Item dialog can prefill the form from one or more product photos **or
+PDF documents** (a receipt, invoice, or manual): the user uploads the sources,
+the backend asks a vision model to extract structured fields (name, type, price,
+currency, serial number, URLs, purchase date, comments), and the user
+reviews/accepts per-field before saving. When a receipt/invoice PDF is supplied
+the model is prompted to read the price, currency, and purchase date and to put
+the seller/vendor name into `comments` (there is no dedicated seller field).
 
-Tracked under #1720 (feature) and #1976 (deploy/config wiring).
+Tracked under #1720 (feature), #1976 (deploy/config wiring), and #1983 Part B
+(accept PDFs as a prefill source — `application/pdf` joins the MIME allowlist and
+each provider sends a PDF as a document/file content block instead of an image).
 
 This doc is the operator + developer guide for **turning the feature on**. The
 application code (backend + frontend) already ships; only configuration selects

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -2,8 +2,8 @@
 
 The Add-Item dialog can prefill the form from one or more product photos **or
 PDF documents** (a receipt, invoice, or manual): the user uploads the sources,
-the backend asks a vision model to extract structured fields (name, type, price,
-currency, serial number, URLs, purchase date, comments), and the user
+the backend asks a vision model to extract structured fields (name, short name, type, price,
+currency, serial number, URLs, purchase date, warranty expiry date, comments), and the user
 reviews/accepts per-field before saving. When a receipt/invoice PDF is supplied
 the model is prompted to read the price, currency, and purchase date and to put
 the seller/vendor name into `comments` (there is no dedicated seller field).

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -69,6 +69,7 @@ All settings read from the `run` config section, i.e. the env var name is the
 | `AI_VISION_MAX_PHOTOS` | `5` | Per scan request |
 | `AI_VISION_MAX_PHOTO_BYTES` | `10485760` | 10 MiB per photo |
 | `AI_VISION_RATE_LIMIT_PER_HOUR` | `30` | Per-user; `0` disables |
+| `AI_VISION_MAX_TOKENS` | `4096` | Cap on the model's structured output. Must hold a multi-line invoice (each product ≈10 fields); too low truncates the JSON and a multi-product scan returns empty/partial. `0` = provider default (4096). |
 | `PUBLIC_AI_VISION_SCAN_ENABLED` | `false` | **Opt-in.** Enable the unauthenticated `POST /public/commodities/scan` endpoint (#1988). No effect unless a real provider is also configured. |
 
 > ⚠️ **The public endpoint has no auth wall.** Every anonymous call spends

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -68,6 +68,11 @@ const ACCEPTED_EXT = /\.(jpe?g|png|webp|heic|heif|pdf)$/i
 // Hard cap (mirrors BE) — additional rejections fire from the BE side.
 const MAX_PHOTOS = 5
 
+// Mirrors the commodity form's short_name limit (schemas.ts + the Go model's
+// validation.Length(1, 40)). An AI-guessed short_name longer than this is
+// truncated on accept so it never trips the Basics-step validator.
+const SHORT_NAME_MAX_LEN = 40
+
 // isPdfFile reports whether a staged file is a PDF document rather than an
 // image. PDFs can't be rendered as an <img> thumbnail, so the staged tile
 // shows a document icon + filename instead. The MIME check is primary; the
@@ -108,6 +113,7 @@ export interface ScanAcceptedValues {
   serial_number?: string
   urls?: string[]
   purchase_date?: string
+  warranty_expires_at?: string
   comments?: string
 }
 
@@ -323,11 +329,20 @@ export function AiScanStep({
       const value = guess.value
       switch (key) {
         case "name":
-        case "short_name":
         case "serial_number":
         case "comments":
         case "purchase_date":
+        case "warranty_expires_at":
           if (typeof value === "string" && value.trim() !== "") out[key] = value
+          break
+        case "short_name":
+          if (typeof value === "string" && value.trim() !== "") {
+            // Cap at the form's 40-char limit (SHORT_NAME_MAX_LEN) so an
+            // over-long AI guess pre-fills truncated instead of failing
+            // validation on the Basics step. The prompt already steers the
+            // model to ≤40; this is the defensive backstop.
+            out.short_name = value.trim().slice(0, SHORT_NAME_MAX_LEN)
+          }
           break
         case "type":
           if (typeof value === "string" && isKnownType(value)) {
@@ -743,6 +758,7 @@ function ReviewPanel({
     "type",
     "serial_number",
     "purchase_date",
+    "warranty_expires_at",
     "original_price",
     "original_price_currency",
     "urls",
@@ -770,7 +786,7 @@ function ReviewPanel({
           <AlertDescription>
             {warningsByField.global.map((w, i) => (
               <p key={i} className="text-xs">
-                {w.detail ?? w.code}
+                {warningMessage(w, t)}
               </p>
             ))}
           </AlertDescription>
@@ -943,6 +959,8 @@ function fieldLabelKey(field: ScanFieldName): string {
       return "originalPriceHelp"
     case "urls":
       return "urls"
+    case "warranty_expires_at":
+      return "warrantyExpiresAt"
     case "comments":
       return "comments"
   }
@@ -976,9 +994,23 @@ function warningTitle(code: string, t: (k: string) => string): string {
       return t("commodities:form.step.ai.review.warning.ambiguousPrice")
     case "currency_inferred":
       return t("commodities:form.step.ai.review.warning.currencyInferred")
+    case "multiple_items":
+      return t("commodities:form.step.ai.review.warning.multipleItems")
     default:
       return code
   }
+}
+
+// warningMessage renders a global (field-less) warning. Known codes get a
+// localized message; everything else falls back to the provider's English
+// detail (or the bare code). `multiple_items` (#1983) is the one the user
+// most needs to read — the document had several products and only the most
+// prominent one was pre-filled.
+function warningMessage(w: ScanWarning, t: (k: string) => string): string {
+  if (w.code === "multiple_items") {
+    return t("commodities:form.step.ai.review.warning.multipleItems")
+  }
+  return w.detail ?? w.code
 }
 
 function errorCodeTitle(code: string | null, t: (k: string) => string): string | null {

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -720,8 +720,16 @@ function ScanningPanel({ onCancel }: { onCancel: () => void }) {
           {t("commodities:form.step.ai.scanning.subtitle")}
         </p>
       </div>
-      <div className="h-1.5 w-full max-w-48 overflow-hidden rounded-full bg-muted">
-        <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-500" />
+      <div
+        className="h-1.5 w-full max-w-48 overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-label={t("commodities:form.step.ai.scanning.title")}
+        data-testid="commodity-form-ai-scanning-bar"
+      >
+        {/* Indeterminate: a partial bar slides across the track (the scan
+            duration is unknown), so the user sees work is ongoing rather
+            than a static fill stuck partway. */}
+        <div className="ai-scan-bar h-full w-2/5 rounded-full bg-amber-500" />
       </div>
       <Button
         type="button"

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -15,7 +15,16 @@
 // note line is removed (the feature ships now).
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { AlertCircle, Camera, CheckCircle2, Plus, ScanText, Sparkles, X } from "lucide-react"
+import {
+  AlertCircle,
+  Camera,
+  CheckCircle2,
+  FileText,
+  Plus,
+  ScanText,
+  Sparkles,
+  X,
+} from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -38,10 +47,12 @@ import type {
   ScanWarning,
 } from "@/features/commodities/scanApi"
 
-// Mirrors `media.go` MIME allow-list on the BE. The `<input accept>`
+// Mirrors `services.AllowedMIMETypes` on the BE. The `<input accept>`
 // attribute is a hint the browser may honour loosely (HEIC files on
 // Android Chrome come back with empty MIME types), so we re-check at
-// staging time and reject anything unrecognised inline.
+// staging time and reject anything unrecognised inline. `application/pdf`
+// (#1983) lets the user prefill from a receipt / invoice / manual, not
+// just a product photo.
 const ACCEPTED_MIME = new Set([
   "image/jpeg",
   "image/jpg",
@@ -49,14 +60,25 @@ const ACCEPTED_MIME = new Set([
   "image/webp",
   "image/heic",
   "image/heif",
+  "application/pdf",
 ])
-const ACCEPTED_EXT = /\.(jpe?g|png|webp|heic|heif)$/i
+const ACCEPTED_EXT = /\.(jpe?g|png|webp|heic|heif|pdf)$/i
 // Hard cap (mirrors BE) — additional rejections fire from the BE side.
 const MAX_PHOTOS = 5
+
+// isPdfFile reports whether a staged file is a PDF document rather than an
+// image. PDFs can't be rendered as an <img> thumbnail, so the staged tile
+// shows a document icon + filename instead. The MIME check is primary; the
+// extension fallback covers browsers that hand back an empty `type`.
+function isPdfFile(file: File): boolean {
+  return file.type.toLowerCase() === "application/pdf" || /\.pdf$/i.test(file.name)
+}
 
 interface StagedPhoto {
   id: string
   file: File
+  // Object-URL preview for image thumbnails. Empty for PDFs — they render
+  // as a document tile, so no bitmap URL is created (and nothing to revoke).
   preview: string
 }
 
@@ -199,7 +221,9 @@ export function AiScanStep({
               ? crypto.randomUUID()
               : `${file.name}-${file.size}-${file.lastModified}-${Math.random()}`,
           file,
-          preview: URL.createObjectURL(file),
+          // No object URL for PDFs — they render as a document tile, not
+          // an <img>, so there's no bitmap to create or revoke.
+          preview: isPdfFile(file) ? "" : URL.createObjectURL(file),
         })
       }
       setPhotos((prev) => {
@@ -509,11 +533,24 @@ function OfferPanel({
             <div className="flex flex-wrap justify-center gap-2 px-3">
               {photos.map((p) => (
                 <div key={p.id} className="group relative" data-testid="commodity-form-ai-thumb">
-                  <img
-                    src={p.preview}
-                    alt={p.file.name}
-                    className="size-14 rounded-lg border border-border object-cover"
-                  />
+                  {isPdfFile(p.file) ? (
+                    <div
+                      className="flex size-14 flex-col items-center justify-center gap-0.5 rounded-lg border border-border bg-muted/40 px-1"
+                      title={p.file.name}
+                      data-testid="commodity-form-ai-thumb-pdf"
+                    >
+                      <FileText aria-hidden="true" className="size-5 text-muted-foreground" />
+                      <span className="w-full truncate text-center text-[8px] leading-tight text-muted-foreground">
+                        {p.file.name}
+                      </span>
+                    </div>
+                  ) : (
+                    <img
+                      src={p.preview}
+                      alt={p.file.name}
+                      className="size-14 rounded-lg border border-border object-cover"
+                    />
+                  )}
                   <button
                     type="button"
                     aria-label={t("commodities:form.step.ai.offer.staged.remove")}
@@ -560,7 +597,7 @@ function OfferPanel({
             id="ai-photo-input"
             type="file"
             multiple
-            accept="image/jpeg,image/jpg,image/png,image/webp,image/heic,image/heif"
+            accept="image/jpeg,image/jpg,image/png,image/webp,image/heic,image/heif,application/pdf,.pdf"
             className="sr-only"
             data-testid="commodity-form-ai-file-input"
             onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -14,6 +14,7 @@
 // header + grid pattern is preserved; the design deviation tracker
 // note line is removed (the feature ships now).
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import {
   AlertCircle,
@@ -37,6 +38,7 @@ import {
   getServerErrorCode,
   type ClassifiedServerError,
 } from "@/lib/server-error"
+import { http } from "@/lib/http"
 import { cn } from "@/lib/utils"
 import { COMMODITY_TYPES, type CommodityTypeValue } from "@/features/commodities/constants"
 import { useScanCommodityPhotos } from "@/features/commodities/scanHooks"
@@ -160,19 +162,30 @@ export function AiScanStep({
 
   const scan = useScanCommodityPhotos(slug, anonymous)
 
-  // Known-currency set is intentionally narrow: just the tenant's
-  // default currency. We deliberately do NOT fetch the full
-  // /currencies list from inside the AI step — adding a network query
-  // to the AI-step mount path makes every unrelated wizard test that
-  // walks past this step trip the global MSW "unhandled request"
-  // guard, and the actual product value of a wider validator here is
-  // small (the CurrencyCombobox on the Basics step is the
-  // authoritative picker; if the AI guessed a non-default ISO the
-  // worst case is the picker stays on the default and the user picks
-  // again). When that needs to change, fetch via a lazy mutation
-  // gated on `photos.length > 0` so the query never fires until the
-  // user actually engages the AI flow.
-  const knownCurrencies = useMemo(() => [defaultCurrency], [defaultCurrency])
+  // Validate a model-guessed currency against the server's REAL supported
+  // list (the same `/currencies` endpoint + ["currencies"] cache key the
+  // CurrencyCombobox uses), not just the tenant default. The old behaviour
+  // accepted a guess only when it equalled the default and dropped every
+  // other valid ISO — so scanning a CZK invoice under a USD/EUR group
+  // showed "not on the supported list" even though CZK is fully supported.
+  //
+  // The query is LAZY (`enabled` only once a file is staged) so it never
+  // fires on the AI-step mount path — unrelated wizard tests that walk
+  // straight to "Fill manually" don't trip the MSW unhandled-request guard.
+  // It's skipped entirely in the anonymous landing flow, where there is no
+  // group/auth to resolve `/currencies` against; there (and while the query
+  // is still loading) we fall back to the tenant default so the set is never
+  // empty.
+  const currenciesQuery = useQuery<string[]>({
+    queryKey: ["currencies"],
+    queryFn: ({ signal }) => http.get<string[]>("/currencies", { signal }),
+    enabled: !anonymous && photos.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+  const knownCurrencies = useMemo(() => {
+    const supported = currenciesQuery.data
+    return supported && supported.length > 0 ? supported : [defaultCurrency]
+  }, [currenciesQuery.data, defaultCurrency])
 
   // Revoke object-URLs on unmount. We stash the live list of previews
   // in a ref so the cleanup only fires once at unmount — a `[photos]`

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -290,6 +290,13 @@ export function AiScanStep({
         photos: photos.map((p) => p.file),
         signal: ac.signal,
       })
+      // Nothing usable came back (an unreadable document, or a model
+      // truncation). Don't drop the user into a green-but-empty "review" —
+      // keep them on the offer with a retry hint.
+      if (Object.keys(r.fields).length === 0 && r.items.length === 0) {
+        setStagingError(t("commodities:form.step.ai.errors.noDetails"))
+        return
+      }
       setResult(r)
       setSelectedItemFields(null)
       // More than one distinct product → the user chooses which to fill

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -21,6 +21,7 @@ import {
   Camera,
   CheckCircle2,
   FileText,
+  Layers,
   Plus,
   ScanText,
   Sparkles,
@@ -45,7 +46,9 @@ import { useScanCommodityPhotos } from "@/features/commodities/scanHooks"
 import type {
   ScanFieldGuess,
   ScanFieldName,
+  ScanItem,
   ScanResult,
+  ScanResultFields,
   ScanWarning,
 } from "@/features/commodities/scanApi"
 
@@ -161,6 +164,10 @@ export function AiScanStep({
   const [photos, setPhotos] = useState<StagedPhoto[]>([])
   const [stagingError, setStagingError] = useState<string | null>(null)
   const [result, setResult] = useState<ScanResult | null>(null)
+  // When the scan returns more than one candidate product, the user picks
+  // one in the "choose" phase; its fields land here and drive the review.
+  // Null = single-item scan (review reads result.fields) or not yet chosen.
+  const [selectedItemFields, setSelectedItemFields] = useState<ScanResultFields | null>(null)
   const [acceptedFields, setAcceptedFields] = useState<Set<ScanFieldName>>(new Set())
   const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
   const [errorCode, setErrorCode] = useState<string | null>(null)
@@ -289,16 +296,15 @@ export function AiScanStep({
         signal: ac.signal,
       })
       setResult(r)
-      // Default-accept every field with confidence ≥ 0.3 (the
-      // low-confidence threshold for the chip styling — anything below
-      // is the model essentially guessing). Users can re-check
-      // individually in the review phase before applying.
-      const defaults = new Set<ScanFieldName>()
-      for (const key of Object.keys(r.fields) as ScanFieldName[]) {
-        const guess = r.fields[key]
-        if (guess && guess.confidence >= 0.3) defaults.add(key)
+      setSelectedItemFields(null)
+      // More than one distinct product → the user chooses which to fill
+      // first (no default-accept until they pick). A single product →
+      // straight to review with confident fields pre-checked.
+      if (r.items.length > 1) {
+        setAcceptedFields(new Set())
+      } else {
+        setAcceptedFields(defaultAcceptedFor(r.fields))
       }
-      setAcceptedFields(defaults)
     } catch (err) {
       // AbortError fires when the user clicks Cancel — silently roll
       // back to the offer phase instead of rendering a scary banner.
@@ -318,13 +324,27 @@ export function AiScanStep({
     scan.reset()
   }
 
+  // chooseItem promotes one candidate (from a multi-product scan) into the
+  // review phase: its fields become the active set and the confident ones
+  // are pre-checked.
+  function chooseItem(index: number) {
+    if (!result) return
+    const item = result.items[index]
+    if (!item) return
+    setSelectedItemFields(item.fields)
+    setAcceptedFields(defaultAcceptedFor(item.fields))
+  }
+
   function applyAccepted() {
     if (!result) return
+    // The active item: the user's pick from a multi-product scan, or the
+    // single primary result otherwise.
+    const fields = selectedItemFields ?? result.fields
     const out: ScanAcceptedValues = {}
     let droppedCurrency: string | null = null
-    for (const key of Object.keys(result.fields) as ScanFieldName[]) {
+    for (const key of Object.keys(fields) as ScanFieldName[]) {
       if (!acceptedFields.has(key)) continue
-      const guess = result.fields[key]
+      const guess = fields[key]
       if (!guess) continue
       const value = guess.value
       switch (key) {
@@ -387,12 +407,14 @@ export function AiScanStep({
     // (also relevant for the implicit revocation cleanup).
     clearPhotos()
     setResult(null)
+    setSelectedItemFields(null)
     setAcceptedFields(new Set())
   }
 
   function retakePhotos() {
     clearPhotos()
     setResult(null)
+    setSelectedItemFields(null)
     setAcceptedFields(new Set())
     setServerError(null)
     setErrorCode(null)
@@ -407,10 +429,15 @@ export function AiScanStep({
     })
   }
 
-  const phase: "offer" | "scanning" | "review" | "error" = (() => {
+  // A multi-product scan inserts a "choose" phase between scanning and
+  // review; a single-product scan (or once an item is chosen) goes straight
+  // to review, per the design.
+  const needsChoice = !!result && result.items.length > 1 && selectedItemFields === null
+  const phase: "offer" | "scanning" | "choose" | "review" | "error" = (() => {
     if (scan.isPending) return "scanning"
-    if (result) return "review"
     if (serverError) return "error"
+    if (needsChoice) return "choose"
+    if (result) return "review"
     return "offer"
   })()
 
@@ -422,9 +449,12 @@ export function AiScanStep({
     >
       {phase === "scanning" ? (
         <ScanningPanel onCancel={cancelScan} />
+      ) : phase === "choose" && result ? (
+        <ChoosePanel items={result.items} onChoose={chooseItem} onSkip={onSkip} />
       ) : phase === "review" && result ? (
         <ReviewPanel
-          result={result}
+          fields={selectedItemFields ?? result.fields}
+          warnings={result.warnings}
           acceptedFields={acceptedFields}
           onToggleField={toggleField}
           onAccept={applyAccepted}
@@ -712,10 +742,95 @@ function ScanningPanel({ onCancel }: { onCancel: () => void }) {
   )
 }
 
+// ---- Choose phase (multi-item) --------------------------------------
+
+interface ChoosePanelProps {
+  items: ScanItem[]
+  onChoose: (index: number) => void
+  onSkip: () => void
+}
+
+// ChoosePanel lists every candidate product the scan found so the user
+// picks which one to pre-fill (shown only when there's more than one — a
+// single item goes straight to review).
+function ChoosePanel({ items, onChoose, onSkip }: ChoosePanelProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col gap-3" data-testid="commodity-form-ai-choose">
+      <div className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5">
+        <Layers aria-hidden="true" className="size-4 shrink-0 text-primary" />
+        <p className="text-sm font-medium">{t("commodities:form.step.ai.choose.title")}</p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t("commodities:form.step.ai.choose.subtitle")}
+      </p>
+      <div className="flex flex-col gap-2">
+        {items.map((item, i) => {
+          const summary = chooseItemSummary(item)
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onChoose(i)}
+              data-testid={`commodity-form-ai-choose-item-${i}`}
+              className="flex flex-col items-start gap-0.5 rounded-lg border border-border bg-muted/20 px-3 py-2.5 text-left transition-colors hover:border-primary/40 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <p className="text-sm font-medium">
+                {chooseItemTitle(item) ??
+                  t("commodities:form.step.ai.choose.itemFallback", { index: i + 1 })}
+              </p>
+              {summary ? <p className="text-xs text-muted-foreground">{summary}</p> : null}
+            </button>
+          )
+        })}
+      </div>
+      <div className="flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onSkip}
+          data-testid="commodity-form-ai-fill-manually"
+        >
+          {t("commodities:form.fillManually")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// chooseItemTitle prefers the model's name, then short_name; null when
+// neither is present (the caller renders a numbered fallback).
+function chooseItemTitle(item: ScanItem): string | null {
+  const name = item.fields.name?.value
+  if (typeof name === "string" && name.trim() !== "") return name
+  const short = item.fields.short_name?.value
+  if (typeof short === "string" && short.trim() !== "") return short
+  return null
+}
+
+// chooseItemSummary builds a one-line "type · price · serial" summary so
+// the user can tell similar candidates apart. Empty when nothing useful.
+function chooseItemSummary(item: ScanItem): string {
+  const parts: string[] = []
+  const type = item.fields.type?.value
+  if (typeof type === "string" && type.trim() !== "") parts.push(type)
+  const price = item.fields.original_price?.value
+  if (typeof price === "number" && Number.isFinite(price)) {
+    const currency = item.fields.original_price_currency?.value
+    parts.push(typeof currency === "string" && currency ? `${price} ${currency}` : String(price))
+  }
+  const serial = item.fields.serial_number?.value
+  if (typeof serial === "string" && serial.trim() !== "") parts.push(serial)
+  return parts.join(" · ")
+}
+
 // ---- Review phase ---------------------------------------------------
 
 interface ReviewPanelProps {
-  result: ScanResult
+  // Active item's fields (the chosen candidate, or the single primary).
+  fields: ScanResultFields
+  warnings: ScanWarning[]
   acceptedFields: Set<ScanFieldName>
   onToggleField: (key: ScanFieldName, next: boolean) => void
   onAccept: () => void
@@ -725,7 +840,8 @@ interface ReviewPanelProps {
 }
 
 function ReviewPanel({
-  result,
+  fields,
+  warnings,
   acceptedFields,
   onToggleField,
   onAccept,
@@ -740,7 +856,7 @@ function ReviewPanel({
   const warningsByField = useMemo(() => {
     const map = new Map<string, ScanWarning[]>()
     const global: ScanWarning[] = []
-    for (const w of result.warnings) {
+    for (const w of warnings) {
       if (w.field) {
         const list = map.get(w.field) ?? []
         list.push(w)
@@ -750,7 +866,7 @@ function ReviewPanel({
       }
     }
     return { map, global }
-  }, [result.warnings])
+  }, [warnings])
 
   const fieldOrder: ScanFieldName[] = [
     "name",
@@ -795,9 +911,9 @@ function ReviewPanel({
 
       <div className="flex flex-col gap-2">
         {fieldOrder.map((key) => {
-          const guess = result.fields[key]
+          const guess = fields[key]
           if (!guess) return null
-          const warnings = warningsByField.map.get(key) ?? []
+          const rowWarnings = warningsByField.map.get(key) ?? []
           const currencyUnknown =
             key === "original_price_currency" &&
             typeof guess.value === "string" &&
@@ -809,7 +925,7 @@ function ReviewPanel({
               guess={guess}
               checked={acceptedFields.has(key)}
               onToggle={(next) => onToggleField(key, next)}
-              warnings={warnings}
+              warnings={rowWarnings}
               currencyUnknown={currencyUnknown}
             />
           )
@@ -1036,4 +1152,16 @@ function errorCodeTitle(code: string | null, t: (k: string) => string): string |
 
 function isKnownType(value: string): value is CommodityTypeValue {
   return (COMMODITY_TYPES as readonly string[]).includes(value)
+}
+
+// defaultAcceptedFor pre-checks every field the model is reasonably sure
+// about (confidence ≥ 0.3 — below that it's essentially guessing). Used
+// both for a single-item scan and after the user picks a candidate.
+function defaultAcceptedFor(fields: ScanResultFields): Set<ScanFieldName> {
+  const defaults = new Set<ScanFieldName>()
+  for (const key of Object.keys(fields) as ScanFieldName[]) {
+    const guess = fields[key]
+    if (guess && guess.confidence >= 0.3) defaults.add(key)
+  }
+  return defaults
 }

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -1,7 +1,7 @@
 // AI vision scan step for the Add Item dialog (#1720). Replaces the
 // inert offer-only stub with a four-phase state machine:
 //
-//   offer    → user drops/picks 1..5 photos, clicks "Scan photos"
+//   offer    → user drops/picks 1..5 photos or PDFs, clicks "Scan files"
 //   scanning → mutation in flight; user can Cancel via AbortController
 //   review   → per-field checkboxes + confidence chips + warnings;
 //              "Use these values" prefills the wizard and advances

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -33,7 +33,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ServerErrorBanner } from "@/components/ServerErrorBanner"
-import { currencyMeta } from "@/lib/currency-meta"
+import { currencyMeta, KNOWN_CURRENCY_CODES } from "@/lib/currency-meta"
 import {
   classifyServerError,
   getServerErrorCode,
@@ -175,30 +175,17 @@ export function AiScanStep({
 
   const scan = useScanCommodityPhotos(slug, anonymous)
 
-  // Validate a model-guessed currency against the server's REAL supported
-  // list (the same `/currencies` endpoint + ["currencies"] cache key the
-  // CurrencyCombobox uses), not just the tenant default. The old behaviour
-  // accepted a guess only when it equalled the default and dropped every
-  // other valid ISO — so scanning a CZK invoice under a USD/EUR group
-  // showed "not on the supported list" even though CZK is fully supported.
-  //
-  // The query is LAZY (`enabled` only once a file is staged) so it never
-  // fires on the AI-step mount path — unrelated wizard tests that walk
-  // straight to "Fill manually" don't trip the MSW unhandled-request guard.
-  // It's skipped entirely in the anonymous landing flow, where there is no
-  // group/auth to resolve `/currencies` against; there (and while the query
-  // is still loading) we fall back to the tenant default so the set is never
-  // empty.
+  // /currencies is a PUBLIC, group-agnostic endpoint returning the full ISO
+  // list; the lazy query extends the accepted set to long-tail codes once it
+  // loads (and works in the anonymous flow too — no auth/group needed).
+  // `enabled` gates it on a staged file so it never fires on the AI-step mount
+  // path (no MSW unhandled-request churn on the "Fill manually" walk-through).
   const currenciesQuery = useQuery<string[]>({
     queryKey: ["currencies"],
     queryFn: ({ signal }) => http.get<string[]>("/currencies", { signal }),
-    enabled: !anonymous && photos.length > 0,
+    enabled: photos.length > 0,
     staleTime: 5 * 60 * 1000,
   })
-  const knownCurrencies = useMemo(() => {
-    const supported = currenciesQuery.data
-    return supported && supported.length > 0 ? supported : [defaultCurrency]
-  }, [currenciesQuery.data, defaultCurrency])
 
   // Revoke object-URLs on unmount. We stash the live list of previews
   // in a ref so the cleanup only fires once at unmount — a `[photos]`
@@ -217,12 +204,19 @@ export function AiScanStep({
     }
   }, [])
 
-  // Compute which currencies the BE accepts as a lowercased set so
-  // the case-insensitive match below stays O(1).
-  const currencySet = useMemo(
-    () => new Set(knownCurrencies.map((c) => c.trim().toUpperCase())),
-    [knownCurrencies]
-  )
+  // The set of currency codes an AI guess may pre-fill (uppercased for O(1)
+  // case-insensitive match): the FE's curated KNOWN_CURRENCY_CODES (covers
+  // CZK + every common code, checked SYNCHRONOUSLY so a valid guess is never
+  // dropped while waiting on — or if we never get — the network) ∪ the tenant
+  // default ∪ the full ISO list from /currencies once it resolves.
+  const currencySet = useMemo(() => {
+    const set = new Set<string>(KNOWN_CURRENCY_CODES)
+    if (defaultCurrency.trim() !== "") set.add(defaultCurrency.trim().toUpperCase())
+    for (const c of currenciesQuery.data ?? []) {
+      if (typeof c === "string" && c.trim() !== "") set.add(c.trim().toUpperCase())
+    }
+    return set
+  }, [currenciesQuery.data, defaultCurrency])
 
   const handleFiles = useCallback(
     (files: File[]) => {

--- a/frontend/src/components/items/AiScanStep.tsx
+++ b/frontend/src/components/items/AiScanStep.tsx
@@ -118,6 +118,7 @@ export interface ScanAcceptedValues {
   purchase_date?: string
   warranty_expires_at?: string
   comments?: string
+  tags?: string[]
 }
 
 interface AiScanStepProps {
@@ -388,6 +389,22 @@ export function AiScanStep({
           if (Array.isArray(value)) {
             const cleaned = value.filter((u) => typeof u === "string" && u.trim() !== "")
             if (cleaned.length > 0) out.urls = cleaned
+          }
+          break
+        case "tags":
+          if (Array.isArray(value)) {
+            // Trim + drop empties + de-dupe case-insensitively so the form's
+            // tag chips stay clean.
+            const seen = new Set<string>()
+            const cleaned: string[] = []
+            for (const raw of value) {
+              if (typeof raw !== "string") continue
+              const tag = raw.trim()
+              if (tag === "" || seen.has(tag.toLowerCase())) continue
+              seen.add(tag.toLowerCase())
+              cleaned.push(tag)
+            }
+            if (cleaned.length > 0) out.tags = cleaned
           }
           break
       }
@@ -880,6 +897,7 @@ function ReviewPanel({
     "original_price",
     "original_price_currency",
     "urls",
+    "tags",
     "comments",
   ]
 
@@ -1081,6 +1099,8 @@ function fieldLabelKey(field: ScanFieldName): string {
       return "warrantyExpiresAt"
     case "comments":
       return "comments"
+    case "tags":
+      return "tags"
   }
 }
 

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -642,6 +642,7 @@ export function CommodityFormDialog({
       apply("urls", values.urls)
     }
     if (values.comments !== undefined) apply("comments", values.comments)
+    if (values.tags !== undefined) apply("tags", values.tags)
     setStep("basics")
   }
 

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -243,13 +243,10 @@ export function CommodityFormDialog({
   // would only 404, so we skip straight to manual entry.
   //
   // `aiStepAvailable` means "the AI scan surface is reachable in this
-  // dialog instance" — i.e. AI vision is enabled. It gates the Basics-step
-  // Back button, which rewinds to the scanner, in ANY mode: notably when
-  // you reopen a saved draft for editing you can still jump to AI scan to
-  // finish filling it (the previous create-only gate left Back dead there).
-  // Only the OPENING step stays create-only — edit mode opens on Basics
-  // (you don't want the scanner forced when a row already exists).
-  const aiStepAvailable = enableAiScan
+  // dialog instance" — i.e. create mode with AI vision enabled. It gates the
+  // Basics-step Back button, which rewinds to the scanner. Without the AI
+  // surface Basics is the first screen and Back is a no-op.
+  const aiStepAvailable = mode === "create" && enableAiScan
   const initialStep: StepKey = mode === "create" && enableAiScan ? "ai" : "basics"
   const [step, setStep] = useState<StepKey>(initialStep)
   // Tracks which form steps the user has already landed on, so the

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -943,7 +943,7 @@ export function CommodityFormDialog({
           // AI-step footer: only the Cancel/close affordance lives in
           // the dialog chrome. The four-phase state machine (offer /
           // scanning / review / error) owns its own primary actions
-          // inline — "Scan photos" / "Use these values" / "Re-take" /
+          // inline — "Scan files" / "Use these values" / "Start over" /
           // "Fill manually" / "Cancel scan" — so the footer stays
           // tight and never wrestles with phase-specific buttons.
           <DialogFooter className="gap-2">

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -623,6 +623,9 @@ export function CommodityFormDialog({
     if (values.type !== undefined) apply("type", values.type)
     if (values.serial_number !== undefined) apply("serial_number", values.serial_number)
     if (values.purchase_date !== undefined) apply("purchase_date", values.purchase_date)
+    if (values.warranty_expires_at !== undefined) {
+      apply("warranty_expires_at", values.warranty_expires_at)
+    }
     if (values.original_price !== undefined) apply("original_price", values.original_price)
     if (values.original_price_currency !== undefined) {
       apply("original_price_currency", values.original_price_currency)

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -243,10 +243,14 @@ export function CommodityFormDialog({
   // would only 404, so we skip straight to manual entry.
   //
   // `aiStepAvailable` means "the AI scan surface is reachable in this
-  // dialog instance" — i.e. create mode with AI vision enabled. It gates the
-  // Basics-step Back button, which rewinds to the scanner. Without the AI
-  // surface Basics is the first screen and Back is a no-op.
-  const aiStepAvailable = mode === "create" && enableAiScan
+  // dialog instance" — i.e. AI vision is enabled. It gates the Basics-step
+  // Back button, which rewinds to the scanner, in ANY mode: this is the
+  // requested behaviour so that reopening a saved draft for editing can
+  // still jump to AI scan to finish filling it. Only the OPENING step stays
+  // create-only — edit mode opens on Basics (don't force the scanner when a
+  // row already exists). (Copilot flagged this vs the original PR text; the
+  // edit-mode rewind is intentional and the PR description was updated.)
+  const aiStepAvailable = enableAiScan
   const initialStep: StepKey = mode === "create" && enableAiScan ? "ai" : "basics"
   const [step, setStep] = useState<StepKey>(initialStep)
   // Tracks which form steps the user has already landed on, so the

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -242,13 +242,15 @@ export function CommodityFormDialog({
   // disabled) create mode also opens on Basics — the scan surface
   // would only 404, so we skip straight to manual entry.
   //
-  // `aiStepAvailable` is the single source of truth for "the AI scan
-  // surface exists in this dialog instance": create mode with the scan
-  // entry enabled. It gates both the opening step AND the Back button on
-  // Basics, which rewinds to the scanner when AI is on (instead of being
-  // a dead no-op on the first form step).
-  const aiStepAvailable = mode === "create" && enableAiScan
-  const initialStep: StepKey = aiStepAvailable ? "ai" : "basics"
+  // `aiStepAvailable` means "the AI scan surface is reachable in this
+  // dialog instance" — i.e. AI vision is enabled. It gates the Basics-step
+  // Back button, which rewinds to the scanner, in ANY mode: notably when
+  // you reopen a saved draft for editing you can still jump to AI scan to
+  // finish filling it (the previous create-only gate left Back dead there).
+  // Only the OPENING step stays create-only — edit mode opens on Basics
+  // (you don't want the scanner forced when a row already exists).
+  const aiStepAvailable = enableAiScan
+  const initialStep: StepKey = mode === "create" && enableAiScan ? "ai" : "basics"
   const [step, setStep] = useState<StepKey>(initialStep)
   // Tracks which form steps the user has already landed on, so the
   // segmented stepper bar lets them click back-and-forth between

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -454,9 +454,9 @@ export function CommodityFormDialog({
     if (step === "ai") return
     if (step === "basics") {
       // Back from the first form step rewinds to the AI scan entry when
-      // it's available (create mode + AI enabled), so a user who picked
-      // "Fill manually" can re-open the scanner. Without the AI surface
-      // Basics is the first screen and Back is a no-op.
+      // it's available (AI enabled), so a user who picked "Fill manually"
+      // can re-open the scanner. Without the AI surface, Basics is the
+      // first screen and Back is a no-op.
       if (aiStepAvailable) setStep("ai")
       return
     }

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -241,7 +241,14 @@ export function CommodityFormDialog({
   // When `enableAiScan` is off (anonymous flow with public_scan
   // disabled) create mode also opens on Basics — the scan surface
   // would only 404, so we skip straight to manual entry.
-  const initialStep: StepKey = mode === "create" && enableAiScan ? "ai" : "basics"
+  //
+  // `aiStepAvailable` is the single source of truth for "the AI scan
+  // surface exists in this dialog instance": create mode with the scan
+  // entry enabled. It gates both the opening step AND the Back button on
+  // Basics, which rewinds to the scanner when AI is on (instead of being
+  // a dead no-op on the first form step).
+  const aiStepAvailable = mode === "create" && enableAiScan
+  const initialStep: StepKey = aiStepAvailable ? "ai" : "basics"
   const [step, setStep] = useState<StepKey>(initialStep)
   // Tracks which form steps the user has already landed on, so the
   // segmented stepper bar lets them click back-and-forth between
@@ -442,9 +449,15 @@ export function CommodityFormDialog({
   }
   function prevStep() {
     if (step === "ai") return
+    if (step === "basics") {
+      // Back from the first form step rewinds to the AI scan entry when
+      // it's available (create mode + AI enabled), so a user who picked
+      // "Fill manually" can re-open the scanner. Without the AI surface
+      // Basics is the first screen and Back is a no-op.
+      if (aiStepAvailable) setStep("ai")
+      return
+    }
     const idx = FORM_STEPS.indexOf(step)
-    // Prev is disabled on Basics (idx === 0) — the AI surface is an
-    // alternative entry, not a previous step the user can rewind to.
     if (idx > 0) setStep(FORM_STEPS[idx - 1])
   }
 
@@ -953,7 +966,10 @@ export function CommodityFormDialog({
               type="button"
               variant="outline"
               onClick={prevStep}
-              disabled={formStepIndex <= 0 || isPending}
+              // Enabled on Basics too when the AI scan surface exists —
+              // Back there rewinds to the scanner (see prevStep). Without
+              // it, Basics is the first screen so Back stays disabled.
+              disabled={isPending || (formStepIndex <= 0 && !aiStepAvailable)}
             >
               <ChevronLeft className="size-4" aria-hidden="true" />
               {t("commodities:form.back")}

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -135,6 +135,40 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     expect(screen.getByRole("button", { name: /^back$/i })).toBeDisabled()
   })
 
+  it("keeps Back active on Basics in edit mode so a draft can jump to AI scan", async () => {
+    withGroupSlug()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="edit"
+          initialValues={{
+            id: "c1",
+            name: "Draft item",
+            short_name: "Draft",
+            type: "electronics",
+            area_id: "a1",
+            status: "in_use",
+            count: 1,
+          }}
+          areas={areas}
+          locations={locations}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+        />
+      ),
+    })
+    // Edit opens on Basics. Back is active because AI vision is enabled and
+    // rewinds to the AI scan surface — so a reopened draft can be finished
+    // with a scan (the previous create-only gate left Back dead here).
+    const back = await screen.findByRole("button", { name: /^back$/i })
+    expect(back).toBeEnabled()
+    const user = userEvent.setup()
+    await user.click(back)
+    expect(await screen.findByTestId("commodity-form-ai-step")).toBeInTheDocument()
+  })
+
   it("renders the offer phase by default with no thumbnails", async () => {
     renderDialog()
     expect(await screen.findByTestId("commodity-form-ai-step")).toHaveAttribute(
@@ -330,6 +364,52 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     await user.click(screen.getByTestId("commodity-form-ai-use-values"))
     const shortInput = (await screen.findByLabelText(/^Short name$/i)) as HTMLInputElement
     expect(shortInput.value).toHaveLength(40)
+  })
+
+  it("shows a chooser for a multi-item scan and the pick drives the review", async () => {
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: { name: { value: "Coffee Machine", confidence: 0.9 } },
+        items: [
+          { fields: { name: { value: "Coffee Machine", confidence: 0.9 } } },
+          { fields: { name: { value: "Milk Frother", confidence: 0.8 } } },
+        ],
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(
+      await screen.findByTestId("commodity-form-ai-file-input"),
+      makePdf("receipt.pdf")
+    )
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    // Two candidates → the chooser, not review.
+    await screen.findByTestId("commodity-form-ai-choose")
+    expect(screen.getByTestId("commodity-form-ai-step")).toHaveAttribute("data-ai-phase", "choose")
+    expect(screen.getByTestId("commodity-form-ai-choose-item-0")).toHaveTextContent(
+      "Coffee Machine"
+    )
+    expect(screen.getByTestId("commodity-form-ai-choose-item-1")).toHaveTextContent("Milk Frother")
+    // Pick the second → review pre-fills that item's fields.
+    await user.click(screen.getByTestId("commodity-form-ai-choose-item-1"))
+    await screen.findByTestId("commodity-form-ai-review")
+    expect(screen.getByTestId("commodity-form-ai-row-name-value")).toHaveTextContent("Milk Frother")
+  })
+
+  it("skips the chooser when only one item is detected", async () => {
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: { name: { value: "Solo Item", confidence: 0.9 } },
+        items: [{ fields: { name: { value: "Solo Item", confidence: 0.9 } } }],
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(await screen.findByTestId("commodity-form-ai-file-input"), makePdf("x.pdf"))
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    // One item → straight to review, no chooser.
+    await screen.findByTestId("commodity-form-ai-review")
+    expect(screen.queryByTestId("commodity-form-ai-choose")).not.toBeInTheDocument()
   })
 
   it("renders the rate-limited banner on 429 and keeps Fill manually usable", async () => {

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -69,9 +69,7 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     // first render — each test can still override with a tighter
     // handler via `server.use(...)`.
     server.use(
-      http.get(apiUrl(`/g/${SLUG}/currencies`), () =>
-        HttpResponse.json(["USD", "EUR", "GBP", "CZK"])
-      )
+      http.get(apiUrl(`/currencies`), () => HttpResponse.json(["USD", "EUR", "GBP", "CZK"]))
     )
   })
 
@@ -244,6 +242,37 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     await user.click(screen.getByTestId("commodity-form-ai-use-values"))
     const nameInput = (await screen.findByLabelText(/^Name$/i)) as HTMLInputElement
     expect(nameInput.value).toBe("Sony WH-1000XM5")
+  })
+
+  it("accepts a server-supported non-default currency (CZK) guessed from the scan", async () => {
+    // defaultCurrency is USD; the /currencies mock (beforeEach) includes CZK.
+    // A Czech-invoice guess must therefore be pre-fillable — not dropped as
+    // "unsupported" just because it isn't the group default.
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: {
+          original_price: { value: 1290, confidence: 0.9 },
+          original_price_currency: { value: "CZK", confidence: 0.9 },
+        },
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(
+      await screen.findByTestId("commodity-form-ai-file-input"),
+      makePdf("invoice.pdf")
+    )
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    await screen.findByTestId("commodity-form-ai-review")
+    const row = screen.getByTestId("commodity-form-ai-row-original_price_currency")
+    // Once /currencies resolves, CZK is recognised: no "won't be pre-filled"
+    // note, and the row stays default-checked so the value carries over.
+    await waitFor(() =>
+      expect(within(row).queryByText(/won't be pre-filled/i)).not.toBeInTheDocument()
+    )
+    expect(
+      screen.getByTestId("commodity-form-ai-row-original_price_currency-check")
+    ).toHaveAttribute("data-state", "checked")
   })
 
   it("renders the rate-limited banner on 429 and keeps Fill manually usable", async () => {

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -20,6 +20,13 @@ function makeImage(name = "photo.jpg", type = "image/jpeg"): File {
   return new File([new Uint8Array([0xff, 0xd8, 0xff])], name, { type })
 }
 
+// Helper: build a PDF File (#1983) so the document-staging path can be
+// asserted. The "%PDF" magic bytes keep any content sniffing happy;
+// jsdom never reads the contents.
+function makePdf(name = "receipt.pdf"): File {
+  return new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], name, { type: "application/pdf" })
+}
+
 // Helper: install the active group slug so `useScanCommodityPhotos`
 // hits the right /g/<slug>/commodities/scan route inside the http
 // wrapper's group-rewrite logic.
@@ -90,6 +97,46 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     expect(screen.queryByTestId("commodity-form-ai-step")).not.toBeInTheDocument()
   })
 
+  it("rewinds from Basics back to the AI scan step via Back", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    // "Fill manually" hands off from the AI offer to Basics.
+    await user.click(await screen.findByTestId("commodity-form-ai-fill-manually"))
+    expect(await screen.findByLabelText(/^Name$/i)).toBeInTheDocument()
+    expect(screen.queryByTestId("commodity-form-ai-step")).not.toBeInTheDocument()
+    // Back on the first form step rewinds to the AI offer surface
+    // instead of being a dead no-op (the AI step is the create-mode
+    // entry, so it's a place the user can return to).
+    await user.click(screen.getByRole("button", { name: /^back$/i }))
+    expect(await screen.findByTestId("commodity-form-ai-step")).toHaveAttribute(
+      "data-ai-phase",
+      "offer"
+    )
+    expect(screen.queryByLabelText(/^Name$/i)).not.toBeInTheDocument()
+  })
+
+  it("keeps Back disabled on Basics when the AI step is unavailable", async () => {
+    withGroupSlug()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="create"
+          enableAiScan={false}
+          areas={areas}
+          locations={locations}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+        />
+      ),
+    })
+    // Lands straight on Basics with no scanner to rewind to, so Back has
+    // nothing to do and stays disabled.
+    expect(await screen.findByTestId("commodity-form-next")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^back$/i })).toBeDisabled()
+  })
+
   it("renders the offer phase by default with no thumbnails", async () => {
     renderDialog()
     expect(await screen.findByTestId("commodity-form-ai-step")).toHaveAttribute(
@@ -107,6 +154,19 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     const input = await screen.findByTestId("commodity-form-ai-file-input")
     await user.upload(input, makeImage("alpha.jpg"))
     expect(await screen.findByTestId("commodity-form-ai-thumb")).toBeInTheDocument()
+    expect(screen.getByTestId("commodity-form-ai-scan")).toBeEnabled()
+  })
+
+  it("stages a PDF document with a document tile and enables Scan", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const input = await screen.findByTestId("commodity-form-ai-file-input")
+    await user.upload(input, makePdf("receipt.pdf"))
+    // A PDF can't render as an <img> thumbnail, so it stages as a
+    // document tile carrying the filename — but it still counts as a
+    // scannable source, so the Scan button enables (#1983 Part B).
+    const tile = await screen.findByTestId("commodity-form-ai-thumb-pdf")
+    expect(tile).toHaveTextContent("receipt.pdf")
     expect(screen.getByTestId("commodity-form-ai-scan")).toBeEnabled()
   })
 

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -275,6 +275,63 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     ).toHaveAttribute("data-state", "checked")
   })
 
+  it("renders a warranty_expires_at review row from the scan", async () => {
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: {
+          warranty_expires_at: { value: "2027-05-01", confidence: 0.7 },
+        },
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(
+      await screen.findByTestId("commodity-form-ai-file-input"),
+      makePdf("manual.pdf")
+    )
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    await screen.findByTestId("commodity-form-ai-review")
+    expect(screen.getByTestId("commodity-form-ai-row-warranty_expires_at-value")).toHaveTextContent(
+      "2027-05-01"
+    )
+  })
+
+  it("surfaces the multiple_items warning when the document has several products", async () => {
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: { name: { value: "First Item", confidence: 0.9 } },
+        warnings: [{ code: "multiple_items" }],
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(
+      await screen.findByTestId("commodity-form-ai-file-input"),
+      makePdf("receipt.pdf")
+    )
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    await screen.findByTestId("commodity-form-ai-review")
+    // The field-less warning is localized in the global review banner.
+    expect(screen.getByText(/more than one item/i)).toBeInTheDocument()
+  })
+
+  it("truncates an over-long short_name guess to the 40-char form limit", async () => {
+    const long = "X".repeat(60)
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: { short_name: { value: long, confidence: 0.9 } },
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(await screen.findByTestId("commodity-form-ai-file-input"), makePdf("x.pdf"))
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    await screen.findByTestId("commodity-form-ai-review")
+    await user.click(screen.getByTestId("commodity-form-ai-use-values"))
+    const shortInput = (await screen.findByLabelText(/^Short name$/i)) as HTMLInputElement
+    expect(shortInput.value).toHaveLength(40)
+  })
+
   it("renders the rate-limited banner on 429 and keeps Fill manually usable", async () => {
     server.use(
       ...commodityScanHandlers.error(SLUG, 429, "commodity_scan.rate_limited", "slow down")

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -135,7 +135,7 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     expect(screen.getByRole("button", { name: /^back$/i })).toBeDisabled()
   })
 
-  it("keeps Back active on Basics in edit mode so a draft can jump to AI scan", async () => {
+  it("keeps Back disabled on Basics in edit mode (no AI rewind)", async () => {
     withGroupSlug()
     renderWithProviders({
       children: (

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -330,6 +330,22 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     )
   })
 
+  it("renders a tags review row from the scan", async () => {
+    server.use(
+      ...commodityScanHandlers.ok(SLUG, {
+        fields: { tags: { value: ["coffee", "kitchen"], confidence: 0.7 } },
+      })
+    )
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(await screen.findByTestId("commodity-form-ai-file-input"), makePdf("x.pdf"))
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    await screen.findByTestId("commodity-form-ai-review")
+    expect(screen.getByTestId("commodity-form-ai-row-tags-value")).toHaveTextContent(
+      "coffee, kitchen"
+    )
+  })
+
   it("surfaces the multiple_items warning when the document has several products", async () => {
     server.use(
       ...commodityScanHandlers.ok(SLUG, {

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -446,6 +446,19 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     await waitFor(() => expect(screen.getByLabelText(/^Name$/i)).toBeInTheDocument())
   })
 
+  it("shows a retry hint instead of an empty review when nothing is extracted", async () => {
+    server.use(...commodityScanHandlers.ok(SLUG, { fields: {} }))
+    const user = userEvent.setup()
+    renderDialog()
+    await user.upload(await screen.findByTestId("commodity-form-ai-file-input"), makePdf("x.pdf"))
+    await user.click(screen.getByTestId("commodity-form-ai-scan"))
+    // Stays on the offer with a hint, not a green-but-empty review.
+    expect(await screen.findByTestId("commodity-form-ai-staging-error")).toHaveTextContent(
+      /couldn't read any details/i
+    )
+    expect(screen.queryByTestId("commodity-form-ai-review")).not.toBeInTheDocument()
+  })
+
   it("renders the provider-disabled banner on 503", async () => {
     server.use(
       ...commodityScanHandlers.error(SLUG, 503, "commodity_scan.provider_disabled", "provider off")

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.aiStep.test.tsx
@@ -135,7 +135,7 @@ describe("<CommodityFormDialog /> AI scan step", () => {
     expect(screen.getByRole("button", { name: /^back$/i })).toBeDisabled()
   })
 
-  it("keeps Back disabled on Basics in edit mode (no AI rewind)", async () => {
+  it("keeps Back active on Basics in edit mode (rewinds to AI scan)", async () => {
     withGroupSlug()
     renderWithProviders({
       children: (

--- a/frontend/src/features/commodities/scanApi.ts
+++ b/frontend/src/features/commodities/scanApi.ts
@@ -56,6 +56,7 @@ export type ScanFieldName =
   | "purchase_date"
   | "warranty_expires_at"
   | "comments"
+  | "tags"
 
 export interface ScanResultFields {
   name?: ScanFieldGuess<string>
@@ -68,6 +69,7 @@ export interface ScanResultFields {
   purchase_date?: ScanFieldGuess<string>
   warranty_expires_at?: ScanFieldGuess<string>
   comments?: ScanFieldGuess<string>
+  tags?: ScanFieldGuess<string[]>
 }
 
 // One candidate product in a multi-product scan; same field shape as the
@@ -226,6 +228,7 @@ function assignField(
       }
       break
     case "urls":
+    case "tags":
       if (Array.isArray(value)) {
         const strs = value.filter((u): u is string => typeof u === "string" && u.trim() !== "")
         if (strs.length > 0) out[key] = { value: strs, confidence }

--- a/frontend/src/features/commodities/scanApi.ts
+++ b/frontend/src/features/commodities/scanApi.ts
@@ -29,7 +29,13 @@ export interface ScanFieldGuess<T extends ScanFieldValue = ScanFieldValue> {
 }
 
 export interface ScanWarning {
-  code: "low_confidence" | "unreadable_serial" | "ambiguous_price" | "currency_inferred" | string
+  code:
+    | "low_confidence"
+    | "unreadable_serial"
+    | "ambiguous_price"
+    | "currency_inferred"
+    | "multiple_items"
+    | string
   field?: string
   detail?: string
 }
@@ -48,6 +54,7 @@ export type ScanFieldName =
   | "serial_number"
   | "urls"
   | "purchase_date"
+  | "warranty_expires_at"
   | "comments"
 
 export interface ScanResultFields {
@@ -59,6 +66,7 @@ export interface ScanResultFields {
   serial_number?: ScanFieldGuess<string>
   urls?: ScanFieldGuess<string[]>
   purchase_date?: ScanFieldGuess<string>
+  warranty_expires_at?: ScanFieldGuess<string>
   comments?: ScanFieldGuess<string>
 }
 
@@ -171,6 +179,7 @@ function assignField(
     case "original_price_currency":
     case "serial_number":
     case "purchase_date":
+    case "warranty_expires_at":
     case "comments":
       if (typeof value === "string") {
         out[key] = { value, confidence }

--- a/frontend/src/features/commodities/scanApi.ts
+++ b/frontend/src/features/commodities/scanApi.ts
@@ -70,10 +70,24 @@ export interface ScanResultFields {
   comments?: ScanFieldGuess<string>
 }
 
+// One candidate product in a multi-product scan; same field shape as the
+// top-level result so the review UI consumes a chosen item unchanged.
+export interface ScanItem {
+  fields: ScanResultFields
+}
+
 export interface ScanResult {
   fields: ScanResultFields
+  // Present (length > 1) only when the BE detected more than one distinct
+  // product; the dialog then renders a chooser so the user picks which to
+  // pre-fill. Empty for the common single-item case (review uses `fields`).
+  items: ScanItem[]
   warnings: ScanWarning[]
 }
+
+// Raw per-field map as it arrives on the wire (value is polymorphic per
+// the OpenAPI spec; narrowed in assignField).
+type RawFieldMap = Partial<Record<ScanFieldName, { value?: unknown; confidence?: number } | null>>
 
 // On-the-wire JSON:API envelope. Kept loose because the only contract
 // the FE relies on is the `data.attributes` shape; everything else
@@ -83,7 +97,8 @@ interface ScanResponseEnvelope {
     type?: string
     id?: string
     attributes?: {
-      fields?: Partial<Record<ScanFieldName, { value?: unknown; confidence?: number } | null>>
+      fields?: RawFieldMap
+      items?: Array<{ fields?: RawFieldMap } | null> | null
       warnings?: ScanWarning[] | null
     }
   }
@@ -145,25 +160,36 @@ export async function scanCommodityPhotos(opts: ScanCommodityPhotosOptions): Pro
 // without round-tripping through `http`.
 export function normalizeScanResponse(env: ScanResponseEnvelope): ScanResult {
   const attrs = env.data?.attributes
-  const rawFields = attrs?.fields ?? {}
+  const fields = normalizeFields(attrs?.fields)
+  // Multi-item list (#1983): normalize each candidate's fields and drop any
+  // that came back empty so a stray {} never renders a blank choice.
+  const rawItems = Array.isArray(attrs?.items) ? attrs.items : []
+  const items: ScanItem[] = rawItems
+    .map((it) => ({ fields: normalizeFields(it?.fields) }))
+    .filter((it) => Object.keys(it.fields).length > 0)
+  return {
+    fields,
+    items,
+    warnings: Array.isArray(attrs?.warnings) ? attrs.warnings : [],
+  }
+}
+
+// normalizeFields converts a raw BE field map into ScanResultFields,
+// dropping null/undefined values. Shared by the primary `fields` and each
+// item in a multi-product scan. Type-narrowing happens in assignField; the
+// BE schema guarantees the per-field value shape (string | number | string[]).
+function normalizeFields(rawFields: RawFieldMap | undefined): ScanResultFields {
   const fields: ScanResultFields = {}
-  for (const key of Object.keys(rawFields) as ScanFieldName[]) {
-    const guess = rawFields[key]
+  const raw = rawFields ?? {}
+  for (const key of Object.keys(raw) as ScanFieldName[]) {
+    const guess = raw[key]
     if (!guess) continue
     const value = guess.value
     if (value === null || value === undefined) continue
     const confidence = typeof guess.confidence === "number" ? guess.confidence : 0
-    // Type-narrowing happens at the read sites; keeping `value` as
-    // `unknown` here would force every consumer through a `String(...)`
-    // dance. The BE schema guarantees the shape per-field so a
-    // structural cast is safe — `value` is one of string | number |
-    // string[] per the OpenAPI spec.
     assignField(fields, key, value, confidence)
   }
-  return {
-    fields,
-    warnings: Array.isArray(attrs?.warnings) ? attrs.warnings : [],
-  }
+  return fields
 }
 
 function assignField(

--- a/frontend/src/features/commodities/schemas.ts
+++ b/frontend/src/features/commodities/schemas.ts
@@ -111,7 +111,7 @@ const baseCommoditySchema = z
     name: z.string().trim().min(1, NAME_REQUIRED).max(200, NAME_TOO_LONG),
     // BE always requires `short_name` regardless of draft (rules.NotEmpty
     // unconditional in models.Commodity.ValidateWithContext).
-    short_name: z.string().trim().min(1, SHORT_NAME_REQUIRED).max(20, SHORT_NAME_TOO_LONG),
+    short_name: z.string().trim().min(1, SHORT_NAME_REQUIRED).max(40, SHORT_NAME_TOO_LONG),
     type: z.string().min(1, TYPE_REQUIRED),
     // Area is optional (#1987): the create dialog no longer asks for a
     // location, and an item can be left unassigned (#1986). Edit mode

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -282,7 +282,7 @@
         },
         "description": "Photograph the item and its label, or add a receipt or invoice PDF — AI will pre-fill the form for you.",
         "dropzone": {
-          "hint": "JPG, PNG, HEIC or PDF — up to 5 files",
+          "hint": "JPG, PNG, WEBP, HEIC/HEIF or PDF — up to 5 files",
           "primary": "Drop photos or PDFs here or browse"
         },
         "errors": {

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -275,10 +275,10 @@
     "serverError": "Something went wrong. Please try again.",
     "step": {
       "ai": {
-        "description": "Photograph the item and its label — AI will pre-fill the form for you.",
+        "description": "Photograph the item and its label, or add a receipt or invoice PDF — AI will pre-fill the form for you.",
         "dropzone": {
-          "hint": "JPG, PNG, HEIC — up to 5 photos",
-          "primary": "Drop photos here or browse"
+          "hint": "JPG, PNG, HEIC or PDF — up to 5 files",
+          "primary": "Drop photos or PDFs here or browse"
         },
         "errors": {
           "photoTooLarge": "One of the photos is too large to scan. Try a smaller file.",
@@ -296,8 +296,8 @@
             "detail": "Too many scan requests. Try again in a moment.",
             "title": "Hold on — too many scans"
           },
-          "tooManyPhotos": "You can attach up to 5 photos per scan.",
-          "unsupportedMime": "Only JPG, PNG, WEBP, HEIC, and HEIF photos can be scanned."
+          "tooManyPhotos": "You can attach up to 5 files per scan.",
+          "unsupportedMime": "Only JPG, PNG, WEBP, HEIC, HEIF photos and PDF documents can be scanned."
         },
         "fullItem": {
           "description": "Photograph the whole item clearly so AI can identify it",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -281,13 +281,13 @@
           "primary": "Drop photos or PDFs here or browse"
         },
         "errors": {
-          "photoTooLarge": "One of the photos is too large to scan. Try a smaller file.",
+          "photoTooLarge": "One of the files is too large to scan. Try a smaller file.",
           "providerDisabled": {
             "detail": "AI vision isn't enabled on this server right now. Use Fill manually to continue.",
             "title": "AI vision is unavailable"
           },
           "providerError": {
-            "title": "AI vision couldn't process those photos"
+            "title": "AI vision couldn't process those files"
           },
           "providerTimeout": {
             "title": "AI vision took too long to respond"
@@ -309,12 +309,12 @@
         },
         "offer": {
           "dropzone": {
-            "activeHint": "Release to add photos"
+            "activeHint": "Release to add files"
           },
           "staged": {
             "remove": "Remove",
-            "title_one": "{{count}} photo staged",
-            "title_other": "{{count}} photos staged"
+            "title_one": "{{count}} file staged",
+            "title_other": "{{count}} files staged"
           }
         },
         "review": {
@@ -324,7 +324,7 @@
             "medium": "{{percent}}% likely"
           },
           "currencyInferred": "Currency wasn't on the server's supported list — it won't be pre-filled.",
-          "retake": "Re-take photos",
+          "retake": "Start over",
           "subtitle": "Untick anything that looks wrong before we prefill the form.",
           "title": "Review extracted details",
           "useValues": "Use these values",
@@ -338,9 +338,9 @@
         "scanning": {
           "cancel": "Cancel",
           "subtitle": "AI is reading the label and identifying the item.",
-          "title": "Scanning your photos…"
+          "title": "Scanning your files…"
         },
-        "scanPhotos": "Scan photos",
+        "scanPhotos": "Scan files",
         "title": "Fill with AI"
       },
       "basics": {

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -286,6 +286,7 @@
           "primary": "Drop photos or PDFs here or browse"
         },
         "errors": {
+          "noDetails": "We couldn't read any details from that. Try a clearer photo or a different document.",
           "photoTooLarge": "One of the files is too large to scan. Try a smaller file.",
           "providerDisabled": {
             "detail": "AI vision isn't enabled on this server right now. Use Fill manually to continue.",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -275,6 +275,11 @@
     "serverError": "Something went wrong. Please try again.",
     "step": {
       "ai": {
+        "choose": {
+          "itemFallback": "Item {{index}}",
+          "subtitle": "We found more than one product. Pick the one to add — you can add the others separately afterwards.",
+          "title": "Choose which item to add"
+        },
         "description": "Photograph the item and its label, or add a receipt or invoice PDF — AI will pre-fill the form for you.",
         "dropzone": {
           "hint": "JPG, PNG, HEIC or PDF — up to 5 files",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -224,7 +224,7 @@
     "serialNumberHelp": "Found on device label or packaging",
     "serialNumberPlaceholder": "e.g. SN-MEL-2022-00412",
     "shortName": "Short name",
-    "shortNameHelp": "1–20 chars, used in compact lists and labels",
+    "shortNameHelp": "1–40 chars, used in compact lists and labels",
     "shortNamePlaceholder": "e.g. Dishwasher",
     "status": "Status",
     "tags": "Tags",
@@ -332,6 +332,7 @@
             "ambiguousPrice": "Price looks ambiguous",
             "currencyInferred": "Currency was inferred",
             "lowConfidence": "Low confidence",
+            "multipleItems": "This looks like more than one item — we pre-filled the most prominent one. Add the others separately after saving.",
             "unreadableSerial": "Serial number was hard to read"
           }
         },
@@ -469,7 +470,7 @@
     "purchaseDateRequired": "Purchase date is required for non-draft items.",
     "quantityForbidsWarranty": "Items with quantity greater than 1 don't support warranty tracking. Split into separate items for per-unit tracking.",
     "shortNameRequired": "Short name is required.",
-    "shortNameTooLong": "Short name must be 20 characters or fewer.",
+    "shortNameTooLong": "Short name must be 40 characters or fewer.",
     "statusRequired": "Pick a status.",
     "typeRequired": "Pick a type.",
     "urlInvalid": "Enter a valid URL (e.g. https://example.com)."

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -247,3 +247,24 @@
     background: white !important;
   }
 }
+
+/* Indeterminate progress bar for the AI-scan "scanning" phase. The scan
+   duration is unknown (one upstream model call), so we can't show a real
+   0–100% — a partial bar slides across the track to signal ongoing work.
+   Honours prefers-reduced-motion. */
+@keyframes ai-scan-bar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(250%);
+  }
+}
+.ai-scan-bar {
+  animation: ai-scan-bar 1.1s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ai-scan-bar {
+    animation: none;
+  }
+}

--- a/frontend/src/lib/currency-meta.ts
+++ b/frontend/src/lib/currency-meta.ts
@@ -55,3 +55,10 @@ export function currencyMeta(code: string): CurrencyMeta {
   const upper = code.trim().toUpperCase()
   return BY_CODE.get(upper) ?? { code: upper, symbol: upper, name: upper }
 }
+
+// KNOWN_CURRENCY_CODES is the curated subset of ISO 4217 codes the FE always
+// knows synchronously (the BE's /api/v1/currencies returns the full ISO list,
+// but that's an async fetch). Use this where a value needs an immediate "is
+// this a real, common currency" check without waiting on — or depending on —
+// the network (e.g. accepting an AI-guessed currency like CZK for prefill).
+export const KNOWN_CURRENCY_CODES: readonly string[] = ENTRIES.map((e) => e.code)

--- a/frontend/src/test/handlers/commodityScan.ts
+++ b/frontend/src/test/handlers/commodityScan.ts
@@ -32,7 +32,9 @@ export function ok(slug: string, attrs: OkAttributes) {
           type: "commodity_scan",
           attributes: {
             fields: attrs.fields,
-            items: attrs.items ?? [],
+            // Omit items for the single-item case, mirroring the BE's
+            // `omitempty` (and the slow() helper).
+            ...(attrs.items ? { items: attrs.items } : {}),
             warnings: attrs.warnings ?? [],
           },
         },

--- a/frontend/src/test/handlers/commodityScan.ts
+++ b/frontend/src/test/handlers/commodityScan.ts
@@ -18,6 +18,9 @@ type Field =
 
 interface OkAttributes {
   fields: Partial<Record<string, Field>>
+  // Multi-product scans (#1983): one entry per candidate. Omitted/empty for
+  // the common single-item case.
+  items?: Array<{ fields: Partial<Record<string, Field>> }>
   warnings?: Array<{ code: string; field?: string; detail?: string }>
 }
 
@@ -29,6 +32,7 @@ export function ok(slug: string, attrs: OkAttributes) {
           type: "commodity_scan",
           attributes: {
             fields: attrs.fields,
+            items: attrs.items ?? [],
             warnings: attrs.warnings ?? [],
           },
         },

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -10441,6 +10441,12 @@ export type components = {
             fields?: {
                 [key: string]: components["schemas"]["jsonapi.CommodityScanFieldGuess"];
             };
+            /**
+             * @description Items is present only when the source described more than one
+             *     distinct product; one entry per product, most prominent first. The
+             *     FE renders a chooser. Empty/absent for a single product.
+             */
+            items?: components["schemas"]["jsonapi.CommodityScanItem"][];
             latency_ms?: number;
             used_tokens?: number;
             warnings?: components["schemas"]["jsonapi.CommodityScanWarning"][];
@@ -10449,6 +10455,11 @@ export type components = {
             confidence?: number;
             /** @description Value is polymorphic — see the type-level doc comment. */
             value?: Record<string, never>;
+        };
+        "jsonapi.CommodityScanItem": {
+            fields?: {
+                [key: string]: components["schemas"]["jsonapi.CommodityScanFieldGuess"];
+            };
         };
         "jsonapi.CommodityScanResource": {
             attributes?: components["schemas"]["jsonapi.CommodityScanAttributes"];
@@ -10466,7 +10477,7 @@ export type components = {
              * @example low_confidence
              * @enum {string}
              */
-            code?: "low_confidence" | "unreadable_serial" | "ambiguous_price" | "currency_inferred" | "no_photo_text";
+            code?: "low_confidence" | "unreadable_serial" | "ambiguous_price" | "currency_inferred" | "no_photo_text" | "multiple_items";
             detail?: string;
             field?: string;
         };

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -12473,23 +12473,23 @@ export type components = {
     responses: never;
     parameters: never;
     requestBodies: {
-        /** @description Area object */
-        "jsonapi.AreaRequest": {
-            content: {
-                "application/vnd.api+json": components["schemas"]["jsonapi.AreaRequest"];
-            };
-        };
         postG_groupslug_commoditiesScan: {
             content: {
                 "multipart/form-data": {
                     /**
                      * Format: binary
-                     * @description Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple `photos` parts).
+                     * @description Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts).
                      */
                     photos: string;
                     /** @description Optional free-form hint (brand, category guess) */
                     hint?: string;
                 };
+            };
+        };
+        /** @description Area object */
+        "jsonapi.AreaRequest": {
+            content: {
+                "application/vnd.api+json": components["schemas"]["jsonapi.AreaRequest"];
             };
         };
         /** @description Commodity object */

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -3837,8 +3837,8 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Run an AI vision scan on uploaded photos
-         * @description Extract structured commodity field guesses from 1..N product photos. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.
+         * Run an AI vision scan on uploaded photos or documents
+         * @description Extract structured commodity field guesses from 1..N product photos or PDF documents. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.
          */
         post: {
             parameters: {
@@ -3861,7 +3861,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.CommodityScanResponse"];
                     };
                 };
-                /** @description Photo too large */
+                /** @description File too large */
                 413: {
                     headers: {
                         [name: string]: unknown;
@@ -3879,7 +3879,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Too many photos / no photos */
+                /** @description Too many files / no files */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -8851,7 +8851,7 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Run an AI vision scan on uploaded photos (public)
+         * Run an AI vision scan on uploaded photos or documents (public)
          * @description Anonymous variant of the photo scan for the landing-page CTA (#1988). Unauthenticated, IP + global-daily rate limited, gated behind a deployment feature flag. Returns field guesses only and persists nothing.
          */
         post: {
@@ -8872,7 +8872,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.CommodityScanResponse"];
                     };
                 };
-                /** @description Photo too large */
+                /** @description File too large */
                 413: {
                     headers: {
                         [name: string]: unknown;
@@ -8890,7 +8890,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Too many photos / no photos */
+                /** @description Too many files / no files */
                 422: {
                     headers: {
                         [name: string]: unknown;

--- a/go/apiserver/commodity_scan.go
+++ b/go/apiserver/commodity_scan.go
@@ -113,7 +113,7 @@ func CommodityScanPublic(scanService *services.CommodityScanService, maxFormByte
 // @Tags commodities
 // @Accept multipart/form-data
 // @Produce json-api
-// @Param photos formData file true "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple `photos` parts)."
+// @Param photos formData file true "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts)."
 // @Param hint formData string false "Optional free-form hint (brand, category guess)"
 // @Success 200 {object} jsonapi.CommodityScanResponse "OK"
 // @Failure 413 {object} jsonapi.Errors "Photo too large"
@@ -187,7 +187,7 @@ func (api *commodityScanAPI) handlePublicScan(w http.ResponseWriter, r *http.Req
 // @Accept multipart/form-data
 // @Produce json-api
 // @Param groupSlug path string true "Group slug"
-// @Param photos formData file true "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple `photos` parts)."
+// @Param photos formData file true "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts)."
 // @Param hint formData string false "Optional free-form hint (brand, category guess)"
 // @Success 200 {object} jsonapi.CommodityScanResponse "OK"
 // @Failure 413 {object} jsonapi.Errors "Photo too large"

--- a/go/apiserver/commodity_scan.go
+++ b/go/apiserver/commodity_scan.go
@@ -511,12 +511,19 @@ type commodityScanResource struct {
 }
 
 // commodityScanResultDT is the wire shape. Each field carries an
-// optional value + confidence; absent fields mean "no signal".
+// optional value + confidence; absent fields mean "no signal". Items is
+// present only for a multi-product scan (the FE renders a chooser).
 type commodityScanResultDT struct {
 	Fields     map[string]commodityScanFieldDT `json:"fields"`
+	Items      []commodityScanItemDT           `json:"items,omitempty"`
 	Warnings   []aivision.Warning              `json:"warnings,omitempty"`
 	UsedTokens int                             `json:"used_tokens,omitempty"`
 	LatencyMS  int64                           `json:"latency_ms,omitempty"`
+}
+
+// commodityScanItemDT is one candidate product in a multi-product scan.
+type commodityScanItemDT struct {
+	Fields map[string]commodityScanFieldDT `json:"fields"`
 }
 
 type commodityScanFieldDT struct {
@@ -524,19 +531,30 @@ type commodityScanFieldDT struct {
 	Confidence float64         `json:"confidence"`
 }
 
-func newCommodityScanResponse(r *aivision.ScanResult) *commodityScanResponse {
-	dt := commodityScanResultDT{
-		Fields:     make(map[string]commodityScanFieldDT, len(r.Fields)),
-		Warnings:   r.Warnings,
-		UsedTokens: r.UsedTokens,
-		LatencyMS:  r.LatencyMS,
-	}
-	for name, g := range r.Fields {
+// marshalScanFields converts the provider's FieldGuess map into the wire
+// field map, dropping any value that fails to marshal. Shared by the
+// primary fields and each item's fields.
+func marshalScanFields(fields map[string]aivision.FieldGuess) map[string]commodityScanFieldDT {
+	out := make(map[string]commodityScanFieldDT, len(fields))
+	for name, g := range fields {
 		raw, err := json.Marshal(g.Value)
 		if err != nil {
 			continue
 		}
-		dt.Fields[name] = commodityScanFieldDT{Value: raw, Confidence: g.Confidence}
+		out[name] = commodityScanFieldDT{Value: raw, Confidence: g.Confidence}
+	}
+	return out
+}
+
+func newCommodityScanResponse(r *aivision.ScanResult) *commodityScanResponse {
+	dt := commodityScanResultDT{
+		Fields:     marshalScanFields(r.Fields),
+		Warnings:   r.Warnings,
+		UsedTokens: r.UsedTokens,
+		LatencyMS:  r.LatencyMS,
+	}
+	for _, it := range r.Items {
+		dt.Items = append(dt.Items, commodityScanItemDT{Fields: marshalScanFields(it.Fields)})
 	}
 	return &commodityScanResponse{
 		Data:       commodityScanResource{Type: "commodity_scan", Attributes: dt},

--- a/go/apiserver/commodity_scan.go
+++ b/go/apiserver/commodity_scan.go
@@ -108,7 +108,7 @@ func CommodityScanPublic(scanService *services.CommodityScanService, maxFormByte
 // CommodityScanService.ScanAnonymous and reuses the same body/photo
 // readers and the shared renderScanError → mapCommodityScanError mapping.
 //
-// @Summary Run an AI vision scan on uploaded photos (public)
+// @Summary Run an AI vision scan on uploaded photos or documents (public)
 // @Description Anonymous variant of the photo scan for the landing-page CTA (#1988). Unauthenticated, IP + global-daily rate limited, gated behind a deployment feature flag. Returns field guesses only and persists nothing.
 // @Tags commodities
 // @Accept multipart/form-data
@@ -116,9 +116,9 @@ func CommodityScanPublic(scanService *services.CommodityScanService, maxFormByte
 // @Param photos formData file true "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts)."
 // @Param hint formData string false "Optional free-form hint (brand, category guess)"
 // @Success 200 {object} jsonapi.CommodityScanResponse "OK"
-// @Failure 413 {object} jsonapi.Errors "Photo too large"
+// @Failure 413 {object} jsonapi.Errors "File too large"
 // @Failure 415 {object} jsonapi.Errors "Unsupported MIME type"
-// @Failure 422 {object} jsonapi.Errors "Too many photos / no photos"
+// @Failure 422 {object} jsonapi.Errors "Too many files / no files"
 // @Failure 429 {object} jsonapi.Errors "Rate limited"
 // @Failure 502 {object} jsonapi.Errors "Provider unavailable / parse error"
 // @Failure 503 {object} jsonapi.Errors "Provider disabled"
@@ -181,8 +181,8 @@ func (api *commodityScanAPI) handlePublicScan(w http.ResponseWriter, r *http.Req
 // validates the basics, and delegates to CommodityScanService.Scan,
 // then renders a JSON:API response with type "commodity_scan".
 //
-// @Summary Run an AI vision scan on uploaded photos
-// @Description Extract structured commodity field guesses from 1..N product photos. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.
+// @Summary Run an AI vision scan on uploaded photos or documents
+// @Description Extract structured commodity field guesses from 1..N product photos or PDF documents. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.
 // @Tags commodities
 // @Accept multipart/form-data
 // @Produce json-api
@@ -190,9 +190,9 @@ func (api *commodityScanAPI) handlePublicScan(w http.ResponseWriter, r *http.Req
 // @Param photos formData file true "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts)."
 // @Param hint formData string false "Optional free-form hint (brand, category guess)"
 // @Success 200 {object} jsonapi.CommodityScanResponse "OK"
-// @Failure 413 {object} jsonapi.Errors "Photo too large"
+// @Failure 413 {object} jsonapi.Errors "File too large"
 // @Failure 415 {object} jsonapi.Errors "Unsupported MIME type"
-// @Failure 422 {object} jsonapi.Errors "Too many photos / no photos"
+// @Failure 422 {object} jsonapi.Errors "Too many files / no files"
 // @Failure 429 {object} jsonapi.Errors "Rate limited"
 // @Failure 502 {object} jsonapi.Errors "Provider unavailable / parse error"
 // @Failure 503 {object} jsonapi.Errors "Provider disabled"

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -110,7 +110,7 @@ type Config struct {
 	AIVisionOpenAIAPIKey     string `yaml:"ai_vision_openai_api_key" env:"AI_VISION_OPENAI_API_KEY" env-default:""`
 	AIVisionOpenAIModel      string `yaml:"ai_vision_openai_model" env:"AI_VISION_OPENAI_MODEL" env-default:"gpt-4o"`
 	AIVisionOpenAIBaseURL    string `yaml:"ai_vision_openai_base_url" env:"AI_VISION_OPENAI_BASE_URL" env-default:""`
-	AIVisionTimeout          string `yaml:"ai_vision_timeout" env:"AI_VISION_TIMEOUT" env-default:"20s"`
+	AIVisionTimeout          string `yaml:"ai_vision_timeout" env:"AI_VISION_TIMEOUT" env-default:"60s"`
 	AIVisionMaxPhotos        int    `yaml:"ai_vision_max_photos" env:"AI_VISION_MAX_PHOTOS" env-default:"5"`
 	AIVisionMaxPhotoBytes    int    `yaml:"ai_vision_max_photo_bytes" env:"AI_VISION_MAX_PHOTO_BYTES" env-default:"10485760"`
 	AIVisionRateLimitPerHour int    `yaml:"ai_vision_rate_limit_per_hour" env:"AI_VISION_RATE_LIMIT_PER_HOUR" env-default:"30"`
@@ -242,8 +242,10 @@ func (c *Config) SetDefaults() {
 	}
 	if c.AIVisionTimeout == "" {
 		// #1720: matches AI_VISION_TIMEOUT env-default. Empty values
-		// come from YAML configs that omit the key entirely.
-		c.AIVisionTimeout = "20s"
+		// come from YAML configs that omit the key entirely. 60s leaves
+		// room for a PDF + a multi-product invoice extraction (20s timed
+		// those out at the 504 boundary).
+		c.AIVisionTimeout = "60s"
 	}
 	if c.AIVisionProvider == "" {
 		c.AIVisionProvider = "none"

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -114,6 +114,12 @@ type Config struct {
 	AIVisionMaxPhotos        int    `yaml:"ai_vision_max_photos" env:"AI_VISION_MAX_PHOTOS" env-default:"5"`
 	AIVisionMaxPhotoBytes    int    `yaml:"ai_vision_max_photo_bytes" env:"AI_VISION_MAX_PHOTO_BYTES" env-default:"10485760"`
 	AIVisionRateLimitPerHour int    `yaml:"ai_vision_rate_limit_per_hour" env:"AI_VISION_RATE_LIMIT_PER_HOUR" env-default:"30"`
+	// AIVisionMaxTokens caps the model's structured output. It must hold a
+	// multi-line invoice (each product is ~10 fields), or the JSON truncates
+	// and a multi-product scan comes back empty/partial. Zero falls back to
+	// the provider default (4096). It is only a ceiling — small scans don't
+	// pay for the headroom.
+	AIVisionMaxTokens int `yaml:"ai_vision_max_tokens" env:"AI_VISION_MAX_TOKENS" env-default:"4096"`
 
 	// PublicAIVisionScanEnabled gates the unauthenticated public photo-scan
 	// endpoint (#1988) that backs the landing-page "add your first item"

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -102,6 +102,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.IntVar(&cfg.AIVisionMaxPhotos, "ai-vision-max-photos", cfg.AIVisionMaxPhotos, "Maximum number of photos accepted per scan request")
 	flags.IntVar(&cfg.AIVisionMaxPhotoBytes, "ai-vision-max-photo-bytes", cfg.AIVisionMaxPhotoBytes, "Maximum bytes accepted per photo (defaults to 10 MiB)")
 	flags.IntVar(&cfg.AIVisionRateLimitPerHour, "ai-vision-rate-limit-per-hour", cfg.AIVisionRateLimitPerHour, "Per-user hourly scan rate limit (0 disables the limit)")
+	flags.IntVar(&cfg.AIVisionMaxTokens, "ai-vision-max-tokens", cfg.AIVisionMaxTokens, "Cap on the vision model's structured output (must hold a multi-line invoice; 0 = provider default 4096)")
 	flags.BoolVar(&cfg.PublicAIVisionScanEnabled, "public-ai-vision-scan-enabled", cfg.PublicAIVisionScanEnabled, "Enable the unauthenticated public photo-scan endpoint for the landing-page CTA (#1988). Default false; spends vendor tokens.")
 
 	// OAuth third-party sign-in (issue #1394). Each provider requires

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -247,6 +247,7 @@ func wireCommodityScan(cfg *Config, params *apiserver.Params) error {
 		OpenAIAPIKey:     cfg.AIVisionOpenAIAPIKey,
 		OpenAIModel:      cfg.AIVisionOpenAIModel,
 		OpenAIBaseURL:    cfg.AIVisionOpenAIBaseURL,
+		MaxTokens:        cfg.AIVisionMaxTokens,
 	})
 	switch {
 	case err == nil:

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"math"
+	"net/http"
 	"strings"
 	"time"
 
@@ -248,6 +249,11 @@ func wireCommodityScan(cfg *Config, params *apiserver.Params) error {
 		OpenAIModel:      cfg.AIVisionOpenAIModel,
 		OpenAIBaseURL:    cfg.AIVisionOpenAIBaseURL,
 		MaxTokens:        cfg.AIVisionMaxTokens,
+		// Derive the HTTP-client cap from the configured per-call deadline so
+		// the context (AI_VISION_TIMEOUT) is always the binding timeout — even
+		// when an operator raises it above the provider's fixed 90s fallback.
+		// +30s slack keeps the client a safety net strictly above the context.
+		HTTPClient: &http.Client{Timeout: timeout + 30*time.Second},
 	})
 	switch {
 	case err == nil:

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -240,6 +240,10 @@ func wireCommodityScan(cfg *Config, params *apiserver.Params) error {
 		return err
 	}
 
+	if cfg.AIVisionMaxTokens < 0 {
+		return errors.New("AI_VISION_MAX_TOKENS must not be negative")
+	}
+
 	provider, err := aivision.NewProvider(aivision.ProviderConfig{
 		Name:             strings.TrimSpace(cfg.AIVisionProvider),
 		AnthropicAPIKey:  cfg.AIVisionAnthropicAPIKey,

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -10249,6 +10249,13 @@ const docTemplate = `{
                         "$ref": "#/definitions/jsonapi.CommodityScanFieldGuess"
                     }
                 },
+                "items": {
+                    "description": "Items is present only when the source described more than one\ndistinct product; one entry per product, most prominent first. The\nFE renders a chooser. Empty/absent for a single product.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CommodityScanItem"
+                    }
+                },
                 "latency_ms": {
                     "type": "integer"
                 },
@@ -10272,6 +10279,17 @@ const docTemplate = `{
                 "value": {
                     "description": "Value is polymorphic — see the type-level doc comment.",
                     "type": "object"
+                }
+            }
+        },
+        "jsonapi.CommodityScanItem": {
+            "type": "object",
+            "properties": {
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/jsonapi.CommodityScanFieldGuess"
+                    }
                 }
             }
         },
@@ -10308,7 +10326,8 @@ const docTemplate = `{
                         "unreadable_serial",
                         "ambiguous_price",
                         "currency_inferred",
-                        "no_photo_text"
+                        "no_photo_text",
+                        "multiple_items"
                     ],
                     "example": "low_confidence"
                 },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -2928,7 +2928,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/commodities/scan": {
             "post": {
-                "description": "Extract structured commodity field guesses from 1..N product photos. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.",
+                "description": "Extract structured commodity field guesses from 1..N product photos or PDF documents. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2938,7 +2938,7 @@ const docTemplate = `{
                 "tags": [
                     "commodities"
                 ],
-                "summary": "Run an AI vision scan on uploaded photos",
+                "summary": "Run an AI vision scan on uploaded photos or documents",
                 "parameters": [
                     {
                         "type": "string",
@@ -2969,7 +2969,7 @@ const docTemplate = `{
                         }
                     },
                     "413": {
-                        "description": "Photo too large",
+                        "description": "File too large",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -2981,7 +2981,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Too many photos / no photos",
+                        "description": "Too many files / no files",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7724,7 +7724,7 @@ const docTemplate = `{
                 "tags": [
                     "commodities"
                 ],
-                "summary": "Run an AI vision scan on uploaded photos (public)",
+                "summary": "Run an AI vision scan on uploaded photos or documents (public)",
                 "parameters": [
                     {
                         "type": "file",
@@ -7748,7 +7748,7 @@ const docTemplate = `{
                         }
                     },
                     "413": {
-                        "description": "Photo too large",
+                        "description": "File too large",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7760,7 +7760,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Too many photos / no photos",
+                        "description": "Too many files / no files",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -2949,7 +2949,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "file",
-                        "description": "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple ` + "`" + `photos` + "`" + ` parts).",
+                        "description": "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple ` + "`" + `photos` + "`" + ` parts).",
                         "name": "photos",
                         "in": "formData",
                         "required": true
@@ -7728,7 +7728,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "file",
-                        "description": "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple ` + "`" + `photos` + "`" + ` parts).",
+                        "description": "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple ` + "`" + `photos` + "`" + ` parts).",
                         "name": "photos",
                         "in": "formData",
                         "required": true

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -2942,7 +2942,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple `photos` parts).",
+                        "description": "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts).",
                         "name": "photos",
                         "in": "formData",
                         "required": true
@@ -7721,7 +7721,7 @@
                 "parameters": [
                     {
                         "type": "file",
-                        "description": "Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the form field to upload up to 5 photos in a single request (multipart/form-data with multiple `photos` parts).",
+                        "description": "Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data with multiple `photos` parts).",
                         "name": "photos",
                         "in": "formData",
                         "required": true

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -2921,7 +2921,7 @@
         },
         "/g/{groupSlug}/commodities/scan": {
             "post": {
-                "description": "Extract structured commodity field guesses from 1..N product photos. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.",
+                "description": "Extract structured commodity field guesses from 1..N product photos or PDF documents. The handler does not persist any commodity — it only returns structured suggestions for the Add Item dialog to pre-fill.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2931,7 +2931,7 @@
                 "tags": [
                     "commodities"
                 ],
-                "summary": "Run an AI vision scan on uploaded photos",
+                "summary": "Run an AI vision scan on uploaded photos or documents",
                 "parameters": [
                     {
                         "type": "string",
@@ -2962,7 +2962,7 @@
                         }
                     },
                     "413": {
-                        "description": "Photo too large",
+                        "description": "File too large",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -2974,7 +2974,7 @@
                         }
                     },
                     "422": {
-                        "description": "Too many photos / no photos",
+                        "description": "Too many files / no files",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7717,7 +7717,7 @@
                 "tags": [
                     "commodities"
                 ],
-                "summary": "Run an AI vision scan on uploaded photos (public)",
+                "summary": "Run an AI vision scan on uploaded photos or documents (public)",
                 "parameters": [
                     {
                         "type": "file",
@@ -7741,7 +7741,7 @@
                         }
                     },
                     "413": {
-                        "description": "Photo too large",
+                        "description": "File too large",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7753,7 +7753,7 @@
                         }
                     },
                     "422": {
-                        "description": "Too many photos / no photos",
+                        "description": "Too many files / no files",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -10242,6 +10242,13 @@
                         "$ref": "#/definitions/jsonapi.CommodityScanFieldGuess"
                     }
                 },
+                "items": {
+                    "description": "Items is present only when the source described more than one\ndistinct product; one entry per product, most prominent first. The\nFE renders a chooser. Empty/absent for a single product.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CommodityScanItem"
+                    }
+                },
                 "latency_ms": {
                     "type": "integer"
                 },
@@ -10265,6 +10272,17 @@
                 "value": {
                     "description": "Value is polymorphic — see the type-level doc comment.",
                     "type": "object"
+                }
+            }
+        },
+        "jsonapi.CommodityScanItem": {
+            "type": "object",
+            "properties": {
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/jsonapi.CommodityScanFieldGuess"
+                    }
                 }
             }
         },
@@ -10301,7 +10319,8 @@
                         "unreadable_serial",
                         "ambiguous_price",
                         "currency_inferred",
-                        "no_photo_text"
+                        "no_photo_text",
+                        "multiple_items"
                     ],
                     "example": "low_confidence"
                 },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -7364,9 +7364,9 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: Extract structured commodity field guesses from 1..N product photos.
-        The handler does not persist any commodity — it only returns structured suggestions
-        for the Add Item dialog to pre-fill.
+      description: Extract structured commodity field guesses from 1..N product photos
+        or PDF documents. The handler does not persist any commodity — it only returns
+        structured suggestions for the Add Item dialog to pre-fill.
       parameters:
       - description: Group slug
         in: path
@@ -7392,7 +7392,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.CommodityScanResponse'
         "413":
-          description: Photo too large
+          description: File too large
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "415":
@@ -7400,7 +7400,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Too many photos / no photos
+          description: Too many files / no files
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "429":
@@ -7419,7 +7419,7 @@ paths:
           description: Provider timed out
           schema:
             $ref: '#/definitions/jsonapi.Errors'
-      summary: Run an AI vision scan on uploaded photos
+      summary: Run an AI vision scan on uploaded photos or documents
       tags:
       - commodities
   /g/{groupSlug}/commodities/values:
@@ -9858,7 +9858,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.CommodityScanResponse'
         "413":
-          description: Photo too large
+          description: File too large
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "415":
@@ -9866,7 +9866,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Too many photos / no photos
+          description: Too many files / no files
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "429":
@@ -9885,7 +9885,7 @@ paths:
           description: Provider timed out
           schema:
             $ref: '#/definitions/jsonapi.Errors'
-      summary: Run an AI vision scan on uploaded photos (public)
+      summary: Run an AI vision scan on uploaded photos or documents (public)
       tags:
       - commodities
   /register:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1465,6 +1465,14 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/jsonapi.CommodityScanFieldGuess'
         type: object
+      items:
+        description: |-
+          Items is present only when the source described more than one
+          distinct product; one entry per product, most prominent first. The
+          FE renders a chooser. Empty/absent for a single product.
+        items:
+          $ref: '#/definitions/jsonapi.CommodityScanItem'
+        type: array
       latency_ms:
         type: integer
       used_tokens:
@@ -1480,6 +1488,13 @@ definitions:
         type: number
       value:
         description: Value is polymorphic — see the type-level doc comment.
+        type: object
+    type: object
+  jsonapi.CommodityScanItem:
+    properties:
+      fields:
+        additionalProperties:
+          $ref: '#/definitions/jsonapi.CommodityScanFieldGuess'
         type: object
     type: object
   jsonapi.CommodityScanResource:
@@ -1506,6 +1521,7 @@ definitions:
         - ambiguous_price
         - currency_inferred
         - no_photo_text
+        - multiple_items
         example: low_confidence
         type: string
       detail:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -7373,8 +7373,8 @@ paths:
         name: groupSlug
         required: true
         type: string
-      - description: Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the
-          form field to upload up to 5 photos in a single request (multipart/form-data
+      - description: Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif
+          or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data
           with multiple `photos` parts).
         in: formData
         name: photos
@@ -9839,8 +9839,8 @@ paths:
         Unauthenticated, IP + global-daily rate limited, gated behind a deployment
         feature flag. Returns field guesses only and persists nothing.
       parameters:
-      - description: Product photo(s); image/jpeg|jpg|png|webp|heic|heif. Repeat the
-          form field to upload up to 5 photos in a single request (multipart/form-data
+      - description: Product photo(s) or PDF document(s); image/jpeg|jpg|png|webp|heic|heif
+          or application/pdf. Repeat the field to upload up to 5 files (multipart/form-data
           with multiple `photos` parts).
         in: formData
         name: photos

--- a/go/internal/aivision/anthropic/anthropic.go
+++ b/go/internal/aivision/anthropic/anthropic.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -39,6 +40,15 @@ const (
 // DefaultModel is the model used when no override is supplied via Config.
 // Operators may override via AI_VISION_ANTHROPIC_MODEL.
 const DefaultModel = "claude-sonnet-4-6"
+
+// DefaultMaxTokens is the output-budget cap used when Config.MaxTokens is
+// unset. It must comfortably hold a multi-line invoice: each product carries
+// ~10 fields, so a handful of products already exceeds the old 1024 cap and
+// the tool-use JSON gets truncated mid-array (→ an empty/partial extraction).
+// 4096 holds well over a dozen products; operators raise it via
+// AI_VISION_MAX_TOKENS for unusually long receipts. It is only a ceiling —
+// the model stops once the products are emitted, so small scans don't pay.
+const DefaultMaxTokens = 4096
 
 // Config carries the runtime knobs. APIKey is required; Model defaults
 // to DefaultModel; BaseURL defaults to the public API; HTTPClient
@@ -84,7 +94,7 @@ func New(cfg Config) (*Provider, error) {
 	}
 	maxTokens := cfg.MaxTokens
 	if maxTokens <= 0 {
-		maxTokens = 1024
+		maxTokens = DefaultMaxTokens
 	}
 	return &Provider{
 		apiKey:     cfg.APIKey,
@@ -206,10 +216,12 @@ type toolChoicePayload struct {
 }
 
 // anthropicResponse is the slice of the upstream response shape we read.
-// We only need usage + content[].input on the tool_use block.
+// We only need usage + content[].input on the tool_use block, plus
+// stop_reason to detect a max_tokens truncation.
 type anthropicResponse struct {
-	Content []anthropicResponseBlock `json:"content"`
-	Usage   *anthropicUsage          `json:"usage,omitempty"`
+	Content    []anthropicResponseBlock `json:"content"`
+	Usage      *anthropicUsage          `json:"usage,omitempty"`
+	StopReason string                   `json:"stop_reason"`
 }
 
 type anthropicResponseBlock struct {
@@ -270,6 +282,14 @@ func parseResponse(body []byte) (*aivision.ScanResult, error) {
 	var resp anthropicResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return nil, errxtrace.Classify(aivision.ErrProviderBadResponse)
+	}
+	// max_tokens truncates the tool-use JSON mid-array, yielding an empty or
+	// partial extraction (the classic "single product works, a multi-line
+	// invoice comes back blank"). Log it loudly so the fix is obvious: raise
+	// AI_VISION_MAX_TOKENS.
+	if resp.StopReason == "max_tokens" {
+		slog.Warn("aivision anthropic response hit max_tokens; extraction may be truncated — raise AI_VISION_MAX_TOKENS",
+			"stop_reason", resp.StopReason)
 	}
 	for _, block := range resp.Content {
 		if block.Type != "tool_use" || len(block.Input) == 0 {

--- a/go/internal/aivision/anthropic/anthropic.go
+++ b/go/internal/aivision/anthropic/anthropic.go
@@ -179,12 +179,16 @@ type messagePayload struct {
 }
 
 type contentBlock struct {
-	Type   string            `json:"type"`
-	Text   string            `json:"text,omitempty"`
-	Source *imageSourceBlock `json:"source,omitempty"`
+	Type   string       `json:"type"`
+	Text   string       `json:"text,omitempty"`
+	Source *sourceBlock `json:"source,omitempty"`
 }
 
-type imageSourceBlock struct {
+// sourceBlock is the base64 payload carried by both an "image" and a
+// "document" content block — Anthropic uses the identical
+// {type,media_type,data} shape for each, only the parent block's Type
+// differs (image vs document, #1983 Part B).
+type sourceBlock struct {
 	Type      string `json:"type"`
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`
@@ -221,9 +225,16 @@ type anthropicUsage struct {
 func (p *Provider) buildPayload(req aivision.ScanRequest) *anthropicRequest {
 	content := make([]contentBlock, 0, len(req.Photos)+1)
 	for _, photo := range req.Photos {
+		// A PDF rides in a "document" block; an image rides in an
+		// "image" block. The base64 source payload is byte-identical
+		// either way (see sourceBlock).
+		blockType := "image"
+		if photo.IsPDF() {
+			blockType = "document"
+		}
 		content = append(content, contentBlock{
-			Type: "image",
-			Source: &imageSourceBlock{
+			Type: blockType,
+			Source: &sourceBlock{
 				Type:      "base64",
 				MediaType: photo.ContentType,
 				Data:      base64.StdEncoding.EncodeToString(photo.Data),
@@ -245,7 +256,7 @@ func (p *Provider) buildPayload(req aivision.ScanRequest) *anthropicRequest {
 		Tools: []toolDeclaration{
 			{
 				Name:        toolName,
-				Description: "Record the structured product extraction the assistant inferred from the photos.",
+				Description: "Record the structured product extraction the assistant inferred from the photos or documents.",
 				InputSchema: aivision.ResponseSchema(),
 			},
 		},

--- a/go/internal/aivision/anthropic/anthropic.go
+++ b/go/internal/aivision/anthropic/anthropic.go
@@ -90,7 +90,10 @@ func New(cfg Config) (*Provider, error) {
 	}
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		// Must exceed the service-layer per-call deadline (AI_VISION_TIMEOUT,
+		// default 60s) so THAT context deadline is the binding one and a slow
+		// multi-product extraction maps to a clean timeout, not a client cap.
+		httpClient = &http.Client{Timeout: 90 * time.Second}
 	}
 	maxTokens := cfg.MaxTokens
 	if maxTokens <= 0 {

--- a/go/internal/aivision/anthropic/anthropic_test.go
+++ b/go/internal/aivision/anthropic/anthropic_test.go
@@ -199,3 +199,24 @@ func TestAnthropicProvider_MarshalTestPayload(t *testing.T) {
 	c.Assert(string(body), qt.Contains, "record_product_extraction")
 	c.Assert(string(body), qt.Contains, "tool_choice")
 }
+
+func TestAnthropicProvider_PDFDocumentBlock(t *testing.T) {
+	c := qt.New(t)
+
+	provider, err := anthropic.New(anthropic.Config{APIKey: "sk-test"})
+	c.Assert(err, qt.IsNil)
+
+	body, err := provider.MarshalTestPayload(aivision.ScanRequest{
+		Photos: []aivision.PhotoInput{
+			{Filename: "receipt.pdf", ContentType: "application/pdf", Data: []byte("%PDF-1.7")},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// A PDF (#1983) rides in a "document" content block whose base64
+	// source carries the application/pdf media_type — never an "image"
+	// block, which the upstream API rejects for non-image media types.
+	c.Assert(string(body), qt.Contains, `"type":"document"`)
+	c.Assert(string(body), qt.Contains, `"media_type":"application/pdf"`)
+	c.Assert(string(body), qt.Not(qt.Contains), `"type":"image"`)
+}

--- a/go/internal/aivision/mock/mock.go
+++ b/go/internal/aivision/mock/mock.go
@@ -232,9 +232,9 @@ func DefaultResult() aivision.ScanResult {
 	}
 }
 
-// MultiItemResult is the canned result the mock returns when a PDF is
-// supplied — a stand-in for a multi-line invoice (two purchased products),
-// so the item-chooser flow is demonstrable with the deterministic provider.
+// MultiItemResult is the canned result the mock returns when the uploaded
+// filename looks like a receipt/invoice — a stand-in for a multi-line invoice
+// (two purchased products), so the item-chooser flow is demonstrable with the deterministic provider.
 // Per the real-provider contract, Fields mirrors the first (most prominent)
 // item. Dates are fixed so screenshots/e2e stay deterministic.
 func MultiItemResult() aivision.ScanResult {

--- a/go/internal/aivision/mock/mock.go
+++ b/go/internal/aivision/mock/mock.go
@@ -223,6 +223,7 @@ func DefaultResult() aivision.ScanResult {
 			aivision.FieldNamePurchaseDate:      {Value: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02"), Confidence: 0.50},
 			aivision.FieldNameWarrantyExpiresAt: {Value: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02"), Confidence: 0.45},
 			aivision.FieldNameComments:          {Value: "Black over-ear wireless headphones with active noise cancellation.", Confidence: 0.65},
+			aivision.FieldNameTags:              {Value: []string{"audio", "headphones", "wireless"}, Confidence: 0.60},
 		},
 		Warnings: []aivision.Warning{
 			{Code: "low_confidence", Field: aivision.FieldNamePurchaseDate, Detail: "purchase date inferred from packaging design only"},
@@ -247,6 +248,7 @@ func MultiItemResult() aivision.ScanResult {
 		aivision.FieldNameOriginalPriceCurrency: {Value: "EUR", Confidence: 0.90},
 		aivision.FieldNamePurchaseDate:          {Value: purchased, Confidence: 0.85},
 		aivision.FieldNameComments:              {Value: "Purchased from Sample Store s.r.o.", Confidence: 0.70},
+		aivision.FieldNameTags:                  {Value: []string{"coffee", "kitchen", "appliance"}, Confidence: 0.60},
 	}
 	frother := map[string]aivision.FieldGuess{
 		aivision.FieldNameName:                  {Value: "Milk Frother", Confidence: 0.86},
@@ -256,6 +258,7 @@ func MultiItemResult() aivision.ScanResult {
 		aivision.FieldNameOriginalPriceCurrency: {Value: "EUR", Confidence: 0.90},
 		aivision.FieldNamePurchaseDate:          {Value: purchased, Confidence: 0.85},
 		aivision.FieldNameComments:              {Value: "Purchased from Sample Store s.r.o.", Confidence: 0.70},
+		aivision.FieldNameTags:                  {Value: []string{"coffee", "kitchen"}, Confidence: 0.60},
 	}
 	return aivision.ScanResult{
 		Fields: espresso,

--- a/go/internal/aivision/mock/mock.go
+++ b/go/internal/aivision/mock/mock.go
@@ -163,9 +163,8 @@ func cloneFieldMap(src map[string]aivision.FieldGuess) map[string]aivision.Field
 	return dst
 }
 
-// cloneFieldValue defensively copies the few slice-typed values we know
-// about (currently only []string for the urls field). Scalar types pass
-// through unchanged.
+// cloneFieldValue defensively copies the slice-typed values we know about
+// (the []string fields: urls and tags). Scalar types pass through unchanged.
 func cloneFieldValue(v any) any {
 	if v == nil {
 		return nil

--- a/go/internal/aivision/mock/mock.go
+++ b/go/internal/aivision/mock/mock.go
@@ -7,6 +7,7 @@ package mock
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/denisvmedia/inventario/internal/aivision"
@@ -83,7 +84,7 @@ func (*Provider) Model() string { return "mock" }
 // next call's result. Deep-copying keeps the mock's behaviour identical
 // to a real provider (which always allocates a fresh struct off the
 // wire) and avoids action-at-a-distance test failures.
-func (p *Provider) Scan(ctx context.Context, _ aivision.ScanRequest) (*aivision.ScanResult, error) {
+func (p *Provider) Scan(ctx context.Context, req aivision.ScanRequest) (*aivision.ScanResult, error) {
 	if override, ok := overrideFromContext(ctx); ok {
 		if override.err != nil {
 			return nil, override.err
@@ -94,32 +95,70 @@ func (p *Provider) Scan(ctx context.Context, _ aivision.ScanRequest) (*aivision.
 	if p.defaultErr != nil {
 		return nil, p.defaultErr
 	}
+	// Simulate a multi-line invoice when the filename looks like one, so the
+	// item-chooser flow is exercisable end-to-end with the deterministic
+	// mock provider (preview stacks / e2e) without a real vendor. We key off
+	// the FILENAME, not the MIME type: an invoice may be a PDF, a scan, an
+	// export, or a photo (jpg/png/heic). Anything else returns the
+	// single-item default.
+	if looksLikeInvoice(req.Photos) {
+		result := cloneScanResult(MultiItemResult())
+		return &result, nil
+	}
 	result := cloneScanResult(p.defaultResult)
 	return &result, nil
 }
 
-// cloneScanResult returns a deep copy of src. Fields (a map) and
-// Warnings (a slice) are reallocated; FieldGuess.Value is left as-is
-// because the concrete types we return are all immutable (string,
-// float64, []string with its own allocated backing array — see the
-// per-field clone for the slice case).
+// looksLikeInvoice is the mock's filename heuristic for "this is a multi-line
+// receipt/invoice" — format-agnostic on purpose (an invoice can be a PDF, a
+// scan, an export, or a photo). Name a file invoice.* / receipt.* / bill.* /
+// faktura.* / paragon.* / uctenka.* to demo the chooser. Real providers
+// decide from the actual content, not the name.
+func looksLikeInvoice(photos []aivision.PhotoInput) bool {
+	keywords := []string{"invoice", "receipt", "bill", "faktura", "paragon", "uctenka", "účtenka"}
+	for _, ph := range photos {
+		name := strings.ToLower(ph.Filename)
+		for _, kw := range keywords {
+			if strings.Contains(name, kw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cloneScanResult returns a deep copy of src. Fields/Items (maps + slice)
+// are reallocated; FieldGuess.Value is cloned per cloneFieldValue. Deep-
+// copying keeps the mock identical to a real provider (fresh struct off
+// the wire) and avoids action-at-a-distance across calls.
 func cloneScanResult(src aivision.ScanResult) aivision.ScanResult {
 	dst := aivision.ScanResult{
 		UsedTokens: src.UsedTokens,
 		LatencyMS:  src.LatencyMS,
+		Fields:     cloneFieldMap(src.Fields),
 	}
-	if src.Fields != nil {
-		dst.Fields = make(map[string]aivision.FieldGuess, len(src.Fields))
-		for k, v := range src.Fields {
-			dst.Fields[k] = aivision.FieldGuess{
-				Value:      cloneFieldValue(v.Value),
-				Confidence: v.Confidence,
-			}
+	if src.Items != nil {
+		dst.Items = make([]aivision.ScanItem, len(src.Items))
+		for i, it := range src.Items {
+			dst.Items[i] = aivision.ScanItem{Fields: cloneFieldMap(it.Fields)}
 		}
 	}
 	if src.Warnings != nil {
 		dst.Warnings = make([]aivision.Warning, len(src.Warnings))
 		copy(dst.Warnings, src.Warnings)
+	}
+	return dst
+}
+
+// cloneFieldMap deep-copies a canonical field map (nil stays nil). Shared
+// by the primary Fields and each item's Fields.
+func cloneFieldMap(src map[string]aivision.FieldGuess) map[string]aivision.FieldGuess {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]aivision.FieldGuess, len(src))
+	for k, v := range src {
+		dst[k] = aivision.FieldGuess{Value: cloneFieldValue(v.Value), Confidence: v.Confidence}
 	}
 	return dst
 }
@@ -187,6 +226,42 @@ func DefaultResult() aivision.ScanResult {
 		},
 		Warnings: []aivision.Warning{
 			{Code: "low_confidence", Field: aivision.FieldNamePurchaseDate, Detail: "purchase date inferred from packaging design only"},
+		},
+		UsedTokens: 0,
+		LatencyMS:  1,
+	}
+}
+
+// MultiItemResult is the canned result the mock returns when a PDF is
+// supplied — a stand-in for a multi-line invoice (two purchased products),
+// so the item-chooser flow is demonstrable with the deterministic provider.
+// Per the real-provider contract, Fields mirrors the first (most prominent)
+// item. Dates are fixed so screenshots/e2e stay deterministic.
+func MultiItemResult() aivision.ScanResult {
+	purchased := time.Date(2024, 3, 14, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+	espresso := map[string]aivision.FieldGuess{
+		aivision.FieldNameName:                  {Value: "Espresso Machine", Confidence: 0.93},
+		aivision.FieldNameShortName:             {Value: "Espresso", Confidence: 0.80},
+		aivision.FieldNameType:                  {Value: "white_goods", Confidence: 0.88},
+		aivision.FieldNameOriginalPrice:         {Value: 449.00, Confidence: 0.90},
+		aivision.FieldNameOriginalPriceCurrency: {Value: "EUR", Confidence: 0.90},
+		aivision.FieldNamePurchaseDate:          {Value: purchased, Confidence: 0.85},
+		aivision.FieldNameComments:              {Value: "Purchased from Sample Store s.r.o.", Confidence: 0.70},
+	}
+	frother := map[string]aivision.FieldGuess{
+		aivision.FieldNameName:                  {Value: "Milk Frother", Confidence: 0.86},
+		aivision.FieldNameShortName:             {Value: "Frother", Confidence: 0.75},
+		aivision.FieldNameType:                  {Value: "electronics", Confidence: 0.80},
+		aivision.FieldNameOriginalPrice:         {Value: 39.90, Confidence: 0.88},
+		aivision.FieldNameOriginalPriceCurrency: {Value: "EUR", Confidence: 0.90},
+		aivision.FieldNamePurchaseDate:          {Value: purchased, Confidence: 0.85},
+		aivision.FieldNameComments:              {Value: "Purchased from Sample Store s.r.o.", Confidence: 0.70},
+	}
+	return aivision.ScanResult{
+		Fields: espresso,
+		Items: []aivision.ScanItem{
+			{Fields: espresso},
+			{Fields: frother},
 		},
 		UsedTokens: 0,
 		LatencyMS:  1,

--- a/go/internal/aivision/mock/mock.go
+++ b/go/internal/aivision/mock/mock.go
@@ -181,8 +181,9 @@ func DefaultResult() aivision.ScanResult {
 			// Fixed purchase date keeps the canned result deterministic
 			// across runs — using time.Now() made every test/screenshot
 			// snapshot drift day-to-day.
-			aivision.FieldNamePurchaseDate: {Value: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02"), Confidence: 0.50},
-			aivision.FieldNameComments:     {Value: "Black over-ear wireless headphones with active noise cancellation.", Confidence: 0.65},
+			aivision.FieldNamePurchaseDate:      {Value: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02"), Confidence: 0.50},
+			aivision.FieldNameWarrantyExpiresAt: {Value: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02"), Confidence: 0.45},
+			aivision.FieldNameComments:          {Value: "Black over-ear wireless headphones with active noise cancellation.", Confidence: 0.65},
 		},
 		Warnings: []aivision.Warning{
 			{Code: "low_confidence", Field: aivision.FieldNamePurchaseDate, Detail: "purchase date inferred from packaging design only"},

--- a/go/internal/aivision/mock/mock_test.go
+++ b/go/internal/aivision/mock/mock_test.go
@@ -70,6 +70,35 @@ func TestMockProvider_WithDefaultError(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, wanted)
 }
 
+func TestMockProvider_InvoiceFilenameReturnsMultipleItems(t *testing.T) {
+	c := qt.New(t)
+	provider := mock.New()
+
+	// An invoice can be a photo/scan, not only a PDF — the mock keys off the
+	// filename, so a JPG named like an invoice yields the multi-item result.
+	result, err := provider.Scan(context.Background(), aivision.ScanRequest{
+		Photos: []aivision.PhotoInput{
+			{Filename: "invoice-scan.jpg", ContentType: "image/jpeg", Data: []byte("x")},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(result.Items) >= 2, qt.IsTrue)
+	// Fields mirrors the first (most prominent) item, per the provider contract.
+	c.Assert(result.Fields[aivision.FieldNameName].Value, qt.Equals, result.Items[0].Fields[aivision.FieldNameName].Value)
+}
+
+func TestMockProvider_PlainPhotoStaysSingleItem(t *testing.T) {
+	c := qt.New(t)
+	provider := mock.New()
+	result, err := provider.Scan(context.Background(), aivision.ScanRequest{
+		Photos: []aivision.PhotoInput{
+			{Filename: "photo.jpg", ContentType: "image/jpeg", Data: []byte("x")},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Items, qt.HasLen, 0)
+}
+
 func TestMockProvider_WithDefaultResult(t *testing.T) {
 	c := qt.New(t)
 	custom := aivision.ScanResult{

--- a/go/internal/aivision/openai/openai.go
+++ b/go/internal/aivision/openai/openai.go
@@ -39,6 +39,12 @@ const (
 // Operators may override via AI_VISION_OPENAI_MODEL.
 const DefaultModel = "gpt-4o"
 
+// DefaultMaxTokens is the output-budget cap used when Config.MaxTokens is
+// unset. A multi-line invoice (one ~10-field product per line) easily blows
+// past the old 1024 cap and the JSON is truncated; 4096 holds well over a
+// dozen products. It is only a ceiling — the model stops once done.
+const DefaultMaxTokens = 4096
+
 // Config carries the runtime knobs. APIKey is required; Model defaults
 // to DefaultModel; BaseURL defaults to the public API; HTTPClient
 // defaults to a 30s-timeout client (separate from the per-call context
@@ -80,7 +86,7 @@ func New(cfg Config) (*Provider, error) {
 	}
 	maxTokens := cfg.MaxTokens
 	if maxTokens <= 0 {
-		maxTokens = 1024
+		maxTokens = DefaultMaxTokens
 	}
 	return &Provider{
 		apiKey:     cfg.APIKey,

--- a/go/internal/aivision/openai/openai.go
+++ b/go/internal/aivision/openai/openai.go
@@ -82,7 +82,10 @@ func New(cfg Config) (*Provider, error) {
 	}
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		// Must exceed the service-layer per-call deadline (AI_VISION_TIMEOUT,
+		// default 60s) so that context deadline is the binding one rather than
+		// this client cap.
+		httpClient = &http.Client{Timeout: 90 * time.Second}
 	}
 	maxTokens := cfg.MaxTokens
 	if maxTokens <= 0 {

--- a/go/internal/aivision/openai/openai.go
+++ b/go/internal/aivision/openai/openai.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	errxtrace "github.com/go-extras/errx/stacktrace"
@@ -171,10 +172,20 @@ type contentBlock struct {
 	Type     string         `json:"type"`
 	Text     string         `json:"text,omitempty"`
 	ImageURL *imageURLBlock `json:"image_url,omitempty"`
+	File     *fileBlock     `json:"file,omitempty"`
 }
 
 type imageURLBlock struct {
 	URL string `json:"url"`
+}
+
+// fileBlock is the "file" content part used to pass a PDF document inline
+// (#1983 Part B). FileData is a base64 data: URL just like image_url's URL;
+// Filename is required by the API for inline file_data, so the provider
+// always sends a non-empty name (see pdfFilename).
+type fileBlock struct {
+	Filename string `json:"filename"`
+	FileData string `json:"file_data"`
 }
 
 type responseFormat struct {
@@ -215,6 +226,19 @@ func (p *Provider) buildPayload(req aivision.ScanRequest) *openaiRequest {
 		Text: aivision.UserPromptHeader(req),
 	})
 	for _, photo := range req.Photos {
+		// A PDF rides in a "file" content part (inline base64 data URL);
+		// an image rides in an "image_url" part. Both encode the bytes as
+		// the same data: URL — only the wrapping part differs.
+		if photo.IsPDF() {
+			content = append(content, contentBlock{
+				Type: "file",
+				File: &fileBlock{
+					Filename: pdfFilename(photo.Filename),
+					FileData: dataURL(photo.ContentType, photo.Data),
+				},
+			})
+			continue
+		}
 		content = append(content, contentBlock{
 			Type: "image_url",
 			ImageURL: &imageURLBlock{
@@ -279,9 +303,21 @@ func parseResponse(body []byte) (*aivision.ScanResult, error) {
 	return result, nil
 }
 
-// dataURL encodes raw image bytes as the data:URL form image_url expects.
+// dataURL encodes raw bytes as the data:URL form image_url / file_data
+// expect.
 func dataURL(contentType string, data []byte) string {
 	return fmt.Sprintf("data:%s;base64,%s", contentType, base64.StdEncoding.EncodeToString(data))
+}
+
+// pdfFilename returns a non-empty filename for a PDF file part. The
+// upstream API wants a name alongside inline file_data; the original
+// upload may not carry one (a multipart part without a filename, or the
+// anonymous path), so fall back to a stable default.
+func pdfFilename(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "document.pdf"
+	}
+	return name
 }
 
 // Compile-time check that the constructor result satisfies the

--- a/go/internal/aivision/openai/openai_test.go
+++ b/go/internal/aivision/openai/openai_test.go
@@ -175,3 +175,42 @@ func TestOpenAIProvider_MarshalTestPayload(t *testing.T) {
 	c.Assert(string(body), qt.Contains, "json_schema")
 	c.Assert(string(body), qt.Contains, "image_url")
 }
+
+func TestOpenAIProvider_PDFFileBlock(t *testing.T) {
+	c := qt.New(t)
+
+	provider, err := openai.New(openai.Config{APIKey: "sk-test"})
+	c.Assert(err, qt.IsNil)
+
+	body, err := provider.MarshalTestPayload(aivision.ScanRequest{
+		Photos: []aivision.PhotoInput{
+			{Filename: "receipt.pdf", ContentType: "application/pdf", Data: []byte("%PDF-1.7")},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// A PDF (#1983) rides in a "file" content part carrying a base64
+	// data: URL plus the original filename — not an image_url part.
+	c.Assert(string(body), qt.Contains, `"type":"file"`)
+	c.Assert(string(body), qt.Contains, `"file_data":"data:application/pdf;base64,`)
+	c.Assert(string(body), qt.Contains, `"filename":"receipt.pdf"`)
+	c.Assert(string(body), qt.Not(qt.Contains), "image_url")
+}
+
+func TestOpenAIProvider_PDFFileBlock_DefaultFilename(t *testing.T) {
+	c := qt.New(t)
+
+	provider, err := openai.New(openai.Config{APIKey: "sk-test"})
+	c.Assert(err, qt.IsNil)
+
+	// A multipart part may arrive without a filename; the provider must
+	// still send a non-empty name (the API requires one alongside inline
+	// file_data).
+	body, err := provider.MarshalTestPayload(aivision.ScanRequest{
+		Photos: []aivision.PhotoInput{
+			{ContentType: "application/pdf", Data: []byte("%PDF-1.7")},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(body), qt.Contains, `"filename":"document.pdf"`)
+}

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -22,6 +22,7 @@ const SystemPrompt = "You are an assistant that extracts structured product info
 	"put the seller/vendor/store name (there is no dedicated seller field) into \"comments\".\n" +
 	"Classify \"type\" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.\n" +
 	"Keep \"short_name\" a concise label of at most 40 characters.\n" +
+	"Suggest 2–5 short, lowercase \"tags\" describing the product (brand, category, material, colour).\n" +
 	"If a warranty period or expiry is shown, set \"warranty_expires_at\" to the warranty END date (YYYY-MM-DD); " +
 	"if only a duration like \"2 years\" is given and the purchase date is known, add the duration to the purchase date.\n" +
 	"Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.\n" +
@@ -128,6 +129,7 @@ func ResponseSchema() map[string]any {
 		FieldNamePurchaseDate:          fieldGuessString,
 		FieldNameWarrantyExpiresAt:     fieldGuessString,
 		FieldNameComments:              fieldGuessString,
+		FieldNameTags:                  fieldGuessStringArray,
 	}
 
 	warningSchema := map[string]any{
@@ -292,7 +294,7 @@ func decodeFieldValue(name string, raw json.RawMessage) (any, bool) {
 			return nil, false
 		}
 		return n, true
-	case FieldNameURLs:
+	case FieldNameURLs, FieldNameTags:
 		var s []string
 		if err := json.Unmarshal(raw, &s); err != nil {
 			return nil, false

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -9,16 +9,24 @@ import (
 // SystemPrompt is the role/system instruction sent to every vendor. It
 // is intentionally short — vendors trim very long system prompts and a
 // concise instruction reduces token spend on every call.
-const SystemPrompt = `You are an assistant that extracts structured product information from photos and documents of a physical item.
-You will receive 1 to 5 inputs describing a single product: photos (front, back, label, packaging, etc.) and/or PDF documents such as a receipt, invoice, or product manual.
-From a receipt or invoice, read the purchase price, currency, and purchase date; put the seller/vendor/store name (there is no dedicated seller field) into "comments".
-Classify "type" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.
-Keep "short_name" a concise label of at most 40 characters.
-If a warranty period or expiry is shown, set "warranty_expires_at" to the warranty END date (YYYY-MM-DD); if only a duration like "2 years" is given and the purchase date is known, add the duration to the purchase date.
-If the inputs clearly describe MORE THAN ONE distinct product, set "fields" to the most prominent one AND list EVERY product (most prominent first) in "items", each as {"fields": {...}}. For a single product, omit "items".
-Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.
-For each field, ALWAYS include a "confidence" score between 0.0 and 1.0 reflecting how sure you are.
-Omit fields you have NO evidence for rather than guessing — null/empty is preferred over hallucinated values.`
+const SystemPrompt = "You are an assistant that extracts structured product information from photos and documents of physical items.\n" +
+	"You will receive 1 to 5 inputs — photos and/or PDFs. They may show a product (front, back, label, packaging, etc.) " +
+	"or a purchase document such as a receipt, invoice, or product manual. A receipt/invoice may itself be a PDF, a scan, " +
+	"an export, or a photo (jpg/png/heic) — handle it the same regardless of format.\n" +
+	"Most inputs describe ONE product — extract it into \"fields\".\n" +
+	"A receipt or invoice often lists SEVERAL purchased products. Whenever more than one distinct product is present, " +
+	"return EACH purchased product as its own entry in \"items\" (most prominent / most expensive first), each shaped as " +
+	"{\"fields\": {...}}, and set the top-level \"fields\" to the first entry. IGNORE non-product lines: subtotals, " +
+	"taxes/VAT, shipping, discounts, fees, deposits, and totals. Omit \"items\" entirely when there is only one product.\n" +
+	"For each product (including each invoice line item), read its purchase price, currency, and purchase date; " +
+	"put the seller/vendor/store name (there is no dedicated seller field) into \"comments\".\n" +
+	"Classify \"type\" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.\n" +
+	"Keep \"short_name\" a concise label of at most 40 characters.\n" +
+	"If a warranty period or expiry is shown, set \"warranty_expires_at\" to the warranty END date (YYYY-MM-DD); " +
+	"if only a duration like \"2 years\" is given and the purchase date is known, add the duration to the purchase date.\n" +
+	"Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.\n" +
+	"For each field, ALWAYS include a \"confidence\" score between 0.0 and 1.0 reflecting how sure you are.\n" +
+	"Omit fields you have NO evidence for rather than guessing — null/empty is preferred over hallucinated values."
 
 // UserPromptHeader is the literal text prepended to the multimodal user
 // turn. It tells the model what task to perform; the actual schema is
@@ -158,7 +166,7 @@ func ResponseSchema() map[string]any {
 			// FE can render/accept a chosen item with the same machinery.
 			"items": map[string]any{
 				"type":        "array",
-				"description": "Present ONLY when the source contains more than one distinct product. One entry per product, most prominent first.",
+				"description": "Present ONLY when the source (e.g. a multi-line receipt or invoice) contains more than one distinct purchased product. One entry per product, most prominent first; exclude tax/subtotal/shipping/discount/total lines.",
 				"items": map[string]any{
 					"type":                 "object",
 					"properties":           map[string]any{"fields": fieldsObject},

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -9,8 +9,9 @@ import (
 // SystemPrompt is the role/system instruction sent to every vendor. It
 // is intentionally short — vendors trim very long system prompts and a
 // concise instruction reduces token spend on every call.
-const SystemPrompt = `You are an assistant that extracts structured product information from photos of physical items.
-You will receive 1 to 5 photos of a single product (front, back, label, packaging, etc.).
+const SystemPrompt = `You are an assistant that extracts structured product information from photos and documents of a physical item.
+You will receive 1 to 5 inputs describing a single product: photos (front, back, label, packaging, etc.) and/or PDF documents such as a receipt, invoice, or product manual.
+From a receipt or invoice, read the purchase price, currency, and purchase date; put the seller/vendor/store name (there is no dedicated seller field) into "comments".
 Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.
 For each field, ALWAYS include a "confidence" score between 0.0 and 1.0 reflecting how sure you are.
 Omit fields you have NO evidence for rather than guessing — null/empty is preferred over hallucinated values.`
@@ -21,7 +22,7 @@ Omit fields you have NO evidence for rather than guessing — null/empty is pref
 // tool-use schema, OpenAI response_format json_schema).
 func UserPromptHeader(req ScanRequest) string {
 	var b strings.Builder
-	b.WriteString("Extract the product information from the attached photo(s).\n")
+	b.WriteString("Extract the product information from the attached photo(s) and/or document(s).\n")
 	if req.PreferredCurrencyCode != "" {
 		fmt.Fprintf(&b, "If a price is visible without a clear currency symbol, prefer currency code %q.\n", req.PreferredCurrencyCode)
 	}

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -12,6 +12,10 @@ import (
 const SystemPrompt = `You are an assistant that extracts structured product information from photos and documents of a physical item.
 You will receive 1 to 5 inputs describing a single product: photos (front, back, label, packaging, etc.) and/or PDF documents such as a receipt, invoice, or product manual.
 From a receipt or invoice, read the purchase price, currency, and purchase date; put the seller/vendor/store name (there is no dedicated seller field) into "comments".
+Classify "type" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.
+Keep "short_name" a concise label of at most 40 characters.
+If a warranty period or expiry is shown, set "warranty_expires_at" to the warranty END date (YYYY-MM-DD); if only a duration like "2 years" is given and the purchase date is known, add the duration to the purchase date.
+If the inputs clearly describe MORE THAN ONE distinct product, extract only the single most prominent item and add a warning {"code":"multiple_items"}.
 Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.
 For each field, ALWAYS include a "confidence" score between 0.0 and 1.0 reflecting how sure you are.
 Omit fields you have NO evidence for rather than guessing — null/empty is preferred over hallucinated values.`
@@ -69,16 +73,52 @@ func ResponseSchema() map[string]any {
 		"required":             []string{"value", "confidence"},
 		"additionalProperties": false,
 	}
+	// fieldGuessStringMax mirrors fieldGuessString but caps the value
+	// length, steering the model toward the form's limit (the FE still
+	// truncates defensively). Used for short_name (40 chars).
+	fieldGuessStringMax := func(maxLen int) map[string]any {
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"value":      map[string]any{"type": "string", "maxLength": maxLen},
+				"confidence": map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+			},
+			"required":             []string{"value", "confidence"},
+			"additionalProperties": false,
+		}
+	}
+	// fieldGuessEnum constrains the value to a closed set of strings so the
+	// model's "type" guess stays inside the categories the FE's isKnownType
+	// accepts — otherwise a valid-but-free-form guess (e.g. "laptop") is
+	// silently dropped instead of pre-filling.
+	fieldGuessEnum := func(values []string) map[string]any {
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"value":      map[string]any{"type": "string", "enum": values},
+				"confidence": map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+			},
+			"required":             []string{"value", "confidence"},
+			"additionalProperties": false,
+		}
+	}
+
+	// commodityTypes mirrors models.CommodityType* and the FE COMMODITY_TYPES
+	// constant. Hardcoded so this vendor-neutral leaf package stays free of a
+	// domain-model dependency; the FE's isKnownType is the authoritative gate,
+	// so any drift only costs a dropped type guess, never a bad write.
+	commodityTypes := []string{"white_goods", "electronics", "equipment", "furniture", "clothes", "other"}
 
 	fields := map[string]any{
 		FieldNameName:                  fieldGuessString,
-		FieldNameShortName:             fieldGuessString,
-		FieldNameType:                  fieldGuessString,
+		FieldNameShortName:             fieldGuessStringMax(40),
+		FieldNameType:                  fieldGuessEnum(commodityTypes),
 		FieldNameOriginalPrice:         fieldGuessNumber,
 		FieldNameOriginalPriceCurrency: fieldGuessString,
 		FieldNameSerialNumber:          fieldGuessString,
 		FieldNameURLs:                  fieldGuessStringArray,
 		FieldNamePurchaseDate:          fieldGuessString,
+		FieldNameWarrantyExpiresAt:     fieldGuessString,
 		FieldNameComments:              fieldGuessString,
 	}
 
@@ -93,6 +133,7 @@ func ResponseSchema() map[string]any {
 					"ambiguous_price",
 					"currency_inferred",
 					"no_photo_text",
+					"multiple_items",
 				},
 			},
 			"field":  map[string]any{"type": "string"},

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -13,16 +13,16 @@ const SystemPrompt = "You are an assistant that extracts structured product info
 	"You will receive 1 to 5 inputs — photos and/or PDFs. They may show a product (front, back, label, packaging, etc.) " +
 	"or a purchase document such as a receipt, invoice, or product manual. A receipt/invoice may itself be a PDF, a scan, " +
 	"an export, or a photo (jpg/png/heic) — handle it the same regardless of format.\n" +
-	"Most inputs describe ONE product — extract it into \"fields\".\n" +
-	"A receipt or invoice often lists SEVERAL purchased products. Whenever more than one distinct product is present, " +
-	"return EACH purchased product as its own entry in \"items\" (most prominent / most expensive first), each shaped as " +
-	"{\"fields\": {...}}, and set the top-level \"fields\" to the first entry. IGNORE non-product lines: subtotals, " +
-	"taxes/VAT, shipping, discounts, fees, deposits, and totals. Omit \"items\" entirely when there is only one product.\n" +
-	"For each product (including each invoice line item), read its purchase price, currency, and purchase date; " +
+	"Return \"items\": a JSON array with ONE entry per distinct purchased product, most prominent / most expensive first, " +
+	"each shaped as {\"fields\": {...}}.\n" +
+	"A single product → a one-element array. A receipt or invoice that lists SEVERAL products → one entry for EACH " +
+	"product line. Do NOT collapse them into one and do NOT pick just one — enumerate EVERY product on the document.\n" +
+	"EXCLUDE non-product lines: subtotals, taxes/VAT, shipping/postage, discounts, vouchers, fees, deposits, and totals.\n" +
+	"For each product, from a receipt/invoice read its own purchase price, currency, and purchase date; " +
 	"put the seller/vendor/store name (there is no dedicated seller field) into \"comments\".\n" +
 	"Classify \"type\" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.\n" +
 	"Keep \"short_name\" a concise label of at most 40 characters.\n" +
-	"Suggest 2–5 short, lowercase \"tags\" describing the product (brand, category, material, colour).\n" +
+	"Suggest 2–5 short, lowercase \"tags\" describing each product (brand, category, material, colour).\n" +
 	"If a warranty period or expiry is shown, set \"warranty_expires_at\" to the warranty END date (YYYY-MM-DD); " +
 	"if only a duration like \"2 years\" is given and the purchase date is known, add the duration to the purchase date.\n" +
 	"Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.\n" +
@@ -159,16 +159,21 @@ func ResponseSchema() map[string]any {
 		"additionalProperties": false,
 	}
 
+	// items is the REQUIRED primary output: a list of products. Making the
+	// model produce a list (rather than a single `fields` object) is what
+	// reliably gets every line of a multi-product invoice enumerated instead
+	// of the model picking just one. A single product is simply a 1-element
+	// array. The service derives the single-item `fields` from items[0].
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"fields": fieldsObject,
-			// items is present ONLY when the source describes more than one
-			// distinct product; each entry mirrors the `fields` shape so the
-			// FE can render/accept a chosen item with the same machinery.
 			"items": map[string]any{
-				"type":        "array",
-				"description": "Present ONLY when the source (e.g. a multi-line receipt or invoice) contains more than one distinct purchased product. One entry per product, most prominent first; exclude tax/subtotal/shipping/discount/total lines.",
+				"type":     "array",
+				"minItems": 1,
+				"description": "ONE entry per distinct purchased product (most prominent / most expensive first). " +
+					"A single product is a one-element array; a multi-line receipt or invoice has one entry for EACH " +
+					"product line — never collapse them and never return just one. " +
+					"Exclude tax/subtotal/shipping/discount/total lines.",
 				"items": map[string]any{
 					"type":                 "object",
 					"properties":           map[string]any{"fields": fieldsObject},
@@ -181,7 +186,7 @@ func ResponseSchema() map[string]any {
 				"items": warningSchema,
 			},
 		},
-		"required":             []string{"fields"},
+		"required":             []string{"items"},
 		"additionalProperties": false,
 	}
 }
@@ -231,26 +236,33 @@ func ToScanResult(body []byte) (*ScanResult, error) {
 		Warnings: append([]Warning(nil), raw.Warnings...),
 	}
 
-	fields, fieldWarnings := decodeFieldMap(raw.Fields)
-	out.Fields = fields
-	out.Warnings = append(out.Warnings, fieldWarnings...)
-
-	// Optional multi-item list. Per-item type mismatches are dropped
-	// silently (the primary fields already surfaced any warning); empty
-	// items are skipped so a stray {} doesn't render a blank choice.
+	// items is the model's primary output now (one entry per product). Decode
+	// each, dropping empties so a stray {} never renders a blank choice.
+	var products []ScanItem
 	for _, it := range raw.Items {
 		itemFields, _ := decodeFieldMap(it.Fields)
 		if len(itemFields) == 0 {
 			continue
 		}
-		out.Items = append(out.Items, ScanItem{Fields: itemFields})
+		products = append(products, ScanItem{Fields: itemFields})
 	}
 
-	// Defensive: if the model only populated items and left fields empty,
-	// mirror the most prominent item so single-item consumers (and the
-	// audit ResultJSON) still see a primary extraction.
-	if len(out.Fields) == 0 && len(out.Items) > 0 {
-		out.Fields = out.Items[0].Fields
+	// Primary single-item view: prefer an explicit top-level `fields`
+	// (back-compat with older single-product responses and provider tests),
+	// otherwise the first product. Type-mismatch warnings surface for the
+	// primary only.
+	primary, primaryWarnings := decodeFieldMap(raw.Fields)
+	switch {
+	case len(primary) > 0:
+		out.Fields = primary
+		out.Warnings = append(out.Warnings, primaryWarnings...)
+	case len(products) > 0:
+		out.Fields = products[0].Fields
+	}
+
+	// Expose Items to the FE only when there's an actual choice to make.
+	if len(products) > 1 {
+		out.Items = products
 	}
 
 	return out, nil

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -13,8 +13,8 @@ const SystemPrompt = "You are an assistant that extracts structured product info
 	"You will receive 1 to 5 inputs — photos and/or PDFs. They may show a product (front, back, label, packaging, etc.) " +
 	"or a purchase document such as a receipt, invoice, or product manual. A receipt/invoice may itself be a PDF, a scan, " +
 	"an export, or a photo (jpg/png/heic) — handle it the same regardless of format.\n" +
-	"Return \"items\": a JSON array with ONE entry per distinct purchased product, most prominent / most expensive first, " +
-	"each shaped as {\"fields\": {...}}.\n" +
+	"Return \"items\": a JSON array with ONE entry per distinct purchased product, most prominent / most expensive first. " +
+	"Each entry is that product's field object directly (name, short_name, type, original_price, original_price_currency, etc.).\n" +
 	"A single product → a one-element array. A receipt or invoice that lists SEVERAL products → one entry for EACH " +
 	"product line. Do NOT collapse them into one and do NOT pick just one — enumerate EVERY product on the document.\n" +
 	"EXCLUDE non-product lines: subtotals, taxes/VAT, shipping/postage, discounts, vouchers, fees, deposits, and totals.\n" +
@@ -173,13 +173,12 @@ func ResponseSchema() map[string]any {
 				"description": "ONE entry per distinct purchased product (most prominent / most expensive first). " +
 					"A single product is a one-element array; a multi-line receipt or invoice has one entry for EACH " +
 					"product line — never collapse them and never return just one. " +
-					"Exclude tax/subtotal/shipping/discount/total lines.",
-				"items": map[string]any{
-					"type":                 "object",
-					"properties":           map[string]any{"fields": fieldsObject},
-					"required":             []string{"fields"},
-					"additionalProperties": false,
-				},
+					"Exclude tax/subtotal/shipping/discount/total lines. Each entry is the product's field object.",
+				// Each item IS the field object directly (flat) — one nesting
+				// level, which the model follows far more reliably than a
+				// wrapper object. ToScanResult also accepts the legacy
+				// {"fields": {...}} shape defensively.
+				"items": fieldsObject,
 			},
 			"warnings": map[string]any{
 				"type":  "array",
@@ -203,13 +202,33 @@ func ResponseSchemaJSON() ([]byte, error) {
 // converts to the public ScanResult type.
 type rawScanResponse struct {
 	Fields   map[string]rawFieldGuess `json:"fields"`
-	Items    []rawScanItem            `json:"items"`
+	Items    []json.RawMessage        `json:"items"`
 	Warnings []Warning                `json:"warnings"`
 }
 
-// rawScanItem mirrors one entry of the optional multi-item array.
-type rawScanItem struct {
-	Fields map[string]rawFieldGuess `json:"fields"`
+// decodeRawItem decodes one entry of the items[] array into a field map. It
+// accepts BOTH shapes so model variance can't blank the result:
+//   - flat: the entry IS the field map (the schema we now request),
+//     e.g. {"name": {...}, "type": {...}}
+//   - nested: a {"fields": {...}} wrapper (legacy / some responses)
+//
+// Whichever yields a non-empty field map wins (flat is tried first).
+func decodeRawItem(raw json.RawMessage) map[string]FieldGuess {
+	var flat map[string]rawFieldGuess
+	if err := json.Unmarshal(raw, &flat); err == nil {
+		if f, _ := decodeFieldMap(flat); len(f) > 0 {
+			return f
+		}
+	}
+	var nested struct {
+		Fields map[string]rawFieldGuess `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &nested); err == nil && len(nested.Fields) > 0 {
+		if f, _ := decodeFieldMap(nested.Fields); len(f) > 0 {
+			return f
+		}
+	}
+	return nil
 }
 
 // rawFieldGuess uses json.RawMessage on Value so the same schema can
@@ -240,7 +259,7 @@ func ToScanResult(body []byte) (*ScanResult, error) {
 	// each, dropping empties so a stray {} never renders a blank choice.
 	var products []ScanItem
 	for _, it := range raw.Items {
-		itemFields, _ := decodeFieldMap(it.Fields)
+		itemFields := decodeRawItem(it)
 		if len(itemFields) == 0 {
 			continue
 		}

--- a/go/internal/aivision/prompt.go
+++ b/go/internal/aivision/prompt.go
@@ -15,7 +15,7 @@ From a receipt or invoice, read the purchase price, currency, and purchase date;
 Classify "type" as EXACTLY one of the allowed values in the schema enum; omit it if none clearly fits.
 Keep "short_name" a concise label of at most 40 characters.
 If a warranty period or expiry is shown, set "warranty_expires_at" to the warranty END date (YYYY-MM-DD); if only a duration like "2 years" is given and the purchase date is known, add the duration to the purchase date.
-If the inputs clearly describe MORE THAN ONE distinct product, extract only the single most prominent item and add a warning {"code":"multiple_items"}.
+If the inputs clearly describe MORE THAN ONE distinct product, set "fields" to the most prominent one AND list EVERY product (most prominent first) in "items", each as {"fields": {...}}. For a single product, omit "items".
 Return ONE JSON object that matches the requested schema EXACTLY. Do not include any prose, markdown, or extra keys.
 For each field, ALWAYS include a "confidence" score between 0.0 and 1.0 reflecting how sure you are.
 Omit fields you have NO evidence for rather than guessing — null/empty is preferred over hallucinated values.`
@@ -143,13 +143,28 @@ func ResponseSchema() map[string]any {
 		"additionalProperties": false,
 	}
 
+	fieldsObject := map[string]any{
+		"type":                 "object",
+		"properties":           fields,
+		"additionalProperties": false,
+	}
+
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"fields": map[string]any{
-				"type":                 "object",
-				"properties":           fields,
-				"additionalProperties": false,
+			"fields": fieldsObject,
+			// items is present ONLY when the source describes more than one
+			// distinct product; each entry mirrors the `fields` shape so the
+			// FE can render/accept a chosen item with the same machinery.
+			"items": map[string]any{
+				"type":        "array",
+				"description": "Present ONLY when the source contains more than one distinct product. One entry per product, most prominent first.",
+				"items": map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"fields": fieldsObject},
+					"required":             []string{"fields"},
+					"additionalProperties": false,
+				},
 			},
 			"warnings": map[string]any{
 				"type":  "array",
@@ -173,7 +188,13 @@ func ResponseSchemaJSON() ([]byte, error) {
 // converts to the public ScanResult type.
 type rawScanResponse struct {
 	Fields   map[string]rawFieldGuess `json:"fields"`
+	Items    []rawScanItem            `json:"items"`
 	Warnings []Warning                `json:"warnings"`
+}
+
+// rawScanItem mirrors one entry of the optional multi-item array.
+type rawScanItem struct {
+	Fields map[string]rawFieldGuess `json:"fields"`
 }
 
 // rawFieldGuess uses json.RawMessage on Value so the same schema can
@@ -197,31 +218,59 @@ func ToScanResult(body []byte) (*ScanResult, error) {
 	}
 
 	out := &ScanResult{
-		Fields:   make(map[string]FieldGuess, len(raw.Fields)),
 		Warnings: append([]Warning(nil), raw.Warnings...),
 	}
 
+	fields, fieldWarnings := decodeFieldMap(raw.Fields)
+	out.Fields = fields
+	out.Warnings = append(out.Warnings, fieldWarnings...)
+
+	// Optional multi-item list. Per-item type mismatches are dropped
+	// silently (the primary fields already surfaced any warning); empty
+	// items are skipped so a stray {} doesn't render a blank choice.
+	for _, it := range raw.Items {
+		itemFields, _ := decodeFieldMap(it.Fields)
+		if len(itemFields) == 0 {
+			continue
+		}
+		out.Items = append(out.Items, ScanItem{Fields: itemFields})
+	}
+
+	// Defensive: if the model only populated items and left fields empty,
+	// mirror the most prominent item so single-item consumers (and the
+	// audit ResultJSON) still see a primary extraction.
+	if len(out.Fields) == 0 && len(out.Items) > 0 {
+		out.Fields = out.Items[0].Fields
+	}
+
+	return out, nil
+}
+
+// decodeFieldMap converts a raw vendor field map into the public FieldGuess
+// map, dropping unknown keys and type-mismatched values. It returns the
+// decoded fields plus a (possibly empty) list of "low_confidence" warnings
+// for values whose type didn't match the field's expected shape. Shared by
+// the primary `fields` and each `items[].fields`.
+func decodeFieldMap(raw map[string]rawFieldGuess) (map[string]FieldGuess, []Warning) {
+	out := make(map[string]FieldGuess, len(raw))
+	var warnings []Warning
 	for _, name := range AllFieldNames {
-		rg, ok := raw.Fields[name]
+		rg, ok := raw[name]
 		if !ok {
 			continue
 		}
 		val, ok := decodeFieldValue(name, rg.Value)
 		if !ok {
-			// Field came back but in the wrong shape. Surface as a
-			// warning so the FE can still render the rest of the
-			// extraction; drop the unparseable value.
-			out.Warnings = append(out.Warnings, Warning{
+			warnings = append(warnings, Warning{
 				Code:   "low_confidence",
 				Field:  name,
 				Detail: "field value did not match expected type",
 			})
 			continue
 		}
-		out.Fields[name] = FieldGuess{Value: val, Confidence: rg.Confidence}
+		out[name] = FieldGuess{Value: val, Confidence: rg.Confidence}
 	}
-
-	return out, nil
+	return out, warnings
 }
 
 // decodeFieldValue maps the JSON-typed raw value to the Go concrete

--- a/go/internal/aivision/prompt_test.go
+++ b/go/internal/aivision/prompt_test.go
@@ -17,7 +17,17 @@ func TestResponseSchema_TypeEnumWarrantyShortNameMultiItem(t *testing.T) {
 	schema := aivision.ResponseSchema()
 
 	props := schema["properties"].(map[string]any)
-	fields := props["fields"].(map[string]any)["properties"].(map[string]any)
+
+	// items[] is the REQUIRED primary output — a list of products. Making the
+	// model produce a list is what gets every invoice line enumerated.
+	items := props["items"].(map[string]any)
+	c.Assert(items["type"], qt.Equals, "array")
+	c.Assert(items["minItems"], qt.Equals, 1)
+	c.Assert(schema["required"], qt.DeepEquals, []string{"items"})
+
+	// Each item carries the shared `fields` object — where the per-field
+	// constraints (type enum, short_name cap, warranty) live.
+	fields := items["items"].(map[string]any)["properties"].(map[string]any)["fields"].(map[string]any)["properties"].(map[string]any)
 
 	fieldValue := func(name string) map[string]any {
 		return fields[name].(map[string]any)["properties"].(map[string]any)["value"].(map[string]any)
@@ -33,20 +43,15 @@ func TestResponseSchema_TypeEnumWarrantyShortNameMultiItem(t *testing.T) {
 	// "short_name" carries the 40-char cap that mirrors the form limit.
 	c.Assert(fieldValue(aivision.FieldNameShortName)["maxLength"], qt.Equals, 40)
 
-	// "warranty_expires_at" is part of the extracted set.
+	// "warranty_expires_at" and "tags" are part of the extracted set.
 	_, hasWarranty := fields[aivision.FieldNameWarrantyExpiresAt]
 	c.Assert(hasWarranty, qt.IsTrue)
+	_, hasTags := fields[aivision.FieldNameTags]
+	c.Assert(hasTags, qt.IsTrue)
 
 	// "multiple_items" is an allowed warning code.
 	codeEnum := props["warnings"].(map[string]any)["items"].(map[string]any)["properties"].(map[string]any)["code"].(map[string]any)["enum"].([]string)
 	c.Assert(codeEnum, qt.Contains, "multiple_items")
-
-	// items[] is an array whose entries carry the same `fields` object.
-	items := props["items"].(map[string]any)
-	c.Assert(items["type"], qt.Equals, "array")
-	itemEntry := items["items"].(map[string]any)
-	_, hasItemFields := itemEntry["properties"].(map[string]any)["fields"]
-	c.Assert(hasItemFields, qt.IsTrue)
 }
 
 func TestToScanResult_MultiItem(t *testing.T) {
@@ -74,12 +79,26 @@ func TestToScanResult_SingleItem_NoItems(t *testing.T) {
 	c.Assert(res.Fields["name"].Value, qt.Equals, "Only")
 }
 
-func TestToScanResult_ItemsOnly_MirrorsPrimary(t *testing.T) {
+func TestToScanResult_ItemsOnly_SingleProduct(t *testing.T) {
 	c := qt.New(t)
-	// Model left `fields` empty but populated `items` — Fields mirrors the
-	// first item so single-item consumers still see a primary extraction.
-	res, err := aivision.ToScanResult([]byte(`{"fields":{},"items":[{"fields":{"name":{"value":"A","confidence":0.9}}}]}`))
+	// New contract: the model returns only `items`. A single product → Fields
+	// mirrors items[0] and Items stays empty (no chooser for one product).
+	res, err := aivision.ToScanResult([]byte(`{"items":[{"fields":{"name":{"value":"A","confidence":0.9}}}]}`))
 	c.Assert(err, qt.IsNil)
 	c.Assert(res.Fields["name"].Value, qt.Equals, "A")
-	c.Assert(res.Items, qt.HasLen, 1)
+	c.Assert(res.Items, qt.HasLen, 0)
+}
+
+func TestToScanResult_ItemsOnly_MultiProduct(t *testing.T) {
+	c := qt.New(t)
+	// New contract, multi-product invoice: only `items`, several entries.
+	res, err := aivision.ToScanResult([]byte(`{"items":[
+		{"fields":{"name":{"value":"Pampers","confidence":0.9}}},
+		{"fields":{"name":{"value":"Calculator","confidence":0.8}}},
+		{"fields":{"name":{"value":"Cleaner","confidence":0.7}}}
+	]}`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Items, qt.HasLen, 3)
+	c.Assert(res.Fields["name"].Value, qt.Equals, "Pampers")
+	c.Assert(res.Items[1].Fields["name"].Value, qt.Equals, "Calculator")
 }

--- a/go/internal/aivision/prompt_test.go
+++ b/go/internal/aivision/prompt_test.go
@@ -40,4 +40,46 @@ func TestResponseSchema_TypeEnumWarrantyShortNameMultiItem(t *testing.T) {
 	// "multiple_items" is an allowed warning code.
 	codeEnum := props["warnings"].(map[string]any)["items"].(map[string]any)["properties"].(map[string]any)["code"].(map[string]any)["enum"].([]string)
 	c.Assert(codeEnum, qt.Contains, "multiple_items")
+
+	// items[] is an array whose entries carry the same `fields` object.
+	items := props["items"].(map[string]any)
+	c.Assert(items["type"], qt.Equals, "array")
+	itemEntry := items["items"].(map[string]any)
+	_, hasItemFields := itemEntry["properties"].(map[string]any)["fields"]
+	c.Assert(hasItemFields, qt.IsTrue)
+}
+
+func TestToScanResult_MultiItem(t *testing.T) {
+	c := qt.New(t)
+	body := []byte(`{
+		"fields": { "name": {"value":"Primary","confidence":0.9} },
+		"items": [
+			{ "fields": { "name": {"value":"Primary","confidence":0.9}, "original_price": {"value":10.5,"confidence":0.8} } },
+			{ "fields": { "name": {"value":"Second","confidence":0.7} } }
+		]
+	}`)
+	res, err := aivision.ToScanResult(body)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Fields["name"].Value, qt.Equals, "Primary")
+	c.Assert(res.Items, qt.HasLen, 2)
+	c.Assert(res.Items[0].Fields["original_price"].Value, qt.Equals, 10.5)
+	c.Assert(res.Items[1].Fields["name"].Value, qt.Equals, "Second")
+}
+
+func TestToScanResult_SingleItem_NoItems(t *testing.T) {
+	c := qt.New(t)
+	res, err := aivision.ToScanResult([]byte(`{"fields":{"name":{"value":"Only","confidence":0.9}}}`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Items, qt.HasLen, 0)
+	c.Assert(res.Fields["name"].Value, qt.Equals, "Only")
+}
+
+func TestToScanResult_ItemsOnly_MirrorsPrimary(t *testing.T) {
+	c := qt.New(t)
+	// Model left `fields` empty but populated `items` — Fields mirrors the
+	// first item so single-item consumers still see a primary extraction.
+	res, err := aivision.ToScanResult([]byte(`{"fields":{},"items":[{"fields":{"name":{"value":"A","confidence":0.9}}}]}`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Fields["name"].Value, qt.Equals, "A")
+	c.Assert(res.Items, qt.HasLen, 1)
 }

--- a/go/internal/aivision/prompt_test.go
+++ b/go/internal/aivision/prompt_test.go
@@ -25,9 +25,9 @@ func TestResponseSchema_TypeEnumWarrantyShortNameMultiItem(t *testing.T) {
 	c.Assert(items["minItems"], qt.Equals, 1)
 	c.Assert(schema["required"], qt.DeepEquals, []string{"items"})
 
-	// Each item carries the shared `fields` object — where the per-field
+	// Each item IS the field object directly (flat) — where the per-field
 	// constraints (type enum, short_name cap, warranty) live.
-	fields := items["items"].(map[string]any)["properties"].(map[string]any)["fields"].(map[string]any)["properties"].(map[string]any)
+	fields := items["items"].(map[string]any)["properties"].(map[string]any)
 
 	fieldValue := func(name string) map[string]any {
 		return fields[name].(map[string]any)["properties"].(map[string]any)["value"].(map[string]any)
@@ -100,5 +100,21 @@ func TestToScanResult_ItemsOnly_MultiProduct(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(res.Items, qt.HasLen, 3)
 	c.Assert(res.Fields["name"].Value, qt.Equals, "Pampers")
+	c.Assert(res.Items[1].Fields["name"].Value, qt.Equals, "Calculator")
+}
+
+func TestToScanResult_FlatItems(t *testing.T) {
+	c := qt.New(t)
+	// The schema we now request: each item IS the field map (no `fields`
+	// wrapper). This is the shape that was blanking the review before the
+	// parser learned to accept it.
+	res, err := aivision.ToScanResult([]byte(`{"items":[
+		{"name":{"value":"Pampers","confidence":0.9},"original_price":{"value":434,"confidence":0.9}},
+		{"name":{"value":"Calculator","confidence":0.8}}
+	]}`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Items, qt.HasLen, 2)
+	c.Assert(res.Fields["name"].Value, qt.Equals, "Pampers")
+	c.Assert(res.Items[0].Fields["original_price"].Value, qt.Equals, float64(434))
 	c.Assert(res.Items[1].Fields["name"].Value, qt.Equals, "Calculator")
 }

--- a/go/internal/aivision/prompt_test.go
+++ b/go/internal/aivision/prompt_test.go
@@ -1,0 +1,43 @@
+package aivision_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/internal/aivision"
+)
+
+// TestResponseSchema_TypeEnumWarrantyShortNameMultiItem locks the parts of
+// the structured-output contract that steer prefill quality: a closed
+// commodity-type enum, the short_name length cap, the warranty field, and
+// the multiple_items warning code.
+func TestResponseSchema_TypeEnumWarrantyShortNameMultiItem(t *testing.T) {
+	c := qt.New(t)
+	schema := aivision.ResponseSchema()
+
+	props := schema["properties"].(map[string]any)
+	fields := props["fields"].(map[string]any)["properties"].(map[string]any)
+
+	fieldValue := func(name string) map[string]any {
+		return fields[name].(map[string]any)["properties"].(map[string]any)["value"].(map[string]any)
+	}
+
+	// "type" is constrained to the commodity-type categories so a valid
+	// guess isn't dropped by the FE's isKnownType gate.
+	typeEnum, ok := fieldValue(aivision.FieldNameType)["enum"].([]string)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(typeEnum, qt.Contains, "electronics")
+	c.Assert(typeEnum, qt.Contains, "white_goods")
+
+	// "short_name" carries the 40-char cap that mirrors the form limit.
+	c.Assert(fieldValue(aivision.FieldNameShortName)["maxLength"], qt.Equals, 40)
+
+	// "warranty_expires_at" is part of the extracted set.
+	_, hasWarranty := fields[aivision.FieldNameWarrantyExpiresAt]
+	c.Assert(hasWarranty, qt.IsTrue)
+
+	// "multiple_items" is an allowed warning code.
+	codeEnum := props["warnings"].(map[string]any)["items"].(map[string]any)["properties"].(map[string]any)["code"].(map[string]any)["enum"].([]string)
+	c.Assert(codeEnum, qt.Contains, "multiple_items")
+}

--- a/go/internal/aivision/provider.go
+++ b/go/internal/aivision/provider.go
@@ -111,7 +111,7 @@ type ScanRequest struct {
 //   - original_price: float64 (decimal as string is also accepted by
 //     callers, which coerce it to a number)
 //   - urls: []string
-//   - purchase_date: string in YYYY-MM-DD form
+//   - purchase_date, warranty_expires_at: string in YYYY-MM-DD form
 type FieldGuess struct {
 	Value      any     `json:"value"`
 	Confidence float64 `json:"confidence"`
@@ -124,7 +124,9 @@ type FieldGuess struct {
 type Warning struct {
 	// Code is a stable identifier the FE branches on. Known values:
 	// "low_confidence", "unreadable_serial", "ambiguous_price",
-	// "currency_inferred", "no_photo_text".
+	// "currency_inferred", "no_photo_text", "multiple_items" (the source
+	// describes more than one distinct product; only the most prominent
+	// one was extracted).
 	Code string `json:"code"`
 	// Field is the affected ScanResult.Fields key, or "" when the
 	// warning is global.
@@ -212,6 +214,7 @@ const (
 	FieldNameSerialNumber          FieldName = "serial_number"
 	FieldNameURLs                  FieldName = "urls"
 	FieldNamePurchaseDate          FieldName = "purchase_date"
+	FieldNameWarrantyExpiresAt     FieldName = "warranty_expires_at"
 	FieldNameComments              FieldName = "comments"
 )
 
@@ -226,5 +229,6 @@ var AllFieldNames = []FieldName{
 	FieldNameSerialNumber,
 	FieldNameURLs,
 	FieldNamePurchaseDate,
+	FieldNameWarrantyExpiresAt,
 	FieldNameComments,
 }

--- a/go/internal/aivision/provider.go
+++ b/go/internal/aivision/provider.go
@@ -55,20 +55,34 @@ type Provider interface {
 	Scan(ctx context.Context, req ScanRequest) (*ScanResult, error)
 }
 
-// PhotoInput is a single user-uploaded image handed to the provider as
-// raw bytes plus its (already-detected) MIME type. The service guarantees
-// MIME and size pre-checks; providers may still reject content the
-// upstream vendor declines (e.g. some vendors reject HEIC).
+// PhotoInput is a single user-uploaded source handed to the provider as
+// raw bytes plus its (already-detected) MIME type. Despite the name it
+// carries either a product image OR a PDF document (a receipt, invoice,
+// or manual — #1983 Part B); IsPDF distinguishes the two so each provider
+// can pick the right content-block shape. The service guarantees MIME and
+// size pre-checks; providers may still reject content the upstream vendor
+// declines (e.g. some vendors reject HEIC).
 type PhotoInput struct {
 	// Filename is the original filename for diagnostics; never used as
-	// a security boundary.
+	// a security boundary. Some vendors (OpenAI) require it on a PDF
+	// content part, so it is forwarded verbatim for documents.
 	Filename string
 	// ContentType is the detected MIME type (image/jpeg, image/png,
-	// image/webp, image/heic, image/heif).
+	// image/webp, image/heic, image/heif, or application/pdf).
 	ContentType string
-	// Data is the raw image bytes.
+	// Data is the raw image or PDF bytes.
 	Data []byte
 }
+
+// PDFMediaType is the canonical MIME type for the document (non-image)
+// inputs the scan pipeline accepts. Declared here, next to PhotoInput, so
+// the providers and the service-layer allowlist agree on a single string.
+const PDFMediaType = "application/pdf"
+
+// IsPDF reports whether this input is a PDF document rather than an image.
+// Providers branch on it to emit a document/file content block instead of
+// an image block.
+func (p PhotoInput) IsPDF() bool { return p.ContentType == PDFMediaType }
 
 // ScanRequest is the structured input to Provider.Scan. All fields apart
 // from Photos are optional hints that improve prompt quality without

--- a/go/internal/aivision/provider.go
+++ b/go/internal/aivision/provider.go
@@ -144,8 +144,17 @@ type Warning struct {
 type ScanResult struct {
 	// Fields is keyed by canonical field name. The provider populates
 	// only fields it has evidence for; absent keys mean "no signal" and
-	// the FE leaves the form input blank.
+	// the FE leaves the form input blank. When Items carries more than
+	// one candidate, Fields mirrors the most prominent one (Items[0]) so
+	// single-item consumers keep working unchanged.
 	Fields map[string]FieldGuess `json:"fields"`
+	// Items is populated ONLY when the source describes more than one
+	// distinct product (a multi-line receipt, a photo of several items):
+	// one entry per product, most prominent first. The FE renders a
+	// chooser so the user picks which one to pre-fill. Empty/absent for
+	// the common single-product case (the FE goes straight to review off
+	// Fields).
+	Items []ScanItem `json:"items,omitempty"`
 	// Warnings is the non-fatal note list. nil and empty are
 	// equivalent.
 	Warnings []Warning `json:"warnings,omitempty"`
@@ -156,6 +165,15 @@ type ScanResult struct {
 	// LatencyMS is the wall-clock duration of the upstream call,
 	// measured server-side, used for audit and observability.
 	LatencyMS int64 `json:"latency_ms,omitempty"`
+}
+
+// ScanItem is one candidate product in a multi-product scan. It carries
+// the same canonical Fields map as the single-item ScanResult.Fields, so
+// the FE renders/accepts a chosen item with the exact same machinery.
+type ScanItem struct {
+	// Fields is keyed by canonical field name; same shape and semantics
+	// as ScanResult.Fields.
+	Fields map[string]FieldGuess `json:"fields"`
 }
 
 // Sentinel errors returned by Provider implementations and the registry

--- a/go/internal/aivision/provider.go
+++ b/go/internal/aivision/provider.go
@@ -110,7 +110,7 @@ type ScanRequest struct {
 //     original_price_currency: string
 //   - original_price: float64 (decimal as string is also accepted by
 //     callers, which coerce it to a number)
-//   - urls: []string
+//   - urls, tags: []string
 //   - purchase_date, warranty_expires_at: string in YYYY-MM-DD form
 type FieldGuess struct {
 	Value      any     `json:"value"`
@@ -234,6 +234,7 @@ const (
 	FieldNamePurchaseDate          FieldName = "purchase_date"
 	FieldNameWarrantyExpiresAt     FieldName = "warranty_expires_at"
 	FieldNameComments              FieldName = "comments"
+	FieldNameTags                  FieldName = "tags"
 )
 
 // AllFieldNames is the closed set used by tests and by the prompt
@@ -249,4 +250,5 @@ var AllFieldNames = []FieldName{
 	FieldNamePurchaseDate,
 	FieldNameWarrantyExpiresAt,
 	FieldNameComments,
+	FieldNameTags,
 }

--- a/go/internal/aivision/registry_test.go
+++ b/go/internal/aivision/registry_test.go
@@ -82,7 +82,7 @@ func TestAllFieldNames_Closed(t *testing.T) {
 
 	expected := []string{
 		"name", "short_name", "type", "original_price", "original_price_currency",
-		"serial_number", "urls", "purchase_date", "warranty_expires_at", "comments",
+		"serial_number", "urls", "purchase_date", "warranty_expires_at", "comments", "tags",
 	}
 	c.Assert(aivision.AllFieldNames, qt.DeepEquals, expected)
 }

--- a/go/internal/aivision/registry_test.go
+++ b/go/internal/aivision/registry_test.go
@@ -82,7 +82,7 @@ func TestAllFieldNames_Closed(t *testing.T) {
 
 	expected := []string{
 		"name", "short_name", "type", "original_price", "original_price_currency",
-		"serial_number", "urls", "purchase_date", "comments",
+		"serial_number", "urls", "purchase_date", "warranty_expires_at", "comments",
 	}
 	c.Assert(aivision.AllFieldNames, qt.DeepEquals, expected)
 }

--- a/go/jsonapi/commodity_scan.go
+++ b/go/jsonapi/commodity_scan.go
@@ -19,10 +19,20 @@ type CommodityScanResource struct {
 // original_price_currency, serial_number, urls, purchase_date,
 // comments); warnings is the optional non-fatal note list.
 type CommodityScanAttributes struct {
-	Fields     map[string]CommodityScanFieldGuess `json:"fields"`
-	Warnings   []CommodityScanWarning             `json:"warnings,omitempty"`
-	UsedTokens int                                `json:"used_tokens,omitempty"`
-	LatencyMS  int64                              `json:"latency_ms,omitempty"`
+	Fields map[string]CommodityScanFieldGuess `json:"fields"`
+	// Items is present only when the source described more than one
+	// distinct product; one entry per product, most prominent first. The
+	// FE renders a chooser. Empty/absent for a single product.
+	Items      []CommodityScanItem    `json:"items,omitempty"`
+	Warnings   []CommodityScanWarning `json:"warnings,omitempty"`
+	UsedTokens int                    `json:"used_tokens,omitempty"`
+	LatencyMS  int64                  `json:"latency_ms,omitempty"`
+}
+
+// CommodityScanItem is one candidate product in a multi-product scan; its
+// fields mirror CommodityScanAttributes.Fields.
+type CommodityScanItem struct {
+	Fields map[string]CommodityScanFieldGuess `json:"fields"`
 }
 
 // CommodityScanFieldGuess is the per-field extraction value plus a
@@ -49,7 +59,7 @@ type CommodityScanFieldGuess struct {
 // CommodityScanWarning is a non-fatal note attached to a scan
 // response. code is a stable identifier the FE branches on.
 type CommodityScanWarning struct {
-	Code   string `json:"code" example:"low_confidence" enums:"low_confidence,unreadable_serial,ambiguous_price,currency_inferred,no_photo_text"`
+	Code   string `json:"code" example:"low_confidence" enums:"low_confidence,unreadable_serial,ambiguous_price,currency_inferred,no_photo_text,multiple_items"`
 	Field  string `json:"field,omitempty"`
 	Detail string `json:"detail,omitempty"`
 }

--- a/go/jsonapi/commodity_scan.go
+++ b/go/jsonapi/commodity_scan.go
@@ -17,7 +17,9 @@ type CommodityScanResource struct {
 // CommodityScanAttributes is the result body. fields is keyed by
 // canonical field name (name, short_name, type, original_price,
 // original_price_currency, serial_number, urls, purchase_date,
-// comments); warnings is the optional non-fatal note list.
+// warranty_expires_at, comments, tags); items carries one such field set
+// per product on a multi-product scan; warnings is the optional non-fatal
+// note list.
 type CommodityScanAttributes struct {
 	Fields map[string]CommodityScanFieldGuess `json:"fields"`
 	// Items is present only when the source described more than one
@@ -47,9 +49,10 @@ type CommodityScanItem struct {
 // override (the value is not always an object, and not always strings):
 //
 //   - name, short_name, type, serial_number, comments,
-//     original_price_currency, purchase_date (YYYY-MM-DD): string
+//     original_price_currency, purchase_date,
+//     warranty_expires_at (both YYYY-MM-DD): string
 //   - original_price: number (decimal)
-//   - urls: string[]
+//   - urls, tags: string[]
 type CommodityScanFieldGuess struct {
 	// Value is polymorphic — see the type-level doc comment.
 	Value      any     `json:"value" swaggertype:"object"`

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -373,7 +373,7 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 
 	fields = append(fields,
 		validation.Field(&a.Name, rules.NotEmpty, validation.Length(1, 255)),
-		validation.Field(&a.ShortName, rules.NotEmpty, validation.Length(1, 20)),
+		validation.Field(&a.ShortName, rules.NotEmpty, validation.Length(1, 40)),
 		validation.Field(&a.Type, rules.NotEmpty),
 		validation.Field(&a.Status, rules.NotEmpty),
 		validation.Field(&a.PurchaseDate, whenNotDraft.WithRules(rules.NotEmpty)),

--- a/go/models/commodity_test.go
+++ b/go/models/commodity_test.go
@@ -595,7 +595,7 @@ func TestCommodity_ValidateWithContext_NameLength(t *testing.T) {
 
 	// Create a very long name
 	longName := strings.Repeat("a", 256)
-	longShortName := strings.Repeat("a", 30)
+	longShortName := strings.Repeat("a", 41)
 
 	testCases := []struct {
 		name          string
@@ -634,7 +634,7 @@ func TestCommodity_ValidateWithContext_NameLength(t *testing.T) {
 				Status:                 models.CommodityStatusInUse,
 				PurchaseDate:           models.ToPDate("2023-01-01"),
 			},
-			errorContains: "the length must be between 1 and 20",
+			errorContains: "the length must be between 1 and 40",
 		},
 	}
 

--- a/go/services/commodity_scan_service.go
+++ b/go/services/commodity_scan_service.go
@@ -135,7 +135,7 @@ type CommodityScanConfig struct {
 	Timeout time.Duration
 }
 
-// AllowedMIMETypes is the closed list of image MIME types accepted by
+// AllowedMIMETypes is the closed list of source MIME types accepted by
 // CommodityScanService. The set matches what every supported provider
 // can handle — HEIC/HEIF are included because phones still upload them
 // even when "share as JPEG" is the default.
@@ -145,13 +145,21 @@ type CommodityScanConfig struct {
 // canonical "image/jpeg". Accepting it here is a one-line ergonomic
 // fix that avoids surprising the FE with a 415 on perfectly valid JPEG
 // bytes; the providers normalise the byte stream anyway.
+//
+// "application/pdf" (#1983 Part B) lets a user prefill from a document —
+// a receipt, invoice, or manual — not just a product photo. Both real
+// providers (Anthropic Messages, OpenAI Chat Completions) accept PDFs
+// natively as a document/file content block, so the bytes flow through
+// the same pipeline; only the per-vendor content-block shape differs
+// (see each provider's buildPayload).
 var AllowedMIMETypes = map[string]bool{
-	"image/jpeg": true,
-	"image/jpg":  true, // noncanonical alias some browsers emit for JPEGs
-	"image/png":  true,
-	"image/webp": true,
-	"image/heic": true,
-	"image/heif": true,
+	"image/jpeg":      true,
+	"image/jpg":       true, // noncanonical alias some browsers emit for JPEGs
+	"image/png":       true,
+	"image/webp":      true,
+	"image/heic":      true,
+	"image/heif":      true,
+	"application/pdf": true, // receipts / invoices / manuals (#1983)
 }
 
 // CommodityScanService coordinates the photo-scan flow: rate limit, →

--- a/go/services/commodity_scan_service.go
+++ b/go/services/commodity_scan_service.go
@@ -153,13 +153,13 @@ type CommodityScanConfig struct {
 // the same pipeline; only the per-vendor content-block shape differs
 // (see each provider's buildPayload).
 var AllowedMIMETypes = map[string]bool{
-	"image/jpeg":      true,
-	"image/jpg":       true, // noncanonical alias some browsers emit for JPEGs
-	"image/png":       true,
-	"image/webp":      true,
-	"image/heic":      true,
-	"image/heif":      true,
-	"application/pdf": true, // receipts / invoices / manuals (#1983)
+	"image/jpeg":          true,
+	"image/jpg":           true, // noncanonical alias some browsers emit for JPEGs
+	"image/png":           true,
+	"image/webp":          true,
+	"image/heic":          true,
+	"image/heif":          true,
+	aivision.PDFMediaType: true, // receipts / invoices / manuals (#1983)
 }
 
 // CommodityScanService coordinates the photo-scan flow: rate limit, →

--- a/go/services/commodity_scan_service_test.go
+++ b/go/services/commodity_scan_service_test.go
@@ -36,7 +36,7 @@ func pdfDoc(name string, bytes int) services.ScanPhotoInput {
 	copy(data, []byte("%PDF-1.7\n"))
 	return services.ScanPhotoInput{
 		Filename:    name,
-		ContentType: "application/pdf",
+		ContentType: aivision.PDFMediaType,
 		Data:        data,
 	}
 }

--- a/go/services/commodity_scan_service_test.go
+++ b/go/services/commodity_scan_service_test.go
@@ -31,6 +31,16 @@ func jpegPhoto(name string, bytes int) services.ScanPhotoInput {
 	}
 }
 
+func pdfDoc(name string, bytes int) services.ScanPhotoInput {
+	data := make([]byte, bytes)
+	copy(data, []byte("%PDF-1.7\n"))
+	return services.ScanPhotoInput{
+		Filename:    name,
+		ContentType: "application/pdf",
+		Data:        data,
+	}
+}
+
 func TestCommodityScanService_HappyPath_AuditWritten(t *testing.T) {
 	c := qt.New(t)
 
@@ -113,6 +123,27 @@ func TestCommodityScanService_UnsupportedMIME(t *testing.T) {
 	}
 	_, err := svc.Scan(context.Background(), "tenant-1", "user-1", in)
 	c.Assert(err, qt.ErrorIs, services.ErrScanUnsupportedMIME)
+}
+
+func TestCommodityScanService_AcceptsPDF(t *testing.T) {
+	c := qt.New(t)
+
+	audit := memory.NewCommodityScanAuditRegistry()
+	svc := services.NewCommodityScanService(mock.New(), audit, services.CommodityScanConfig{
+		MaxPhotos:     5,
+		MaxPhotoBytes: 1024,
+	})
+
+	// A PDF receipt/invoice is a valid scan source (#1983 Part B): it must
+	// pass validation, reach the provider, and write the usual audit row —
+	// not be rejected as an unsupported MIME type.
+	result, err := svc.Scan(context.Background(), "tenant-1", "user-1", newScanInput(pdfDoc("receipt.pdf", 256)))
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.IsNotNil)
+
+	count, err := audit.CountRecentForUser(context.Background(), "tenant-1", "user-1", time.Now().Add(-1*time.Hour))
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
 }
 
 func TestCommodityScanService_RateLimited(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Summary

- **AI scan accepts PDFs** (receipts / invoices / manuals) alongside product photos — **Part B of #1983**. `application/pdf` joins `services.AllowedMIMETypes`; Anthropic sends it as a `document` content block and OpenAI as a `file` content part; the prompt is format-agnostic (a receipt/invoice can be a PDF, scan, export, or photo).
- **Multi-product invoices → a chooser.** The model returns `items[]` (one entry per purchased product, required so it enumerates every line instead of picking one); when there's more than one the dialog shows a "choose which item to add" step, otherwise it goes straight to review. `AI_VISION_MAX_TOKENS` (default 4096) was added so a long invoice's JSON isn't truncated.
- **Richer extraction:** `type` is constrained to the commodity-type enum, `short_name` is capped at 40 (form limit bumped 20→40), new `warranty_expires_at` and `tags` fields, and seller/vendor → `comments`. An AI-guessed currency (e.g. CZK) is validated synchronously against the FE's bundled currency set so a valid code pre-fills regardless of the `/currencies` fetch.
- **Manual-entry UX:** the **Back** button on the Basics step rewinds to the AI scan surface whenever AI vision is enabled — in **any mode**, including reopening a saved draft for editing (only the *opening* step stays create-only: edit mode opens on Basics). The scanning indicator is now a moving (indeterminate) progress bar.

Out of scope (tracked separately): **#1983 Part A** — persisting/attaching the scanned source files to the created commodity.

## Related issues

Refs #1983 (Part B), #1720, #1976

## Test plan

- [x] `make lint` — `go vet` + `golangci-lint` clean on the touched Go packages
- [x] `make test` — provider wire-shape + multi-item `ToScanResult` (flat/nested), schema contract, service PDF-accept, apiserver swagger route coverage
- [x] Swagger / codegen — regenerated; `codegen:check` clean
- [x] (frontend) `make test-frontend` — `tsc`, full `eslint`, `prettier --check`, `vitest` (incl. PDF tile, item chooser, Back→AI in edit mode, currency/warranty/tags, empty-extraction guard)
- [ ] (frontend) `make test-e2e` — not run locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * AI scan now accepts PDF documents (receipts, invoices, manuals) alongside photos
  * Multi-product extraction: automatically identifies and separates multiple items from a single document
  * New fields: warranty expiration date and product tags now extracted from scans

* **Improvements**
  * Extended product name character limit from 20 to 40
  * Increased AI vision processing timeout from 20s to 60s for complex documents
  * Enhanced file upload interface to support mixed photo/PDF workflows
  * Added product selection phase when multiple items are detected in a single scan

<!-- end of auto-generated comment: release notes by coderabbit.ai -->