### PR TITLE
[#1988] Anonymous first-item: bind the fill to registration, fork the landing CTA

### DIFF
--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -9,14 +9,16 @@
  * reuses an already-seeded account to exercise the replay mechanism itself,
  * relying on the pending-first-item marker surviving the navigation to /login.
  *
- * The landing "Add New Item" card is gated on the `public_scan` feature flag
- * (the public AI-scan endpoint is mounted only when the operator opts in).
- * Rather than coordinate that backend env across the whole e2e job matrix —
- * the same call ai-scan.spec.ts made for the mock provider — we stub
- * GET /api/v1/feature-flags to report `public_scan: true`. The AI scan itself
- * is skipped via "Fill manually", so the flow has NO dependency on the scan
- * endpoint; the post-login replay POSTs to the REAL backend, so the item is
- * genuinely created and verified.
+ * The landing "Add your first item" card is ALWAYS shown; the `public_scan`
+ * feature flag only controls whether the AI photo-scan *step* renders inside
+ * the create dialog (the public AI-scan endpoint is mounted only when the
+ * operator opts in). This test drives that AI step (step 2 dismisses it via
+ * "Fill manually"), so — rather than coordinate that backend env across the
+ * whole e2e job matrix, the same call ai-scan.spec.ts made for the mock
+ * provider — we stub GET /api/v1/feature-flags to report `public_scan: true`
+ * so the AI step is present to dismiss. The scan itself never runs, so the
+ * flow has NO dependency on the scan endpoint; the post-login replay POSTs to
+ * the REAL backend, so the item is genuinely created and verified.
  *
  * Plain @playwright/test (no app-fixture) so the page starts logged OUT —
  * RootGate only renders the landing surface for an anonymous visitor.

--- a/e2e/tests/anonymous-first-item.spec.ts
+++ b/e2e/tests/anonymous-first-item.spec.ts
@@ -2,8 +2,12 @@
  * Anonymous "add your first item before login" journey (#1988).
  *
  * Exercises the no-data-loss guarantee end-to-end: a logged-out visitor
- * fills the create form on the public landing page, is sent to log in, and
- * after auth the drafted item is replayed into their group with nothing lost.
+ * fills the create form on the public landing page, is sent to REGISTER (the
+ * anonymous fill is framed as new-user onboarding), and after auth the
+ * drafted item is replayed into their group with nothing lost. A real new
+ * user would register + verify their email before signing in; this spec
+ * reuses an already-seeded account to exercise the replay mechanism itself,
+ * relying on the pending-first-item marker surviving the navigation to /login.
  *
  * The landing "Add New Item" card is gated on the `public_scan` feature flag
  * (the public AI-scan endpoint is mounted only when the operator opts in).
@@ -89,19 +93,24 @@ test.describe('Anonymous first-item journey (#1988)', () => {
 
     // 3. Fill the wizard and submit. The anonymous submit is a pure hand-off:
     //    it stashes the draft + the pending-first-item marker and redirects to
-    //    login — it does NOT POST, so we land back on /login, not a detail page.
+    //    REGISTER (the fill is new-user onboarding) — it does NOT POST, so we
+    //    land on /register, not a detail page.
     await fillCommodityWizardAndSubmit(page, commodity);
-    await page.waitForURL(/\/login(\?.*)?$/, { timeout: 15000 });
+    await page.waitForURL(/\/register(\?.*)?$/, { timeout: 15000 });
 
     // The hand-off marker is set before the redirect.
     expect(await page.evaluate((k) => localStorage.getItem(k), MARKER_KEY)).not.toBeNull();
 
-    // 4. Log in. LoginPage sees the marker and routes to /welcome instead of
-    //    the dashboard (peek, not consume — the resolver owns consumption).
-    //    The first-item reassurance drawer (#1988) auto-opens over the form on
-    //    arrival; dismiss it ("Got it") first — its modal overlay otherwise
-    //    intercepts the form clicks (this mirrors the real visitor flow). Wait
-    //    for it to fully close so its exit animation can't race the form.
+    // 4. A brand-new visitor would register + verify their email before
+    //    signing in; this spec reuses a seeded account, so we head straight to
+    //    /login. The pending-first-item marker lives in localStorage and
+    //    survives the navigation. LoginPage sees it and routes to /welcome
+    //    instead of the dashboard (peek, not consume — the resolver owns
+    //    consumption). The first-item reassurance drawer (#1988) auto-opens
+    //    over the form on arrival; dismiss it ("Got it") first — its modal
+    //    overlay otherwise intercepts the form clicks. Wait for it to fully
+    //    close so its exit animation can't race the form.
+    await page.goto('/login');
     await page.getByTestId('pending-first-item-drawer-ok').click();
     await page.getByTestId('pending-first-item-drawer').waitFor({ state: 'hidden' });
     await page.getByTestId('email').fill(TEST_CREDENTIALS.email);

--- a/frontend/src/components/items/AnonymousCommodityDialog.tsx
+++ b/frontend/src/components/items/AnonymousCommodityDialog.tsx
@@ -12,8 +12,10 @@ import { inferDefaultCurrency } from "@/lib/currency-default"
 // the resolver can find the stashed values + IndexedDB pending files.
 export const ANON_DRAFT_KEY = "commodity-draft:anon:create"
 
-// Where the resolver replays the stash. The login page bounces here
-// after auth when peekPendingFirstItem() is set.
+// Where the resolver replays the stash. The hand-off sends the visitor to
+// /register first (the anonymous fill is new-user onboarding); the marker
+// survives the register → verify-email → sign-in round-trip, and the LOGIN
+// page is what finally bounces here once peekPendingFirstItem() is set.
 const WELCOME_PATH = "/welcome"
 
 interface AnonymousCommodityDialogProps {
@@ -43,10 +45,13 @@ interface AnonymousCommodityDialogProps {
 //      auto-save — guarantees the final keystroke is captured), then
 //   2. set the pending-first-item marker (draftKey + inferred currency),
 //      then
-//   3. redirect to /login?redirect=/welcome.
-// After login, FirstItemResolver reads the marker, POSTs the stashed
-// commodity into the resolved group, uploads its IndexedDB pending
-// files, and clears everything. No entered data is ever lost.
+//   3. redirect to /register?redirect=/welcome — the anonymous fill is
+//      framed as new-user onboarding, so it hands off to account creation.
+// After the visitor creates an account, verifies their email, and signs
+// in, FirstItemResolver reads the marker, auto-creates a group seeded with
+// the item's own currency (when they have none), POSTs the stashed
+// commodity into it, uploads its IndexedDB pending files, and clears
+// everything. No entered data is ever lost.
 //
 // `defaultCurrency` is inferred from the browser locale because there's
 // no group to read one from; `areas`/`locations` are empty (the create
@@ -64,8 +69,8 @@ export function AnonymousCommodityDialog({
   // POST it — the form-shaped draft is already in localStorage via the
   // dialog's auto-save, so we just persist the request's currency into the
   // pending-first-item marker (so the auto-created "Main" group, when the
-  // user has zero groups, is seeded coherently) and redirect to login. The
-  // dialog's anonymous branch bails before any upload/clear/navigate,
+  // user has zero groups, is seeded coherently) and redirect to register.
+  // The dialog's anonymous branch bails before any upload/clear/navigate,
   // leaving the redirect to us.
   async function handleSubmit(values: CreateCommodityRequest) {
     // The dialog already mirrors form state to localStorage under
@@ -114,15 +119,15 @@ export function AnonymousCommodityDialog({
       currency: values.original_price_currency || defaultCurrency,
       savedAt: Date.now(),
     })
-    navigate(`/login?redirect=${encodeURIComponent(WELCOME_PATH)}`)
+    navigate(`/register?redirect=${encodeURIComponent(WELCOME_PATH)}`)
   }
 
   // "Save as draft" from the dismiss-confirm. Unlike an authenticated user,
   // an anonymous visitor has nowhere to persist a draft except their own
-  // account — so saving a (possibly partial) draft hands off to login just
-  // like a full submit: the dialog has already written the form-shaped draft
-  // under ANON_DRAFT_KEY, so we only set the pending-first-item marker and
-  // route to login. Currency is the locale default (the resolver re-derives
+  // account — so saving a (possibly partial) draft hands off to register
+  // just like a full submit: the dialog has already written the form-shaped
+  // draft under ANON_DRAFT_KEY, so we only set the pending-first-item marker
+  // and route to register. Currency is the locale default (the resolver re-derives
   // it from the real group on replay, so a partial draft with no price is
   // fine). Without this the user would land back on the bare landing page
   // with no obvious way to actually keep what they typed.
@@ -132,7 +137,7 @@ export function AnonymousCommodityDialog({
       currency: defaultCurrency,
       savedAt: Date.now(),
     })
-    navigate(`/login?redirect=${encodeURIComponent(WELCOME_PATH)}`)
+    navigate(`/register?redirect=${encodeURIComponent(WELCOME_PATH)}`)
   }
 
   return (

--- a/frontend/src/components/items/__tests__/AnonymousCommodityDialog.test.tsx
+++ b/frontend/src/components/items/__tests__/AnonymousCommodityDialog.test.tsx
@@ -36,7 +36,7 @@ beforeEach(() => {
 })
 
 describe("<AnonymousCommodityDialog /> save-as-draft hand-off (#1988)", () => {
-  it("sets the pending marker and routes to login when 'Save as draft' is chosen", async () => {
+  it("sets the pending marker and routes to register when 'Save as draft' is chosen", async () => {
     const user = userEvent.setup()
     renderDialog()
     // Enter something so the dialog is dirty, then try to dismiss it.
@@ -44,23 +44,24 @@ describe("<AnonymousCommodityDialog /> save-as-draft hand-off (#1988)", () => {
     await user.click(screen.getByTestId("commodity-form-cancel"))
     // The dismiss-confirm appears; choose "Save as draft".
     await user.click(await screen.findByTestId("commodity-form-close-confirm-save"))
-    // Anonymous save-as-draft hands off to login (not back to the landing
-    // page): marker set + redirect to /login?redirect=/welcome.
+    // Anonymous save-as-draft hands off to register (the fill is new-user
+    // onboarding, not back to the landing page): marker set + redirect to
+    // /register?redirect=/welcome.
     await waitFor(() =>
-      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/login")
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/register")
     )
     expect(screen.getByTestId("loc").getAttribute("data-search")).toContain("redirect=%2Fwelcome")
     expect(peekPendingFirstItem()?.draftKey).toBe(ANON_DRAFT_KEY)
   })
 
-  it("persists the typed draft so it can be replayed after login", async () => {
+  it("persists the typed draft so it can be replayed after sign-in", async () => {
     const user = userEvent.setup()
     renderDialog()
     await user.type(await screen.findByLabelText(/^Name$/i), "Camera")
     await user.click(screen.getByTestId("commodity-form-cancel"))
     await user.click(await screen.findByTestId("commodity-form-close-confirm-save"))
     await waitFor(() =>
-      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/login")
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/register")
     )
     const draft = JSON.parse(window.localStorage.getItem(ANON_DRAFT_KEY) ?? "{}")
     expect(draft.name).toBe("Camera")

--- a/frontend/src/features/auth/firstItemHandoff.ts
+++ b/frontend/src/features/auth/firstItemHandoff.ts
@@ -1,10 +1,11 @@
-// Bridge for the anonymous "add your first item before login" flow (#1988).
-// An unauthenticated visitor fills the create dialog on the landing page; on
-// save we stash the draft (already in localStorage + IndexedDB via the
-// dialog's own draft machinery) and set THIS marker, then send them to log
-// in. After auth, FirstItemResolver reads the marker, POSTs the stashed
-// commodity into the resolved group, uploads its pending files, and clears
-// everything.
+// Bridge for the anonymous "add your first item before you have an account"
+// flow (#1988). An unauthenticated visitor fills the create dialog on the
+// landing page; on save we stash the draft (already in localStorage +
+// IndexedDB via the dialog's own draft machinery) and set THIS marker, then
+// send them to register (the anonymous fill is new-user onboarding). After
+// they create an account and sign in, FirstItemResolver reads the marker,
+// POSTs the stashed commodity into the resolved group, uploads its pending
+// files, and clears everything.
 //
 // Scope is intentionally localStorage (not sessionStorage like the invite
 // bridge): the draft values + the IndexedDB pending files both live in

--- a/frontend/src/i18n/locales/en/landing.json
+++ b/frontend/src/i18n/locales/en/landing.json
@@ -1,13 +1,13 @@
 {
   "cards": {
     "addItem": {
-      "description": "Snap a photo and let AI fill in the details — no account needed to start.",
-      "descriptionManual": "Add your first item in seconds — no account needed to start.",
-      "title": "Add New Item"
+      "description": "Snap a photo and let AI fill in the details — create your free account to save it.",
+      "descriptionManual": "Add your first item in seconds — create your free account to save it.",
+      "title": "Add your first item"
     },
-    "browse": {
-      "description": "Log in to see and manage everything you own.",
-      "title": "Browse My Items"
+    "login": {
+      "description": "Already have an account? Log in to see and manage everything you own.",
+      "title": "I already have an account"
     }
   },
   "draft": {
@@ -17,7 +17,7 @@
     "subtitle": "Track your belongings, their warranties and values in one place.",
     "title": "Everything you own, organized"
   },
-  "loginCta": "Log in to dashboard…",
+  "registerCta": "New here? Create an account",
   "resolver": {
     "defaultGroupName": "Main",
     "errorGeneric": "Something went wrong while adding your item. Your draft is safe — try again.",

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate, useSearchParams } from "react-router-dom"
-import { ArrowRight, Package, Sparkles } from "lucide-react"
+import { ArrowRight, LogIn, Package, Sparkles } from "lucide-react"
 
 import { AnonymousCommodityDialog } from "@/components/items/AnonymousCommodityDialog"
 import {
@@ -13,11 +13,18 @@ import { useFeatureFlag } from "@/features/feature-flags/hooks"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { cn } from "@/lib/utils"
 
-// LandingPage is the public, unauthenticated "/" surface (#1988): an
-// anonymous visitor can start adding their first item (snap a photo, let
-// the public AI scan fill the details) BEFORE creating an account. On
-// save the draft is stashed and the user is sent to log in; after auth
-// the FirstItemResolver replays it into their group.
+// LandingPage is the public, unauthenticated "/" surface (#1988): it forks
+// up front into the two paths a logged-out visitor can take.
+//
+//   - "Add your first item" (new user): snap a photo / fill the form, then
+//     hand off to REGISTRATION. Because an anonymous visitor can't know
+//     which group (and currency) they'll land in, the anonymous fill is
+//     framed as new-user onboarding — after they create an account, verify,
+//     and sign in, FirstItemResolver auto-creates a group seeded with the
+//     item's own currency and replays the draft into it.
+//   - "Log in" (returning user): goes straight to the existing inventory.
+//     They never fill the anonymous form, so there's no draft to resolve and
+//     no currency ambiguity.
 //
 // No analogue exists in design-mocks/ (logged this as a deviation —
 // "Why: not present in mock"). The hero borrows NoGroupPage's
@@ -26,17 +33,18 @@ import { cn } from "@/lib/utils"
 // from the mock's onboarding/empty-state surfaces. The page renders its
 // own full-screen layout because it sits OUTSIDE the authenticated Shell.
 //
-// The "Add New Item" card is ALWAYS shown — adding your first item is the
+// The "Add your first item" card is ALWAYS shown — adding your first item is the
 // page's primary CTA (#1988) and must never disappear (the regression that
 // motivated this change: with public_scan off the page degenerated to a
 // browse-only dead-end). The `public_scan` feature flag only gates the AI
 // photo-scan *accelerator*, not the ability to add an item: when the flag
 // is off the dialog opens directly on manual entry (no scan endpoint is
 // offered, so nothing 404s) and the card copy drops the "let AI fill it in"
-// promise. The post-save hand-off (stash draft → login → replay) is
-// identical either way. "Browse My Items" and the ghost login link both
-// route to /login?redirect=/ so a returning user lands back on "/" (RootGate
-// then resolves them to their dashboard).
+// promise. The post-save hand-off (stash draft → register → replay) is
+// identical either way. The "Log in" card routes to /login?redirect=/ so a
+// returning user lands back on "/" (RootGate then resolves them to their
+// dashboard); the low-emphasis footer link offers a no-item "Create an
+// account" path straight to /register.
 export function LandingPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -92,6 +100,10 @@ export function LandingPage() {
     navigate(`/login?redirect=${encodeURIComponent("/")}`)
   }
 
+  function goToRegister() {
+    navigate("/register")
+  }
+
   return (
     <div className="flex min-h-svh w-full flex-col bg-background">
       <RouteTitle title={t("landing:hero.title")} />
@@ -123,11 +135,13 @@ export function LandingPage() {
             </p>
           </div>
 
-          {/* Add + Browse are both always present, so the grid is always
-              two-up on ≥sm. The Add card's icon + copy reflect whether the
-              AI scan accelerator is available (public_scan): Sparkles +
-              "let AI fill it in" when on, a plain Package + manual-entry
-              copy when off. */}
+          {/* The two paths a logged-out visitor can take are always both
+              present, so the grid is always two-up on ≥sm. The "Add your
+              first item" card's icon + copy reflect whether the AI scan
+              accelerator is available (public_scan): Sparkles + "let AI fill
+              it in" when on, a plain Package + manual-entry copy when off. It
+              hands off to registration. The "Log in" card is the returning
+              user's path. */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <LandingCard
               title={t("landing:cards.addItem.title")}
@@ -141,22 +155,24 @@ export function LandingPage() {
               testId="landing-add-item"
             />
             <LandingCard
-              title={t("landing:cards.browse.title")}
-              description={t("landing:cards.browse.description")}
-              icon={Package}
+              title={t("landing:cards.login.title")}
+              description={t("landing:cards.login.description")}
+              icon={LogIn}
               onClick={goToLogin}
-              testId="landing-browse"
+              testId="landing-login"
             />
           </div>
 
+          {/* Low-emphasis no-item sign-up path for a visitor who'd rather
+              create their account before adding anything. */}
           <div className="text-center">
             <button
               type="button"
-              onClick={goToLogin}
+              onClick={goToRegister}
               className="text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
-              data-testid="landing-login-link"
+              data-testid="landing-register-link"
             >
-              {t("landing:loginCta")}
+              {t("landing:registerCta")}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -51,13 +51,13 @@ beforeEach(() => {
 })
 
 describe("<LandingPage />", () => {
-  it("renders the hero and the Browse card", async () => {
+  it("renders the hero, the Log in card and the register link", async () => {
     mockFlags(false)
     renderLanding()
     expect(await screen.findByTestId("landing-page")).toBeInTheDocument()
     expect(screen.getByText("Everything you own, organized")).toBeInTheDocument()
-    expect(screen.getByTestId("landing-browse")).toBeInTheDocument()
-    expect(screen.getByTestId("landing-login-link")).toBeInTheDocument()
+    expect(screen.getByTestId("landing-login")).toBeInTheDocument()
+    expect(screen.getByTestId("landing-register-link")).toBeInTheDocument()
   })
 
   it("shows the Add card (manual copy) when public_scan is off", async () => {
@@ -82,26 +82,26 @@ describe("<LandingPage />", () => {
     expect(add).toHaveTextContent("let AI fill in the details")
   })
 
-  it("Browse card navigates to /login?redirect=/", async () => {
+  it("Log in card navigates to /login?redirect=/", async () => {
     mockFlags(false)
     const user = userEvent.setup()
     renderLanding()
-    await user.click(await screen.findByTestId("landing-browse"))
+    await user.click(await screen.findByTestId("landing-login"))
     await waitFor(() => {
       expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/login")
     })
     expect(screen.getByTestId("loc").getAttribute("data-search")).toBe("?redirect=%2F")
   })
 
-  it("login link navigates to /login?redirect=/", async () => {
+  it("register link navigates to /register", async () => {
     mockFlags(false)
     const user = userEvent.setup()
     renderLanding()
-    await user.click(await screen.findByTestId("landing-login-link"))
+    await user.click(await screen.findByTestId("landing-register-link"))
     await waitFor(() => {
-      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/login")
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/register")
     })
-    expect(screen.getByTestId("loc").getAttribute("data-search")).toBe("?redirect=%2F")
+    expect(screen.getByTestId("loc").getAttribute("data-search")).toBe("")
   })
 
   it("hides the resume badge when there is no in-progress draft", async () => {

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -117,17 +117,25 @@ export function LoginPage() {
   // sanitizeRedirectPath rejects absolute / protocol-relative URLs so a
   // crafted ?redirect= query can't open-redirect off the app.
   //
-  // Gate on !loginMutation.isSuccess so a JUST-completed form login does NOT
-  // also redirect through this guard: finalizeLogin() is the sole post-login
-  // navigator. Without the gate, a successful login re-renders with
-  // isAuthenticated=true and this guard races finalizeLogin — and when the
-  // page was reached WITHOUT a ?redirect (the #1988 first-item hand-off now
-  // arrives via /register → verify-email → /login, dropping the query), the
-  // guard would send the user to "/" and interrupt FirstItemResolver
-  // mid-replay. Deferring to finalizeLogin keeps its marker → /welcome route
-  // authoritative.
+  // Two subtleties:
+  //  - Gate on !loginMutation.isSuccess so a JUST-completed password login
+  //    doesn't ALSO redirect here: finalizeLogin() is the sole post-login
+  //    navigator. Otherwise the success re-render (isAuthenticated=true) races
+  //    finalizeLogin, and when /login was reached WITHOUT a ?redirect (the
+  //    #1988 first-item hand-off now arrives via /register → verify-email →
+  //    /login, dropping the query) the guard would send the user to "/" and
+  //    interrupt FirstItemResolver mid-replay. (The MFA path never reaches
+  //    this line — the `mfaChallenge` early-return above shields it — even
+  //    though its step-1 mutation is itself "successful".)
+  //  - Honor a pending first-item marker the way finalizeLogin does, so a
+  //    genuinely already-authenticated visitor (no mutation) who still has a
+  //    stashed draft is routed to /welcome to finish it instead of being
+  //    dropped on the dashboard with the draft stranded.
   if (isAuthenticated && !loginMutation.isSuccess) {
-    return <Navigate to={sanitizeRedirectPath(params.get("redirect"))} replace />
+    const firstItemDest = peekPendingFirstItem()
+      ? "/welcome"
+      : sanitizeRedirectPath(params.get("redirect"))
+    return <Navigate to={firstItemDest} replace />
   }
 
   const isPending =

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -116,7 +116,17 @@ export function LoginPage() {
   // after the hooks above to keep the Rules-of-Hooks call order stable.
   // sanitizeRedirectPath rejects absolute / protocol-relative URLs so a
   // crafted ?redirect= query can't open-redirect off the app.
-  if (isAuthenticated) {
+  //
+  // Gate on !loginMutation.isSuccess so a JUST-completed form login does NOT
+  // also redirect through this guard: finalizeLogin() is the sole post-login
+  // navigator. Without the gate, a successful login re-renders with
+  // isAuthenticated=true and this guard races finalizeLogin — and when the
+  // page was reached WITHOUT a ?redirect (the #1988 first-item hand-off now
+  // arrives via /register → verify-email → /login, dropping the query), the
+  // guard would send the user to "/" and interrupt FirstItemResolver
+  // mid-replay. Deferring to finalizeLogin keeps its marker → /welcome route
+  // authoritative.
+  if (isAuthenticated && !loginMutation.isSuccess) {
     return <Navigate to={sanitizeRedirectPath(params.get("redirect"))} replace />
   }
 

--- a/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -104,6 +104,35 @@ describe("<LoginPage />", () => {
     )
   })
 
+  it("routes a fresh login to /welcome when a first-item draft is pending, even without ?redirect (#2015)", async () => {
+    // The #1988 anonymous hand-off now goes via /register → verify-email →
+    // /login, which drops the ?redirect query. finalizeLogin still routes to
+    // /welcome off the pending marker, and the isAuthenticated guard must NOT
+    // override that to "/" on the post-login re-render (the race that
+    // interrupted FirstItemResolver mid-replay — #2015).
+    savePendingFirstItem({ draftKey: "commodity-draft:anon:create", currency: "USD", savedAt: 1 })
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json({
+          access_token: "tok",
+          csrf_token: "csrf",
+          user: { id: "u1", email: "alex@example.com", name: "Alex" },
+        })
+      )
+    )
+    const user = userEvent.setup()
+    renderLogin("/login")
+    // Dismiss the reassurance drawer so its overlay can't intercept the form.
+    await user.click(await screen.findByTestId("pending-first-item-drawer-ok"))
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("login-button"))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/welcome")
+    )
+  })
+
   it("surfaces the server error inline when the API returns 401", async () => {
     server.use(
       msw.post(api("/auth/login"), () =>


### PR DESCRIPTION
## Problem

The anonymous "add your first item before you have an account" flow (follow-up to #1988 / #2005) let a logged-out visitor pick a **currency** inside the item form — but an anonymous visitor can't know which **group** (and therefore which currency) they'll land in after auth. The post-login resolver then silently dropped the drafted item into *whatever* group they signed into, reinterpreting prices against that group's currency. Fine for a brand-new user (the item *is* their first inventory), but confusing/wrong for someone who already has an inventory.

## Approach

Reframe the anonymous fill as **new-user onboarding**, and tell returning users to just log in:

- **Landing forks up front.** Two clear paths: **"Add your first item"** (fill → hand off to registration) and **"Log in"** (returning users go straight to their existing inventory — no anonymous draft). A low-emphasis footer link offers a no-item **"Create an account"** path.
- **Hand-off targets `/register`, not `/login`.** Registration requires email verification (no auto-login), so the new user still completes via login — and the `localStorage` pending-first-item marker survives the whole `register → verify → sign-in` round-trip, so the existing replay still fires at login.
- **Currency comes from the item (unchanged).** When the freshly-registered user has zero groups, `FirstItemResolver` already auto-creates a "Main" group seeded with the item's own currency, then replays the draft into it. No ambiguity.

## Why (almost) no backend changes

The currency-aware group auto-creation already exists: `FirstItemResolver` (0-groups branch) → `useCreateGroup({ group_currency })` → `GroupService.CreateGroup`. This PR is frontend-only.

## Changes

- `LandingPage.tsx` — two-card fork ("Add your first item" / "Log in") + footer "Create an account" link; copy/icons reworked.
- `AnonymousCommodityDialog.tsx` — `handleSubmit` / `handleSaveDraft` redirect to `/register?redirect=/welcome`.
- `landing.json` — dropped the now-misleading "no account needed to start"; `cards.browse`/`loginCta` → `cards.login`/`registerCta`.
- `LoginPage.tsx` — see the follow-up fix below.
- Comments in `firstItemHandoff.ts` updated.

## Follow-up: fix post-login redirect race (surfaced by CI e2e)

The first e2e run failed deterministically in all 3 browsers — the replay landed on `/g/<group>` instead of the item, because of a race the original #1988 flow had masked. The hand-off now reaches `/login` **without** a `?redirect` (via `/register` → verify-email → `/login`, which drops the query). `finalizeLogin` still routes to `/welcome` off the pending marker, but `LoginPage`'s `isAuthenticated` guard *also* fires on the post-login re-render and — with no redirect param — navigated to `/`, unmounting `FirstItemResolver` mid-replay.

Fix: gate that guard on `!loginMutation.isSuccess`, so a just-completed form login defers to `finalizeLogin` as the **sole** post-login navigator (a pre-existing/deep-linked session still redirects exactly as before). This also hardens the real new-user path, which legitimately reaches `/login` without the redirect param. Added a `LoginPage` regression test.

## Edge case (deliberate)

An existing user who *fills then logs in* (e.g. clicks "sign in" from the register page) still has the item replayed into their existing group. That's safe — commodities carry their own `original_price_currency` and the resolver re-runs price conversion against the real group — and it's a rare, user-initiated path rather than the default.

## Tests

- vitest: `LandingPage` (new cards + register-link nav), `AnonymousCommodityDialog` (register hand-off), and a new `LoginPage` regression test (fresh login + pending marker + no `?redirect` → `/welcome`) — green. `typecheck` / `eslint` / `prettier --check` clean.
- e2e `anonymous-first-item.spec.ts`: landing → fill → `/register` → `/login` → replay into the group, verifying no-data-loss + cross-user isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landing page now prominently offers account creation as the primary action for new users.

* **Bug Fixes**
  * Fixed redirect flow for users starting item creation without an account—now properly routes to registration.
  * Fixed item drafts created before sign-in to properly resume after login, preventing loss of user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->