### PR TITLE
Unify the Items & Files bulk-selection bar; match Files card hover to Items

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -147,6 +147,15 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Approved by**: user (explicit) — issue #1547 asks for a compact surfacing of `purchase_date` on the grid card ("below `area` or alongside `current_price`"), names the i18n key shape, and names the `formatDate` helper. The chip-in-top-right-cluster placement is an agent-chosen interpretation of "compact" that the user confirmed visually after two earlier iterations (standalone line, inline dot-separator) were rejected.
 - **Reversion plan**: Permanent until the upstream mock adopts the same line; reconcile when it does.
 
+#### 2026-06-05 — Items bulk-action bar adopts the Files fixed-bottom-overlay shape (shared `BulkActionBar`)
+
+- **Issue/PR**: PR _pending_
+- **Mock**: [`design-mocks/src/components/ItemsPanel.tsx`](../../design-mocks/src/components/ItemsPanel.tsx) has no bulk-select affordance, and the design language doc ([`design/15-form-and-data-ux.md`](design/15-form-and-data-ux.md)) describes the multi-select bar as an _in-flow_ element that "shifts the page header down — doesn't overlay it".
+- **Reality**: The Items list bulk bar (`data-testid="commodities-bulk-bar"`) moved from an in-flow `bg-primary/5` block (which reflowed the list on first selection) to the same `fixed bottom-6 left-1/2 -translate-x-1/2 z-40` `bg-popover` overlay the Files page already uses. Both pages now render the one shared `BulkActionBar` component (`frontend/src/components/ui/bulk-action-bar.tsx`): identical floating shell, slide-in animation, select-all checkbox + "N selected" cluster, and a destructive Delete. The move affordance stays page-specific (Items opens an area-picker dialog; Files uses an inline category `<select>`) because the destination sets differ. The Items bar dropped its separate "Cancel" button (the select-all checkbox now toggles the whole page off, matching Files).
+- **Why**: User-requested unification — the two surfaces shipped visibly different bulk bars (inline tinted block vs. floating pill) and the floating overlay is the already-approved canonical shape (see the Files entry of 2026-05-16). Extracting one component removes the drift risk and supersedes the in-flow description in `15-form-and-data-ux.md` for the overlay treatment.
+- **Approved by**: user (explicit) — asked to make the Items selection panel match the Files one.
+- **Reversion plan**: Permanent unless the upstream mock adopts a richer mass-action pattern; reconcile both surfaces together via the shared component if it does.
+
 ### Dashboard / Overview
 
 #### 2026-05-10 — Stat-card grid: 6 inventory metrics in a single `lg:grid-cols-3` block

--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -149,7 +149,7 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 
 #### 2026-06-05 — Items bulk-action bar adopts the Files fixed-bottom-overlay shape (shared `BulkActionBar`)
 
