### PR TITLE
Tidy In service & Lent out table layout

### DIFF
--- a/frontend/src/pages/loans/LoansListPage.tsx
+++ b/frontend/src/pages/loans/LoansListPage.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Page, PageHeader } from "@/components/ui/page"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useGroupLoans } from "@/features/loans/hooks"
@@ -70,10 +70,8 @@ export function LoansListPage() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle className="sr-only">{t("loans:list.title")}</CardTitle>
-        </CardHeader>
         <CardContent>
+          <h2 className="sr-only">{t("loans:list.title")}</h2>
           {list.isLoading ? (
             <div className="flex flex-col gap-2" data-testid="lent-loading">
               <Skeleton className="h-10" />

--- a/frontend/src/pages/services/ServicesListPage.tsx
+++ b/frontend/src/pages/services/ServicesListPage.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Page, PageHeader } from "@/components/ui/page"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useGroupServices } from "@/features/services/hooks"
@@ -72,10 +72,8 @@ export function ServicesListPage() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle className="sr-only">{t("services:list.title")}</CardTitle>
-        </CardHeader>
         <CardContent>
+          <h2 className="sr-only">{t("services:list.title")}</h2>
           {list.isLoading ? (
             <div className="flex flex-col gap-2" data-testid="in-service-loading">
               <Skeleton className="h-10" />

--- a/frontend/src/pages/services/ServicesListPage.tsx
+++ b/frontend/src/pages/services/ServicesListPage.tsx
@@ -87,92 +87,94 @@ export function ServicesListPage() {
               {t("services:list.empty")}
             </p>
           ) : (
-            <table className="w-full text-sm" data-testid="in-service-table">
-              <thead className="text-left text-xs text-muted-foreground">
-                <tr>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerItem")}</th>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerProvider")}</th>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerReason")}</th>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerSentAt")}</th>
-                  <th className="px-2 py-2 font-medium">
-                    {t("services:list.headerExpectedReturnAt")}
-                  </th>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerCost")}</th>
-                  <th className="px-2 py-2 font-medium">{t("services:list.headerStatus")}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(list.data?.services ?? []).map(({ service, commodity }) => {
-                  const overdueDays = daysOverdue(service)
-                  const open = isOpen(service)
-                  return (
-                    <tr
-                      key={service.id}
-                      className="border-t border-border"
-                      data-testid={`in-service-row-${service.id}`}
-                    >
-                      <td className="px-2 py-2">
-                        {commodity ? (
-                          <Link
-                            to={`/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(commodity.id)}`}
-                            className="font-medium hover:underline"
-                          >
-                            {commodity.name}
-                          </Link>
-                        ) : (
-                          <span className="text-muted-foreground">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-2">
-                        <span>{service.provider_name}</span>
-                        {service.provider_contact ? (
-                          <span className="ml-1 text-muted-foreground">
-                            ({service.provider_contact})
-                          </span>
-                        ) : null}
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {service.reason ? service.reason : "—"}
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {service.sent_at ? formatDate(service.sent_at as string) : ""}
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {service.expected_return_at
-                          ? formatDate(service.expected_return_at as string)
-                          : "—"}
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {service.cost_amount && service.cost_currency ? (
-                          <>
-                            {service.cost_amount} {service.cost_currency}
-                          </>
-                        ) : (
-                          "—"
-                        )}
-                      </td>
-                      <td className="px-2 py-2">
-                        {!open ? (
-                          <Badge variant="secondary">
-                            {t("services:list.returnedStatus", {
-                              date: service.returned_at
-                                ? formatDate(service.returned_at as string)
-                                : "",
-                            })}
-                          </Badge>
-                        ) : overdueDays > 0 ? (
-                          <Badge variant="destructive">
-                            {t("services:list.overdueStatus", { count: overdueDays })}
-                          </Badge>
-                        ) : (
-                          <Badge>{t("services:list.openStatus")}</Badge>
-                        )}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="in-service-table">
+                <thead className="whitespace-nowrap text-left text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerItem")}</th>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerProvider")}</th>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerReason")}</th>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerSentAt")}</th>
+                    <th className="px-2 py-2 font-medium">
+                      {t("services:list.headerExpectedReturnAt")}
+                    </th>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerCost")}</th>
+                    <th className="px-2 py-2 font-medium">{t("services:list.headerStatus")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(list.data?.services ?? []).map(({ service, commodity }) => {
+                    const overdueDays = daysOverdue(service)
+                    const open = isOpen(service)
+                    return (
+                      <tr
+                        key={service.id}
+                        className="border-t border-border"
+                        data-testid={`in-service-row-${service.id}`}
+                      >
+                        <td className="px-2 py-2">
+                          {commodity ? (
+                            <Link
+                              to={`/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(commodity.id)}`}
+                              className="font-medium hover:underline"
+                            >
+                              {commodity.name}
+                            </Link>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="px-2 py-2">
+                          <span>{service.provider_name}</span>
+                          {service.provider_contact ? (
+                            <span className="ml-1 text-muted-foreground">
+                              ({service.provider_contact})
+                            </span>
+                          ) : null}
+                        </td>
+                        <td className="px-2 py-2 text-muted-foreground">
+                          {service.reason ? service.reason : "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-2 text-muted-foreground">
+                          {service.sent_at ? formatDate(service.sent_at as string) : ""}
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-2 text-muted-foreground">
+                          {service.expected_return_at
+                            ? formatDate(service.expected_return_at as string)
+                            : "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-2 text-muted-foreground">
+                          {service.cost_amount && service.cost_currency ? (
+                            <>
+                              {service.cost_amount} {service.cost_currency}
+                            </>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td className="px-2 py-2">
+                          {!open ? (
+                            <Badge variant="secondary">
+                              {t("services:list.returnedStatus", {
+                                date: service.returned_at
+                                  ? formatDate(service.returned_at as string)
+                                  : "",
+                              })}
+                            </Badge>
+                          ) : overdueDays > 0 ? (
+                            <Badge variant="destructive">
+                              {t("services:list.overdueStatus", { count: overdueDays })}
+                            </Badge>
+                          ) : (
+                            <Badge>{t("services:list.openStatus")}</Badge>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
Two small presentational fixes to the `/in-service` (Services) and `/lent` (Loans) list tables.

## 1. Empty `CardHeader` left a dead band above the table (both pages)

Each card held only an `sr-only` `<CardTitle>` inside a `<CardHeader>`. Because the shadcn `Card` adds `py-6` **and** `gap-6` between its children, that empty header still reserved a ~48px blank band at the top of the card — the odd top padding visible above the column headers.

**Fix:** drop the empty `<CardHeader>`; keep the accessible heading as an `sr-only <h2>` inside `<CardContent>`. The table now sits under the card's normal padding. The visible page title is unchanged (it comes from `PageHeader`), and `axe` stays clean on both pages.

## 2. `/in-service` columns wrapped onto two lines (Services only)

The 7-column Services table starved its short columns of width: the **`Expected back`** header wrapped to two lines and the body values split mid-value (`Jun 3,` / `2026`, `1200` / `CZK`). The 5-column Loans table doesn't exhibit this, so it's left as-is here.

**Fix:** `whitespace-nowrap` on `<thead>` and on the **Sent / Expected back / Cost** body cells (Item / Provider / Reason stay free to wrap), plus an `overflow-x-auto` wrapper so the now-rigid columns scroll instead of breaking narrow layouts.

## Verification

- `typecheck` ✓ · `eslint` ✓ · `format:check` ✓
- vitest: ServicesListPage + LoansListPage 14/14 (incl. the `axe`-clean checks) ✓
- Verified visually against the seeded dev build (1280px + narrow): both card tops sit tight under normal padding; Services header + dates/cost stay single-line; Provider/Reason wrap as intended.

## Follow-up (not in this PR)

Both tables still hand-roll a raw `<table>` while the repo ships a shadcn `<Table>` primitive (`frontend/src/components/ui/table.tsx`) that already bakes in `whitespace-nowrap` + `overflow-x-auto`. Migrating Services/Loans onto it would change row hover/border styling and the test surface, so it's worth a separate tracked issue rather than scope creep here.