### PR TITLE
fix(commodities): warranty "Upload Receipt" opens the upload dialog (#2012)

### DIFF
--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -852,7 +852,20 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
             </>
           ) : tab === "warranty" ? (
-            <WarrantyTab commodity={commodity} onSwitchToFiles={() => setTab("files")} />
+            <WarrantyTab
+              commodity={commodity}
+              onUploadReceipt={() => {
+                // #2012: open the upload dialog directly (commodity
+                // preselected) — the same dialog the Files-tab dropzone
+                // opens — instead of just switching tabs and leaving the
+                // user to hunt for the dropzone. Switch the underlying
+                // tab to Files too so the newly uploaded receipt is
+                // visible once the dialog closes.
+                setTab("files")
+                setPendingDropFiles([])
+                setUploadOpen(true)
+              }}
+            />
           ) : tab === "lend" ? (
             <LendTab
               commodityId={commodity?.id ?? id}
@@ -1488,16 +1501,19 @@ function FilesTab({
 
 interface WarrantyTabProps {
   commodity?: Commodity
-  // Optional. When provided, renders an "Upload Receipt" CTA that
-  // jumps to the Files tab so the user can drop the warranty PDF
-  // there instead of inventing a per-commodity upload widget.
-  onSwitchToFiles?: () => void
+  // Optional. When provided, renders an "Upload Receipt" CTA that opens
+  // the page-level UploadFilesDialog with this commodity preselected —
+  // the same dialog the Files-tab dropzone opens (#2012) — instead of
+  // inventing a per-commodity upload widget. The page wires this to
+  // open the dialog and switch the Files tab underneath.
+  onUploadReceipt?: () => void
 }
 
 // WarrantyTab renders the first-class warranty surface (#1367):
 // status-coloured card + expiry-with-days-remaining line + notes block
-// + an "Upload Receipt" CTA pointing at the Files tab. Layout mirrors
-// the design mock (`inventario-design/src/components/ItemDetail.tsx`,
+// + an "Upload Receipt" CTA that opens the upload dialog (#2012).
+// Layout mirrors the design mock
+// (`inventario-design/src/components/ItemDetail.tsx`,
 // `<TabsContent value="warranty">`); the design mock CLAUDE.md
 // requires that warranty status colours go through the canonical
 // WarrantyBadge / `WARRANTY_STATUS_CONFIG` so all four surfaces
@@ -1505,7 +1521,7 @@ interface WarrantyTabProps {
 //
 // The form inputs themselves live in the commodity edit dialog's
 // Warranty step — this tab stays read-only.
-function WarrantyTab({ commodity, onSwitchToFiles }: WarrantyTabProps) {
+function WarrantyTab({ commodity, onUploadReceipt }: WarrantyTabProps) {
   const { t } = useTranslation()
   // #1554: bundle commodities don't carry a warranty — render the
   // "split into separate items" hint instead of the live pill / notes
@@ -1591,13 +1607,13 @@ function WarrantyTab({ commodity, onSwitchToFiles }: WarrantyTabProps) {
             {t("commodities:detail.warranty.emptyState")}
           </p>
         ) : null}
-        {onSwitchToFiles ? (
+        {onUploadReceipt ? (
           <Button
             type="button"
             variant="outline"
             size="sm"
             className="w-fit gap-1.5"
-            onClick={onSwitchToFiles}
+            onClick={onUploadReceipt}
             data-testid="commodity-detail-warranty-upload-receipt"
           >
             <FileText className="size-3.5" aria-hidden="true" />

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -191,6 +191,10 @@ describe("<CommodityDetailPage />", () => {
     const dialog = await screen.findByTestId("files-upload-dialog")
     expect(dialog).toBeInTheDocument()
     expect(dialog).toHaveTextContent(/MacBook Pro 16/)
+    // …and it switches the underlying tab to Files (#2012) so the newly
+    // uploaded receipt is visible once the dialog closes — the Files tab
+    // content mounts behind the modal.
+    expect(await screen.findByTestId("commodity-detail-files")).toBeInTheDocument()
   })
 
   it("preselects the Warranty tab when the URL has ?tab=warranty (#1529)", async () => {

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -169,6 +169,30 @@ describe("<CommodityDetailPage />", () => {
     expect(await screen.findByTestId("commodity-detail-files")).toBeInTheDocument()
   })
 
+  it("opens the upload dialog directly from the Warranty tab's Upload Receipt CTA (#2012)", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture),
+      ...fileHandlers.list(SLUG, []),
+      ...fileHandlers.counts(SLUG, {})
+    )
+    renderDetail(`/g/${SLUG}/commodities/${ID}?tab=warranty`)
+    const uploadReceipt = await screen.findByTestId("commodity-detail-warranty-upload-receipt")
+    // Regression guard: before #2012 this button only switched to the
+    // Files tab and the user had to hunt for the dropzone. The dialog
+    // must not be open until the CTA is clicked.
+    expect(screen.queryByTestId("files-upload-dialog")).toBeNull()
+    await user.click(uploadReceipt)
+    // The CTA now opens the page-level UploadFilesDialog directly — the
+    // same dialog the Files-tab dropzone opens — with this commodity
+    // preselected (the title carries the commodity name).
+    const dialog = await screen.findByTestId("files-upload-dialog")
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveTextContent(/MacBook Pro 16/)
+  })
+
   it("preselects the Warranty tab when the URL has ?tab=warranty (#1529)", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),


### PR DESCRIPTION
## What

Fixes #2012.

On a commodity's **Warranty** tab, the **Upload Receipt** CTA only switched the view to the **Files** tab and stopped there — the user then had to find and click the upload dropzone manually to actually upload a receipt.

This points the button at the same upload-dialog opener the Files tab already uses. Clicking **Upload Receipt** now:

- opens the page-level `UploadFilesDialog` **directly**, with the commodity preselected (the same dialog the Files-tab dropzone opens), and
- switches the underlying tab to **Files** so the newly uploaded receipt is visible once the dialog closes.

So it's one click instead of "switch tab, then go hunt for the dropzone".

## How

- `CommodityDetailContent` wires `WarrantyTab` with an `onUploadReceipt` handler that does `setTab("files")` + `setPendingDropFiles([])` + `setUploadOpen(true)` — reusing the existing `UploadFilesDialog` wiring (`#1448`) rather than inventing a per-commodity upload widget.
- `WarrantyTab`'s prop is renamed `onSwitchToFiles` → `onUploadReceipt` to match the new behaviour; the button + doc comments updated accordingly. The `data-testid` (`commodity-detail-warranty-upload-receipt`) is unchanged.

## Tests

- New vitest regression test in `CommodityDetailPage.test.tsx`: clicking the Warranty-tab **Upload Receipt** CTA opens `files-upload-dialog` (with the commodity name in the title), instead of just switching tabs. Asserts the dialog is closed beforehand.
- `npm run typecheck`, `npm run lint`, `npm run format:check`, and the full `CommodityDetailPage.test.tsx` suite (26 tests) pass locally.

## Notes

Frontend-only change. No backend, schema, or i18n changes. The button label/appearance is unchanged — only its action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The "Upload Receipt" button in the warranty tab now directly opens the file upload dialog.

* **Tests**
  * Added test coverage to verify the "Upload Receipt" dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->