### PR TITLE
feat(settings): merge "Contact support" into the feedback entry point (+ fix 503 maintenance bounce)

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -371,6 +371,7 @@ _None yet._
 - **Why**: A real ticketing system / contact form is a larger surface. `mailto:` is the lowest-friction stand-in that doesn't depend on an in-app destination that doesn't exist yet.
 - **Approved by**: agent-suggested.
 - **Reversion plan**: Swap the href for a real `/support` route or a dialog when the support surface lands.
+- **Resolution**: Resolved 2026-06-06 by #1387 / PR #2014 — the static `mailto:` row was folded into the in-app feedback entry point. The "Send feedback" row was relabelled "Contact support / share feedback" and now opens the existing `FeedbackDialog` (whose "Question" type doubles as the support channel); the `mailto:` row, its i18n keys, and the `HelpSection` external-link (`<a>`) render arm were removed. No `<a>`/`mailto` remains in the section.
 
 #### 2026-05-08 — "Currency migrations" history list inside Danger Zone
 

--- a/e2e/tests/feedback.spec.ts
+++ b/e2e/tests/feedback.spec.ts
@@ -1,8 +1,9 @@
 /**
  * E2E for the in-app feedback dialog (#1387).
  *
- * Drives the full flow: open Settings → Help, click the "Send feedback"
- * row, fill in the form, submit, and assert the success toast.
+ * Drives the full flow: open Settings → Help, click the "Contact
+ * support / share feedback" row, fill in the form, submit, and assert
+ * the success toast.
  *
  * The backend defaults to the stub email service in the e2e harness so
  * the POST /api/v1/feedback request goes all the way through the
@@ -21,7 +22,8 @@ test.describe('Send feedback dialog (#1387)', () => {
     await page.locator('[data-testid="settings-nav-help"]').click();
     await expect(page.locator('[data-testid="section-help"]')).toBeVisible();
 
-    // Click the "Send feedback" row — it opens the FeedbackDialog.
+    // Click the "Contact support / share feedback" row — it opens the
+    // FeedbackDialog.
     await page.locator('[data-testid="help-row-feedback"]').click();
     const dialog = page.locator('[data-testid="feedback-dialog"]');
     await expect(dialog).toBeVisible();

--- a/frontend/src/components/feedback/FeedbackDialog.tsx
+++ b/frontend/src/components/feedback/FeedbackDialog.tsx
@@ -9,10 +9,11 @@
 //   - Rate-limited at the BE (5/hour/user). On 429 we surface a
 //     friendly "try again later" toast.
 //   - On 503 (SUPPORT_EMAIL not configured) we surface a "feedback
-//     isn't set up on this deployment" toast that tells the user to
-//     email support directly. This is a real operator state —
-//     single-tenant deployments may not bother wiring SUPPORT_EMAIL
-//     at all.
+//     isn't configured on this deployment yet" toast. The BE returns a
+//     *typed* 503 (feedback.not_configured) so lib/http.ts doesn't read
+//     it as an outage and bounce the shell to /maintenance. This is a
+//     real operator state — single-tenant deployments may not bother
+//     wiring SUPPORT_EMAIL at all.
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useId, useMemo } from "react"
 import { useForm } from "react-hook-form"

--- a/frontend/src/components/feedback/FeedbackDialog.tsx
+++ b/frontend/src/components/feedback/FeedbackDialog.tsx
@@ -7,12 +7,12 @@
 //     already enforces auth; the BE returns 401 if a stray request
 //     somehow lands here without a session.
 //   - Rate-limited at the BE (5/hour/user). On 429 we surface a
-//     friendly "try again later" toast that points at the static
-//     mailto fallback in Settings → Help.
+//     friendly "try again later" toast.
 //   - On 503 (SUPPORT_EMAIL not configured) we surface a "feedback
-//     isn't set up on this deployment" toast that also points at the
-//     mailto fallback. This is a real operator state — single-tenant
-//     deployments may not bother wiring SUPPORT_EMAIL at all.
+//     isn't set up on this deployment" toast that tells the user to
+//     email support directly. This is a real operator state —
+//     single-tenant deployments may not bother wiring SUPPORT_EMAIL
+//     at all.
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useId, useMemo } from "react"
 import { useForm } from "react-hook-form"

--- a/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { http as msw, HttpResponse } from "msw"
+import { http as msw, HttpResponse, delay } from "msw"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -13,6 +13,7 @@ import { server } from "@/test/server"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
+import { __resetNavigationForTests, setNavigateToMaintenance } from "@/lib/navigation"
 
 const api = (path: string) => `${window.location.origin}/api/v1${path}`
 
@@ -50,6 +51,7 @@ beforeEach(() => {
   clearAuth()
   __resetGroupContextForTests()
   __resetHttpForTests()
+  __resetNavigationForTests()
 })
 
 describe("<FeedbackDialog />", () => {
@@ -141,5 +143,56 @@ describe("<FeedbackDialog />", () => {
     await waitFor(() => {
       expect(onOpenChange).not.toHaveBeenCalledWith(false)
     })
+  })
+
+  it("keeps the dialog open (no /maintenance bounce) on a typed 503 not-configured error", async () => {
+    // Regression: on deployments without SUPPORT_EMAIL the BE returns 503.
+    // It used to be an untyped text/plain 503, which tripped the global
+    // 503 → /maintenance bounce in lib/http.ts and unmounted the whole
+    // shell instead of letting the dialog show its toast. The BE now
+    // returns a *typed* `feedback.not_configured` code (mirrors the
+    // commodity_scan #1720 contract); the dialog must stay put.
+    const navigate = vi.fn()
+    setNavigateToMaintenance(navigate)
+    server.use(
+      ...baseUserHandlers,
+      msw.post(api("/feedback"), async () => {
+        // Small delay so the in-flight (disabled) → settled (enabled)
+        // transition on the submit button is observable below.
+        await delay(30)
+        return HttpResponse.json(
+          {
+            errors: [
+              {
+                status: "503",
+                code: "feedback.not_configured",
+                error: "feedback is not configured on this deployment",
+              },
+            ],
+          },
+          { status: 503 }
+        )
+      })
+    )
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+
+    await waitFor(() => expect(screen.getByTestId("feedback-message")).toBeInTheDocument())
+    await user.type(screen.getByTestId("feedback-message"), "anyone home?")
+    const submit = screen.getByTestId("feedback-submit")
+    await user.click(submit)
+
+    // Drive the full submit cycle so the negative assertion isn't vacuous:
+    // the button disables while the request is in flight, then re-enables
+    // once the 503 has been received AND the global bounce decision (in
+    // lib/http.ts) has run. Only then is "navigate not called" meaningful.
+    await waitFor(() => expect(submit).toBeDisabled())
+    await waitFor(() => expect(submit).not.toBeDisabled())
+
+    // The typed product 503 must NOT bounce the shell to /maintenance…
+    expect(navigate).not.toHaveBeenCalled()
+    // …and the dialog stays open so the user keeps their typed message.
+    expect(screen.getByTestId("feedback-dialog")).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
 })

--- a/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
@@ -160,13 +160,23 @@ describe("<FeedbackDialog />", () => {
         // Small delay so the in-flight (disabled) → settled (enabled)
         // transition on the submit button is observable below.
         await delay(30)
+        // Mirror the real jsonapi.Errors payload the BE emits for the
+        // errx sentinel (see apiserver/feedback.go): `status` is a text
+        // label, `error` is an errormarshal object, and `code` carries
+        // the dotted product code lib/http.ts keys off.
         return HttpResponse.json(
           {
             errors: [
               {
-                status: "503",
+                status: "Service Unavailable",
+                error: {
+                  error: {
+                    message: "feedback is not configured on this deployment",
+                    sentinels: ["feedback is not configured on this deployment"],
+                  },
+                  type: "*errx.sentinel",
+                },
                 code: "feedback.not_configured",
-                error: "feedback is not configured on this deployment",
               },
             ],
           },

--- a/frontend/src/i18n/locales/en/feedback.json
+++ b/frontend/src/i18n/locales/en/feedback.json
@@ -17,7 +17,7 @@
   },
   "toasts": {
     "error": "Couldn't send your feedback. Please try again.",
-    "notConfigured": "Feedback isn't configured on this deployment. Please email support directly.",
+    "notConfigured": "Feedback isn't configured on this deployment yet.",
     "rateLimited": "You've sent a lot of feedback recently. Please try again in a few minutes.",
     "success": "Thanks — your feedback was sent."
   },

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -64,12 +64,10 @@
   },
   "help": {
     "rows": {
-      "contactSupport": "Contact support",
-      "contactSupportDescription": "Get help from the team.",
       "documentation": "Documentation",
       "documentationDescription": "Browse guides and tutorials.",
-      "feedback": "Send feedback",
-      "feedbackDescription": "Help us improve Inventario.",
+      "feedback": "Contact support / share feedback",
+      "feedbackDescription": "Ask the team for help, report a bug, or tell us what to build next.",
       "shortcuts": "Keyboard shortcuts",
       "shortcutsDescription": "View every keyboard shortcut used across the app.",
       "whatsNew": "What's new",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -911,14 +911,15 @@ function HelpSection() {
   const shortcutsDialog = useKeyboardShortcutsDialog()
   const [feedbackOpen, setFeedbackOpen] = useState(false)
 
-  // Five rows: docs (#1384), shortcuts (#1385 — opens the cheat-sheet
+  // Four rows: docs (#1384), shortcuts (#1385 — opens the cheat-sheet
   // modal in-place), what's new (#1386 — with a marketing v{Major.Minor}
-  // badge per design-audit #1536), send feedback (#1387 — opens the
-  // FeedbackDialog in-place), contact support (mailto fallback while a
-  // real ticketing surface is scoped). Real destinations behind each
-  // route are ComingSoonPage already; this section mostly acts as a
-  // discovery aid.
-  type HelpRowKey = "documentation" | "shortcuts" | "whatsNew" | "feedback" | "contactSupport"
+  // badge per design-audit #1536), and "Contact support / share
+  // feedback" (#1387 — opens the FeedbackDialog in-place). The dialog's
+  // "Question" type doubles as the contact-support channel, so the
+  // former static mailto row was folded into this single entry point.
+  // Real destinations behind each route are ComingSoonPage already;
+  // this section mostly acts as a discovery aid.
+  type HelpRowKey = "documentation" | "shortcuts" | "whatsNew" | "feedback"
   // `href: "modal:shortcuts"` → renders a click-to-open <button> wired
   //   to the keyboard-shortcuts dialog. `href: "modal:feedback"` →
   //   opens the FeedbackDialog. Using a sentinel string keeps the row
@@ -928,7 +929,6 @@ function HelpSection() {
     { key: "shortcuts", href: "modal:shortcuts" },
     { key: "whatsNew", href: "/whats-new" },
     { key: "feedback", href: "modal:feedback" },
-    { key: "contactSupport", href: "mailto:support@inventario.app" },
   ]
 
   const versionShort = shortAppVersion(APP_VERSION)
@@ -938,13 +938,12 @@ function HelpSection() {
       <SectionTitle>{t("settings:help.title")}</SectionTitle>
       <div className="rounded-xl border border-border divide-y divide-border">
         {rows.map(({ key, href }) => {
-          // Three-arm union: modal trigger (in-app dialog), external
-          // (mailto), or in-app route. All three use the same chrome —
-          // chevron-right + label + description. The version Badge only
-          // renders on the "whatsNew" row.
+          // Two-arm union: modal trigger (in-app dialog) or in-app
+          // route. Both use the same chrome — chevron-right + label +
+          // description. The version Badge only renders on the
+          // "whatsNew" row.
           const labelKey = key
           const isModal = href.startsWith("modal:")
-          const isExternal = href.startsWith("mailto:") || href.startsWith("http")
           const RowInner = (
             <>
               <div className="flex items-center gap-2">
@@ -976,19 +975,6 @@ function HelpSection() {
                 <div>{RowInner}</div>
                 <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
               </button>
-            )
-          }
-          if (isExternal) {
-            return (
-              <a
-                key={key}
-                href={href}
-                data-testid={`help-row-${key}`}
-                className="flex items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
-              >
-                <div>{RowInner}</div>
-                <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
-              </a>
             )
           }
           return (

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -364,13 +364,31 @@ describe("<SettingsPage />", () => {
     })
   })
 
-  it("help section adds a Contact support row and a version badge on What's new", async () => {
+  it("help section shows the merged support/feedback row and a version badge on What's new", async () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()
     renderSettings()
     await user.click(await screen.findByTestId("settings-nav-help"))
-    expect(screen.getByTestId("help-row-contactSupport")).toBeInTheDocument()
+    // #1387 folded the static "Contact support" mailto row into the
+    // feedback entry point — the dialog's "Question" type doubles as
+    // the support channel, so there's a single row now.
+    expect(screen.queryByTestId("help-row-contactSupport")).not.toBeInTheDocument()
+    const feedbackRow = screen.getByTestId("help-row-feedback")
+    expect(feedbackRow).toHaveTextContent("Contact support / share feedback")
     expect(screen.getByTestId("help-row-whatsNew-badge")).toBeInTheDocument()
+  })
+
+  it("merged support/feedback row opens the FeedbackDialog in place (#1387)", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-help"))
+    const row = screen.getByTestId("help-row-feedback")
+    // It's a click-to-open trigger, not a navigation link.
+    expect(row.tagName).toBe("BUTTON")
+    expect(screen.queryByTestId("feedback-dialog")).not.toBeInTheDocument()
+    await user.click(row)
+    expect(await screen.findByTestId("feedback-dialog")).toBeVisible()
   })
 
   it("Keyboard shortcuts row opens the cheat-sheet dialog in place (#1385)", async () => {

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -3194,7 +3194,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": string;
+                        "application/json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -615,11 +615,12 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			LoginEventRegistry:   params.FactorySet.LoginEventRegistry,
 		}))
 		// In-app feedback / contact support (#1387). Auth-required and
-		// per-user rate-limited (5/hour). The handler returns 503 when
-		// SupportEmail is empty, so it stays mounted in the
-		// "feedback not configured" deployment shape too — the FE can
-		// rely on a stable URL and surface the operator's mailto
-		// fallback when the 503 comes back.
+		// per-user rate-limited (5/hour). The handler returns a typed 503
+		// (feedback.not_configured) when SupportEmail is empty, so it stays
+		// mounted in the "feedback not configured" deployment shape too —
+		// the FE can rely on a stable URL and surface a "feedback isn't
+		// configured" toast (not the global /maintenance bounce) when the
+		// typed 503 comes back.
 		r.With(userMiddlewares...).Route("/feedback", Feedback(FeedbackParams{
 			EmailService: emailSvc,
 			SupportEmail: params.SupportEmail,

--- a/go/apiserver/feedback.go
+++ b/go/apiserver/feedback.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	"github.com/go-extras/errx"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/internal/errormarshal"
@@ -58,7 +59,10 @@ const feedbackMaxRequestBodyBytes = feedbackMaxMessageBytes +
 const feedbackNotConfiguredCode = "feedback.not_configured"
 
 // errFeedbackNotConfigured is the sentinel surfaced by the 503 above.
-var errFeedbackNotConfigured = errors.New("feedback is not configured on this deployment")
+// errx.NewSentinel (not errors.New) keeps it consistent with the other
+// feature-level sentinels — e.g. aivision.ErrProviderDisabled — so it
+// classifies/wraps and asserts via errors.Is the same way across packages.
+var errFeedbackNotConfigured = errx.NewSentinel("feedback is not configured on this deployment")
 
 // FeedbackParams wires the dependencies of the /api/v1/feedback route.
 //

--- a/go/apiserver/feedback.go
+++ b/go/apiserver/feedback.go
@@ -159,6 +159,16 @@ func (api *feedbackAPI) submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bound the request body up front — before any early return — so the
+	// "feedback not configured" 503 path can't be made to drain an
+	// oversized payload either. The handler reads the body itself
+	// (FeedbackRateLimitMiddleware does not peek), so this is the real
+	// upper bound: sized to hold a max-length message + the diagnostics
+	// cap + JSON overhead so a legitimate worst-case payload never hits
+	// 413 before field validation runs.
+	r.Body = http.MaxBytesReader(w, r.Body, feedbackMaxRequestBodyBytes)
+	defer func() { _ = r.Body.Close() }()
+
 	if api.supportEmail == "" {
 		// Endpoint mounted but no destination address configured. Surface
 		// a *typed* 503 (feedback.not_configured) so the dialog shows its
@@ -177,14 +187,6 @@ func (api *feedbackAPI) submit(w http.ResponseWriter, r *http.Request) {
 		}))
 		return
 	}
-
-	// Limit body to a few tens of KB. The handler reads the body itself
-	// (FeedbackRateLimitMiddleware does not peek), so this is the real
-	// upper bound for the request payload — sized to hold a max-length
-	// message + the diagnostics cap + JSON overhead so a legitimate
-	// worst-case payload never hits 413 before field validation runs.
-	r.Body = http.MaxBytesReader(w, r.Body, feedbackMaxRequestBodyBytes)
-	defer func() { _ = r.Body.Close() }()
 
 	var req FeedbackRequest
 	dec := json.NewDecoder(r.Body)

--- a/go/apiserver/feedback.go
+++ b/go/apiserver/feedback.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
 
 	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/errormarshal"
+	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/services"
 )
 
@@ -43,6 +46,19 @@ const feedbackMaxDiagnosticsValueBytes = 1024
 const feedbackMaxRequestBodyBytes = feedbackMaxMessageBytes +
 	(feedbackMaxDiagnosticsEntries * feedbackMaxDiagnosticsValueBytes) +
 	16*1024
+
+// feedbackNotConfiguredCode is the JSON:API error code paired with the
+// 503 returned when SUPPORT_EMAIL is unset. Emitting a *typed* error
+// (dotted code) — rather than a bare text/plain 503 — is what stops the
+// FE's global HTTP client (frontend/src/lib/http.ts) from reading the
+// 503 as a "scheduled maintenance" outage and bouncing the whole shell
+// to /maintenance, which would hide the dialog's "feedback isn't
+// configured" toast. Mirrors the commodity_scan.provider_disabled
+// precedent (#1720 / #1835).
+const feedbackNotConfiguredCode = "feedback.not_configured"
+
+// errFeedbackNotConfigured is the sentinel surfaced by the 503 above.
+var errFeedbackNotConfigured = errors.New("feedback is not configured on this deployment")
 
 // FeedbackParams wires the dependencies of the /api/v1/feedback route.
 //
@@ -130,7 +146,7 @@ func Feedback(params FeedbackParams, limiter services.AuthRateLimiter) func(r ch
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 429 {string} string "Too Many Requests"
-// @Failure 503 {string} string "Feedback not configured"
+// @Failure 503 {object} jsonapi.Errors "Feedback not configured"
 // @Router /feedback [post]
 func (api *feedbackAPI) submit(w http.ResponseWriter, r *http.Request) {
 	user := appctx.UserFromContext(r.Context())
@@ -140,12 +156,21 @@ func (api *feedbackAPI) submit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if api.supportEmail == "" {
-		// Endpoint mounted but no destination address configured.
-		// The FE renders a static help message in that case (the
-		// SettingsPage Help section already has a mailto fallback);
-		// we surface a 503 so the toast can be specific.
+		// Endpoint mounted but no destination address configured. Surface
+		// a *typed* 503 (feedback.not_configured) so the dialog shows its
+		// specific "feedback isn't configured" toast — and, crucially, so
+		// the FE's global 503→/maintenance bounce is skipped. lib/http.ts
+		// only bounces the shell for *untyped* 503s; a dotted JSON:API
+		// error code marks this as a per-feature state, not an outage
+		// (same contract as commodity_scan.provider_disabled, #1720).
 		slog.Warn("Feedback submission rejected: SUPPORT_EMAIL not configured", "user_id", user.ID)
-		http.Error(w, "Feedback is not configured on this deployment", http.StatusServiceUnavailable)
+		_ = render.Render(w, r, jsonapi.NewErrors(jsonapi.Error{
+			Err:            errFeedbackNotConfigured,
+			UserError:      errormarshal.Marshal(errFeedbackNotConfigured),
+			HTTPStatusCode: http.StatusServiceUnavailable,
+			StatusText:     "Service Unavailable",
+			Code:           feedbackNotConfiguredCode,
+		}))
 		return
 	}
 

--- a/go/apiserver/feedback_test.go
+++ b/go/apiserver/feedback_test.go
@@ -175,8 +175,10 @@ func TestFeedback_HappyPath(t *testing.T) {
 // TestFeedback_NoSupportEmail asserts the operator-misconfiguration
 // path: the route stays mounted (so the FE has a stable URL), but
 // without SUPPORT_EMAIL the handler responds 503 and never calls the
-// email service. The FE relies on this status to surface the static
-// mailto fallback in the toast.
+// email service. The 503 carries a *typed* JSON:API code
+// (feedback.not_configured) — the FE relies on that dotted code to skip
+// its global 503→/maintenance bounce and instead show the dialog's
+// "feedback isn't configured" toast.
 func TestFeedback_NoSupportEmail(t *testing.T) {
 	c := qt.New(t)
 	email := &capturingFeedbackEmailService{}
@@ -193,6 +195,7 @@ func TestFeedback_NoSupportEmail(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusServiceUnavailable)
+	assertErrorCode(t, c, rr.Body.Bytes(), "feedback.not_configured")
 	c.Assert(email.calls, qt.Equals, 0)
 }
 

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -147,8 +147,8 @@ type Config struct {
 	EmailReplyTo  string `yaml:"email_reply_to" env:"EMAIL_REPLY_TO" env-default:""`
 	// SupportEmail is the destination address for in-app feedback
 	// submissions (issue #1387). Empty leaves the POST /feedback
-	// endpoint mounted but it returns 503 — the FE then falls back to
-	// the static mailto link surfaced in Settings → Help.
+	// endpoint mounted but it returns a typed 503 (feedback.not_configured)
+	// and the FE shows a "feedback isn't configured" toast.
 	SupportEmail         string `yaml:"support_email" env:"SUPPORT_EMAIL" env-default:""`
 	EmailQueueRedisURL   string `yaml:"email_queue_redis_url" env:"EMAIL_QUEUE_REDIS_URL" env-default:""`
 	EmailQueueWorkers    int    `yaml:"email_queue_workers" env:"EMAIL_QUEUE_WORKERS" env-default:"5"`

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -2285,7 +2285,7 @@ const docTemplate = `{
                     "503": {
                         "description": "Feedback not configured",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -2278,7 +2278,7 @@
                     "503": {
                         "description": "Feedback not configured",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -6134,7 +6134,7 @@ paths:
         "503":
           description: Feedback not configured
           schema:
-            type: string
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Submit feedback
       tags:
       - feedback

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -51,6 +51,9 @@ data:
   {{- end }}
   INVENTARIO_RUN_EMAIL_FROM: {{ .Values.email.from | quote }}
   INVENTARIO_RUN_EMAIL_REPLY_TO: {{ .Values.email.replyTo | quote }}
+  # Feedback destination (#1387). Empty → the endpoint returns a typed 503
+  # (feedback.not_configured) and the dialog shows a "not configured" toast.
+  INVENTARIO_RUN_SUPPORT_EMAIL: {{ .Values.email.supportEmail | quote }}
   INVENTARIO_RUN_EMAIL_QUEUE_WORKERS: {{ .Values.email.queueWorkers | quote }}
   INVENTARIO_RUN_EMAIL_QUEUE_MAX_RETRIES: {{ .Values.email.queueMaxRetries | quote }}
   INVENTARIO_RUN_LOG_EMAIL_URLS: {{ .Values.email.logUrls | quote }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -434,6 +434,15 @@ email:
   # Env: INVENTARIO_RUN_EMAIL_REPLY_TO
   replyTo: ""
 
+  # Destination inbox for in-app "Contact support / share feedback"
+  # submissions (#1387). Empty leaves POST /api/v1/feedback mounted but it
+  # returns a typed 503 (feedback.not_configured) and the dialog shows a
+  # "feedback isn't configured on this deployment" toast. Set a real address
+  # to enable the channel. With demo.mailpit on, this just needs to be a
+  # valid address — Mailpit captures everything regardless of destination.
+  # Env: INVENTARIO_RUN_SUPPORT_EMAIL
+  supportEmail: ""
+
   # Number of background queue workers
   # Env: INVENTARIO_RUN_EMAIL_QUEUE_WORKERS
   queueWorkers: 5

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -71,6 +71,12 @@ demo:
 # links in these emails resolve to the same tailnet node.
 email:
   from: "noreply@inventario.example"
+  # Feedback destination (#1387). demo.mailpit forces provider=smtp, so a real
+  # submit from Settings → "Contact support / share feedback" actually delivers
+  # here and is viewable in the Mailpit web UI (the mail-<app host> tailnet
+  # node) instead of dead-ending on the "not configured" toast. The address is
+  # arbitrary — Mailpit captures all mail regardless of recipient.
+  supportEmail: "support@inventario.example"
 
 # Bootstrap + migrate runs via the chart's setup Job (templates/job-setup.yaml).
 # Idempotent — re-applies safely.


### PR DESCRIPTION
## What & why

The **Settings → Help & support** section carried two near-identical rows:

| Row | Behaviour |
| --- | --- |
| **Send feedback** | Opens the in-app `FeedbackDialog` (#1387) |
| **Contact support** | Static `mailto:support@inventario.app` link |

The dialog's **"Question"** type already doubles as the contact-support channel, so the second row was redundant — and the two-row split actually diverged from #1387's original design, which was a single **"Send feedback / contact support form"**. This consolidates them back into one entry point.

## Changes — UI consolidation

- **Rename** the feedback row to **"Contact support / share feedback"**. It still opens the existing `FeedbackDialog` unchanged — the form the user already knows.
- **Remove** the static "Contact support" mailto row and its i18n keys (`contactSupport`, `contactSupportDescription`).
- **Rewrite** the row description to reflect the merged reality:
  > Ask the team for help, report a bug, or tell us what to build next.
- **Delete** the now-dead external/`mailto` render arm in `HelpSection` — no Help row is external anymore.
- **Refresh** stale comments in `HelpSection` and `FeedbackDialog` that pointed at the removed mailto fallback.

The `FeedbackDialog` itself (title, fields, submit copy) is **untouched** — only its entry point label/description changed.

## Changes — feedback 503 fix (found while testing the preview deploy 🐛)

Submitting feedback on a deployment **without `SUPPORT_EMAIL`** (every PR preview env, this one included) dumped the user on the **"Scheduled maintenance / We'll be right back"** page instead of a toast.

Root cause: the handler returned a bare `text/plain` 503 (`http.Error`). The FE's global HTTP client (`lib/http.ts`) treats any **untyped** 503 as a scheduled-maintenance outage and bounces the whole shell to `/maintenance` — *before* the `HttpError` ever reaches `FeedbackDialog`'s 503 catch. So the dialog's intended "feedback isn't configured" toast was unreachable.

Fix (matches the `commodity_scan.provider_disabled` #1720/#1835 contract): emit the not-configured 503 as a **typed JSON:API error** with code `feedback.not_configured`. `hasTypedProductError()` then returns true, the global maintenance bounce is skipped, the shell stays mounted, and the dialog shows its specific toast.

- `feedback.go`: typed 503 via `render.Render(jsonapi.NewErrors(...))` + sentinel; swagger `@Failure 503` → `jsonapi.Errors`.
- Regenerated `go/docs/*` + `frontend/src/types/api.d.ts`.

## Tests

- SettingsPage help-section unit test: asserts the merged row label and that `help-row-contactSupport` is gone; new test that the row opens the `FeedbackDialog` in place.
- BE `TestFeedback_NoSupportEmail`: now asserts the typed `feedback.not_configured` code.
- New `FeedbackDialog` test: a typed 503 keeps the dialog open and does **not** call `navigateToMaintenance`.
- e2e comment refreshed (`help-row-feedback` testid unchanged → same flow).

Local checks: FE `typecheck` ✅ · `lint` ✅ · `format:check` ✅ · vitest (FeedbackDialog + SettingsPage) 22 passed ✅ — BE `go build` ✅ · `go vet` ✅ · `golangci-lint` 0 issues ✅ · `go test ./apiserver/` ✅

Context: #1387.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified "Contact support / share feedback" action in Settings → Help, consolidating separate contact support and feedback options into a single in-app dialog.

* **Improvements**
  * Enhanced error messaging when feedback submission is unavailable, providing clearer guidance when support email is not configured on the deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->