-- **Issue/PR**: PR _pending_
+- **Issue/PR**: PR #2016
 - **Mock**: [`design-mocks/src/components/ItemsPanel.tsx`](../../design-mocks/src/components/ItemsPanel.tsx) has no bulk-select affordance, and the design language doc ([`design/15-form-and-data-ux.md`](design/15-form-and-data-ux.md)) describes the multi-select bar as an _in-flow_ element that "shifts the page header down — doesn't overlay it".
 - **Reality**: The Items list bulk bar (`data-testid="commodities-bulk-bar"`) moved from an in-flow `bg-primary/5` block (which reflowed the list on first selection) to the same `fixed bottom-6 left-1/2 -translate-x-1/2 z-40` `bg-popover` overlay the Files page already uses. Both pages now render the one shared `BulkActionBar` component (`frontend/src/components/ui/bulk-action-bar.tsx`): identical floating shell, slide-in animation, select-all checkbox + "N selected" cluster, and a destructive Delete. The move affordance stays page-specific (Items opens an area-picker dialog; Files uses an inline category `<select>`) because the destination sets differ. The Items bar dropped its separate "Cancel" button (the select-all checkbox now toggles the whole page off, matching Files).
 - **Why**: User-requested unification — the two surfaces shipped visibly different bulk bars (inline tinted block vs. floating pill) and the floating overlay is the already-approved canonical shape (see the Files entry of 2026-05-16). Extracting one component removes the drift risk and supersedes the in-flow description in `15-form-and-data-ux.md` for the overlay treatment.

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -128,7 +128,7 @@ export function FileCard({
       data-category={file.category}
       data-mime-group={visual.group}
       className={cn(
-        "group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring [&_button]:cursor-pointer",
+        "group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring",
         selected && "ring-2 ring-primary"
       )}
     >
@@ -170,7 +170,7 @@ export function FileCard({
         onClick={() => onOpen(file.id)}
         aria-label={t("files:list.openDetail", { title, defaultValue: `Open ${title}` })}
         data-testid={`file-card-open-${file.id}`}
-        className="flex flex-1 flex-col text-left focus-visible:outline-none"
+        className="flex flex-1 cursor-pointer flex-col text-left focus-visible:outline-none"
       >
         <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
           {renderImage ? (

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -128,7 +128,7 @@ export function FileCard({
       data-category={file.category}
       data-mime-group={visual.group}
       className={cn(
-        "group relative flex h-full flex-col overflow-hidden focus-within:ring-2 focus-within:ring-ring",
+        "group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring",
         selected && "ring-2 ring-primary"
       )}
     >

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -128,7 +128,7 @@ export function FileCard({
       data-category={file.category}
       data-mime-group={visual.group}
       className={cn(
-        "group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring",
+        "group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:shadow-md focus-within:ring-2 focus-within:ring-ring [&_button]:cursor-pointer",
         selected && "ring-2 ring-primary"
       )}
     >

--- a/frontend/src/components/ui/bulk-action-bar.tsx
+++ b/frontend/src/components/ui/bulk-action-bar.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
+
+interface BulkActionBarSelectAll {
+  checked: boolean
+  onCheckedChange: () => void
+  label: string
+  "data-testid"?: string
+}
+
+interface BulkActionBarProps extends React.ComponentProps<"div"> {
+  // Already-pluralized count label, e.g. "3 selected" / "3 items selected".
+  label: React.ReactNode
+  // Landmark aria-label. Defaults to `label` when that is a string.
+  regionLabel?: string
+  // Optional select-all-on-page checkbox shown left of the label.
+  selectAll?: BulkActionBarSelectAll
+  // Action controls (move / delete / …) rendered on the right.
+  children: React.ReactNode
+}
+
+// Shared multi-select bulk-action bar. A fixed bottom-centre overlay on
+// the `popover` token so toggling the first checkbox never reflows the
+// list (no "jolt") and the bar stays visible across scroll. Slides in via
+// `tw-animate-css`. This is the canonical mass-action shell for every
+// list surface (Items, Files, …) — keeping it in one place is what stops
+// the per-page bars from drifting apart again. It is an intentional
+// `mock < reality` divergence (no BulkBar in the design mock) logged in
+// devdocs/frontend/design-deviations.md.
+export function BulkActionBar({
+  label,
+  regionLabel,
+  selectAll,
+  children,
+  className,
+  ...props
+}: BulkActionBarProps) {
+  return (
+    <div
+      role="region"
+      aria-label={regionLabel ?? (typeof label === "string" ? label : undefined)}
+      className={cn(
+        "fixed bottom-6 left-1/2 z-40 w-[calc(100vw-2rem)] max-w-xl -translate-x-1/2",
+        "flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-popover px-4 py-2.5 text-sm text-popover-foreground",
+        "animate-in slide-in-from-bottom-4 fade-in-0 duration-200",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-3">
+        {selectAll ? (
+          <Checkbox
+            checked={selectAll.checked}
+            onCheckedChange={selectAll.onCheckedChange}
+            aria-label={selectAll.label}
+            data-testid={selectAll["data-testid"]}
+          />
+        ) : null}
+        <span>{label}</span>
+      </div>
+      <div className="flex items-center gap-2">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/bulk-action-bar.tsx
+++ b/frontend/src/components/ui/bulk-action-bar.tsx
@@ -3,9 +3,14 @@ import * as React from "react"
 import { Checkbox } from "@/components/ui/checkbox"
 import { cn } from "@/lib/utils"
 
+// Mirror the wrapped Checkbox's API instead of narrowing to a bare
+// toggle, so a caller can read the new checked value (or surface an
+// indeterminate "some selected" state) without fighting the type.
+type CheckboxControl = React.ComponentProps<typeof Checkbox>
+
 interface BulkActionBarSelectAll {
-  checked: boolean
-  onCheckedChange: () => void
+  checked: CheckboxControl["checked"]
+  onCheckedChange: NonNullable<CheckboxControl["onCheckedChange"]>
   label: string
   "data-testid"?: string
 }
@@ -39,6 +44,7 @@ export function BulkActionBar({
 }: BulkActionBarProps) {
   return (
     <div
+      {...props}
       role="region"
       aria-label={regionLabel ?? (typeof label === "string" ? label : undefined)}
       className={cn(
@@ -47,7 +53,6 @@ export function BulkActionBar({
         "animate-in slide-in-from-bottom-4 fade-in-0 duration-200",
         className
       )}
-      {...props}
     >
       <div className="flex items-center gap-3">
         {selectAll ? (

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -259,8 +259,21 @@ export function CommoditiesListPage() {
   }
   function toggleSelectAll(rows: Commodity[]) {
     setSelected((prev) => {
-      if (prev.size === rows.length) return new Set()
-      return new Set(rows.map((r) => r.id ?? "").filter(Boolean))
+      const ids = rows.map((r) => r.id ?? "").filter(Boolean)
+      // Derive the action from the SAME "every visible row selected"
+      // predicate the checkbox renders with — not a `prev.size ===
+      // rows.length` compare. A size compare wedges the toggle whenever
+      // `selected` still holds ids outside the visible set (e.g. the
+      // client-side warranty filter narrows `rows` without clearing
+      // selection): you could no longer uncheck in one click. Add/remove
+      // only the visible ids so off-page selection is preserved too.
+      const allVisibleSelected = ids.length > 0 && ids.every((id) => prev.has(id))
+      const next = new Set(prev)
+      for (const id of ids) {
+        if (allVisibleSelected) next.delete(id)
+        else next.add(id)
+      }
+      return next
     })
   }
 

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -233,6 +233,7 @@ export function CommoditiesListPage() {
   // bulk action would surprise them.
   const typesKey = types.join(",")
   const statusesKey = statuses.join(",")
+  const warrantyKey = warrantyFilter.join(",")
   useEffect(() => {
     // Clear page-local selection on filter/page change.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -247,6 +248,7 @@ export function CommoditiesListPage() {
     lentOutOnly,
     unassignedOnly,
     sortRaw,
+    warrantyKey,
   ])
 
   function toggleSelected(id: string) {
@@ -615,7 +617,14 @@ export function CommoditiesListPage() {
               }}
               aria-disabled={migrationLock.locked || undefined}
               title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
-              className={migrationLock.locked ? "cursor-not-allowed opacity-50" : undefined}
+              // Neutralize the hover bg too: Button's `disabled:` styles
+              // don't apply under `aria-disabled`, so without this the
+              // locked button would still light up on hover.
+              className={
+                migrationLock.locked
+                  ? "cursor-not-allowed opacity-50 hover:bg-background hover:text-foreground"
+                  : undefined
+              }
               data-testid="commodities-bulk-move"
             >
               {t("commodities:bulk.moveButton")}
@@ -632,7 +641,13 @@ export function CommoditiesListPage() {
               disabled={bulkDelete.isPending}
               aria-disabled={migrationLock.locked || undefined}
               title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
-              className={migrationLock.locked ? "cursor-not-allowed opacity-50" : undefined}
+              // Neutralize the hover bg under `aria-disabled` (Button's
+              // `disabled:` styles only key off the real attribute).
+              className={
+                migrationLock.locked
+                  ? "cursor-not-allowed opacity-50 hover:bg-destructive hover:text-white"
+                  : undefined
+              }
               data-testid="commodities-bulk-delete"
             >
               <Trash2 className="mr-2 size-4" aria-hidden="true" />

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -15,11 +15,12 @@ import {
   MapPinOff,
   Plus,
   Search,
-  X,
+  Trash2,
 } from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
+import { BulkActionBar } from "@/components/ui/bulk-action-bar"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -439,6 +440,10 @@ export function CommoditiesListPage() {
   const serviceCounts = serviceCountsQuery.data ?? {}
   const total = list.data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / PER_PAGE))
+  // Select-all reflects the visible (post-warranty-filter) page only, so
+  // the bulk bar's checkbox never silently queues rows the user can't
+  // see. Mirrors the table-header checkbox state.
+  const allRowsSelected = rows.length > 0 && rows.every((r) => selected.has(r.id ?? ""))
   const isLoading = list.isLoading
   const isError = list.isError
   const isEmpty = !isLoading && !isError && rows.length === 0
@@ -575,13 +580,40 @@ export function CommoditiesListPage() {
 
         {selected.size > 0 ? (
           <BulkActionBar
-            count={selected.size}
-            onClear={() => setSelected(new Set())}
-            onDelete={handleBulkDelete}
-            onMove={() => setMoveOpen(true)}
-            isDeleting={bulkDelete.isPending}
-            locked={migrationLock.locked}
-          />
+            label={t("commodities:bulk.selected", { count: selected.size })}
+            regionLabel={t("commodities:bulk.regionLabel")}
+            selectAll={{
+              checked: allRowsSelected,
+              onCheckedChange: () => toggleSelectAll(rows),
+              label: t("commodities:list.selectAll"),
+              "data-testid": "commodities-select-all",
+            }}
+            data-testid="commodities-bulk-bar"
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setMoveOpen(true)}
+              disabled={migrationLock.locked}
+              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              aria-disabled={migrationLock.locked || undefined}
+              data-testid="commodities-bulk-move"
+            >
+              {t("commodities:bulk.moveButton")}
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleBulkDelete}
+              disabled={bulkDelete.isPending || migrationLock.locked}
+              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              aria-disabled={migrationLock.locked || undefined}
+              data-testid="commodities-bulk-delete"
+            >
+              <Trash2 className="mr-2 size-4" aria-hidden="true" />
+              {t("commodities:bulk.deleteButton")}
+            </Button>
+          </BulkActionBar>
         ) : null}
 
         {isError ? (
@@ -980,66 +1012,6 @@ function Toolbar(props: ToolbarProps) {
           <List className="size-4" aria-hidden="true" />
         </Button>
       </div>
-    </div>
-  )
-}
-
-// ---- Bulk action bar ----------------------------------------------------
-
-interface BulkActionBarProps {
-  count: number
-  onClear: () => void
-  onDelete: () => void
-  onMove: () => void
-  isDeleting: boolean
-  locked?: boolean
-}
-
-function BulkActionBar({
-  count,
-  onClear,
-  onDelete,
-  onMove,
-  isDeleting,
-  locked,
-}: BulkActionBarProps) {
-  const { t } = useTranslation()
-  const lockTitle = locked ? t("errors:lockedDuringMigration") : undefined
-  return (
-    <div
-      className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2"
-      role="region"
-      aria-label={t("commodities:bulk.regionLabel")}
-      data-testid="commodities-bulk-bar"
-    >
-      <span className="text-sm font-medium">{t("commodities:bulk.selected", { count })}</span>
-      <Separator orientation="vertical" className="h-4" />
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onMove}
-        disabled={locked}
-        title={lockTitle}
-        aria-disabled={locked || undefined}
-        data-testid="commodities-bulk-move"
-      >
-        {t("commodities:bulk.moveButton")}
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onDelete}
-        disabled={isDeleting || locked}
-        title={lockTitle}
-        aria-disabled={locked || undefined}
-        data-testid="commodities-bulk-delete"
-      >
-        {t("commodities:bulk.deleteButton")}
-      </Button>
-      <Button variant="ghost" size="sm" onClick={onClear} className="ml-auto gap-1">
-        <X className="size-3.5" aria-hidden="true" />
-        {t("common:actions.cancel")}
-      </Button>
     </div>
   )
 }

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -606,10 +606,16 @@ export function CommoditiesListPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setMoveOpen(true)}
-              disabled={migrationLock.locked}
-              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              // Locked = aria-disabled + click-guard rather than the
+              // `disabled` attribute, so the "why" tooltip stays
+              // hover-discoverable (a real `disabled` button gets
+              // `pointer-events-none` and never shows its title).
+              onClick={() => {
+                if (!migrationLock.locked) setMoveOpen(true)
+              }}
               aria-disabled={migrationLock.locked || undefined}
+              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              className={migrationLock.locked ? "cursor-not-allowed opacity-50" : undefined}
               data-testid="commodities-bulk-move"
             >
               {t("commodities:bulk.moveButton")}
@@ -617,10 +623,16 @@ export function CommoditiesListPage() {
             <Button
               variant="destructive"
               size="sm"
-              onClick={handleBulkDelete}
-              disabled={bulkDelete.isPending || migrationLock.locked}
-              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              // `disabled` is reserved for the in-flight delete; the
+              // migration lock uses aria-disabled + click-guard so the
+              // tooltip remains discoverable (see Move button above).
+              onClick={() => {
+                if (!migrationLock.locked) handleBulkDelete()
+              }}
+              disabled={bulkDelete.isPending}
               aria-disabled={migrationLock.locked || undefined}
+              title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+              className={migrationLock.locked ? "cursor-not-allowed opacity-50" : undefined}
               data-testid="commodities-bulk-delete"
             >
               <Trash2 className="mr-2 size-4" aria-hidden="true" />

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -11,8 +11,8 @@ import type { GalleryImage } from "@/components/files/ImageViewer"
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { BulkActionBar } from "@/components/ui/bulk-action-bar"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Page, PageHeader } from "@/components/ui/page"
@@ -369,71 +369,52 @@ export function FilesListPage() {
         </div>
       </div>
 
-      {/* Bulk-action toolbar — a fixed bottom-centre overlay so toggling
-          the first checkbox doesn't reflow the list (no "jolt"). The
-          shadcn `popover` token already encodes the floating-surface
-          elevation, which keeps us off bespoke `shadow-*` per the design
-          rules. Slide-in animation via `tw-animate-css`. The bar is
-          preserved as an intentional `mock < reality` divergence
-          (BulkBar isn't in design-mocks/src/views/FileBrowserView.tsx) —
-          see devdocs/frontend/design-deviations.md. */}
       {selected.size > 0 ? (
-        <div
-          role="region"
-          aria-label={t("files:bulk.selected", { count: selected.size })}
-          className={cn(
-            "fixed bottom-6 left-1/2 z-40 w-[calc(100vw-2rem)] max-w-xl -translate-x-1/2",
-            "flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-popover px-4 py-2.5 text-sm text-popover-foreground",
-            "animate-in slide-in-from-bottom-4 fade-in-0 duration-200"
-          )}
+        <BulkActionBar
+          label={t("files:bulk.selected", { count: selected.size })}
+          selectAll={{
+            checked: allSelectedOnPage,
+            onCheckedChange: toggleAllOnPage,
+            label: t("files:list.selectAll"),
+            "data-testid": "files-select-all",
+          }}
           data-testid="files-bulk-bar"
         >
-          <div className="flex items-center gap-3">
-            <Checkbox
-              checked={allSelectedOnPage}
-              onCheckedChange={toggleAllOnPage}
-              aria-label={t("files:list.selectAll")}
-              data-testid="files-select-all"
-            />
-            <span>{t("files:bulk.selected", { count: selected.size })}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label htmlFor="files-bulk-move" className="sr-only">
+          <Label htmlFor="files-bulk-move" className="sr-only">
+            {t("files:bulk.move")}
+          </Label>
+          {/* eslint-disable-next-line no-restricted-syntax -- bulk "move to category" utility selector (context-mode bulk bar); native <select> retained, covered by native-select unit/e2e */}
+          <select
+            id="files-bulk-move"
+            data-testid="files-bulk-move"
+            defaultValue=""
+            disabled={bulkReclassify.isPending}
+            onChange={async (e) => {
+              const target = e.target.value as FileCategory | ""
+              e.target.value = ""
+              if (!target) return
+              await onBulkMove(target)
+            }}
+            className="h-8 rounded-md border border-input bg-transparent px-2 text-sm"
+          >
+            <option value="" disabled>
               {t("files:bulk.move")}
-            </Label>
-            {/* eslint-disable-next-line no-restricted-syntax -- bulk "move to category" utility selector (context-mode bulk bar); native <select> retained, covered by native-select unit/e2e */}
-            <select
-              id="files-bulk-move"
-              data-testid="files-bulk-move"
-              defaultValue=""
-              disabled={bulkReclassify.isPending}
-              onChange={async (e) => {
-                const target = e.target.value as FileCategory | ""
-                e.target.value = ""
-                if (!target) return
-                await onBulkMove(target)
-              }}
-              className="h-8 rounded-md border border-input bg-transparent px-2 text-sm"
-            >
-              <option value="" disabled>
-                {t("files:bulk.move")}
-              </option>
-              <option value="images">{t("files:categoryImages")}</option>
-              <option value="documents">{t("files:categoryDocuments")}</option>
-              <option value="other">{t("files:categoryOther")}</option>
-            </select>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={onBulkDelete}
-              disabled={bulkDelete.isPending}
-              data-testid="files-bulk-delete"
-            >
-              <Trash2 className="mr-2 size-4" aria-hidden="true" />
-              {t("files:bulk.delete")}
-            </Button>
-          </div>
-        </div>
+            </option>
+            <option value="images">{t("files:categoryImages")}</option>
+            <option value="documents">{t("files:categoryDocuments")}</option>
+            <option value="other">{t("files:categoryOther")}</option>
+          </select>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={onBulkDelete}
+            disabled={bulkDelete.isPending}
+            data-testid="files-bulk-delete"
+          >
+            <Trash2 className="mr-2 size-4" aria-hidden="true" />
+            {t("files:bulk.delete")}
+          </Button>
+        </BulkActionBar>
       ) : null}
 
       {filesQuery.error ? (


### PR DESCRIPTION
## Problem

Two things flagged on the list pages:

1. **The multi-select panel looked different on Items vs Files.** Items used an in-flow tinted block (`1 item selected · Move… · Delete · Cancel`) that shoved the list down on first selection; Files used a polished floating pill at the bottom (`1 selected · Move to… · Delete selected`).
2. **Files grid cards had no hover feedback and the wrong cursor** (arrow), while Items cards lift on hover and show a pointer.

## Changes

**Shared bulk-action bar**
- New `frontend/src/components/ui/bulk-action-bar.tsx` — one floating bottom-centre `popover` overlay (select-all checkbox + "N selected" + an actions slot, slide-in animation). Both list pages render it, so they can't drift apart again.
- **Items** (`CommoditiesListPage`): drops the in-flow `bg-primary/5` block; gains the floating overlay, a **select-all checkbox** (now available in grid mode too), and a **red destructive Delete** with a trash icon. The separate "Cancel" button is gone — the select-all toggle clears the page, same as Files. "Move…" still opens the area-picker dialog (areas are a dynamic list, unlike Files' fixed 3 categories).
- **Files** (`FilesListPage`): now consumes the shared component; identical markup / behaviour / test-ids.

**Card hover + cursor parity**
- `FileCard` grid cards get `cursor-pointer` + `hover:-translate-y-0.5 hover:shadow-md` to match Items. Root cause: Tailwind v4 gives a raw `<button>` no pointer cursor, and the card wrapper had no hover state. (The Files *list* row already had hover + pointer, so only the grid card needed it.)

**Docs**
- Logged the Items-bar overlay divergence in `devdocs/frontend/design-deviations.md` — it now diverges from the design doc's "in-flow, doesn't overlay" note, the same call already approved for the Files bar.

## Tests

- `typecheck` + `eslint` + `prettier --check` clean.
- vitest: `CommoditiesListPage` + `FilesListPage` (45) and all Files component tests (108) green.
- Preserves every depended-on test-id: `commodities-bulk-bar` / `-move` / `-delete`, `files-bulk-bar` / `-select-all` / `-move` / `-delete`.

## Note

Items still reads "N items selected" vs Files "N selected" (existing i18n copy) — the container and styling are now identical; happy to make the copy byte-identical too if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk-action bar unified across Items and Files as a fixed floating overlay; includes select-all + selected-count and a destructive Delete action; Cancel button removed.

* **Style**
  * File cards receive improved hover, focus, and interaction styling for clearer visual feedback.

* **Documentation**
  * Design docs updated to record the bulk-action bar pattern change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->