### PR TITLE
Gate /api/v1/seed behind an enable flag (off by default) (#2039)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,12 @@ ADMIN_NAME=System Administrator
 # Set to 'false' to start with a clean database (you'll need to configure settings manually)
 SEED_DATABASE=true
 
+# Gate for the public, unauthenticated POST /api/v1/seed route (#2039). Off by
+# default in production: it exposes a privileged, RLS-bypassing operation. The
+# compose stack's init-data seed server enables it so seeding works; leave it
+# 'false' for any externally exposed app server.
+ENABLE_SEED_ENDPOINT=true
+
 # Worker Configuration
 MAX_CONCURRENT_EXPORTS=3
 MAX_CONCURRENT_IMPORTS=1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -358,6 +358,11 @@ jobs:
           # platform admin. OFF by default in the binary — /api/v1/seed is
           # unauthenticated, so this must never be set in a real deployment.
           INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"
+          # Mount the public POST /api/v1/seed route (#2039) so the
+          # "Seed test fixtures" step below can reach it. OFF by default in
+          # the binary (it runs a privileged, RLS-bypassing operation); set
+          # here only for this throwaway CI server, never in a real deployment.
+          INVENTARIO_RUN_ENABLE_SEED_ENDPOINT: "true"
         run: |
           mkdir -p /tmp/inventario-uploads
           nohup ./bin/inventario run > /tmp/inventario.log 2>&1 &

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The system implements enterprise-grade multi-tenancy with:
   4. Review the generated SQL, run `go test ./schema/migrations/...` locally, then commit both files.
   If the generator output looks wrong, fix the **model annotations** and regenerate — don't edit the SQL by hand.
   **Hand-written migrations exception.** Some changes can't be expressed via model annotations (data backfills, view refactors, multi-step `ALTER`s, one-off custom DDL). In those rare cases — **STOP and ask the user for explicit permission before writing SQL by hand**. Do not improvise. The user will tell you whether to handcraft the migration or land it as a follow-up using a different approach (e.g. a runtime backfill worker). The CI check still has to pass afterward, so the user's approval includes the trade-off of suppressing drift detection for that specific file.
-- `curl http://localhost:3333/api/v1/seed` - Seed the database with test data
+- `curl http://localhost:3333/api/v1/seed` - Seed the database with test data (the route is gated off by default since #2039; run the server with `--enable-seed-endpoint` / `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true` first)
 - `./inventario tenants create` - Create tenants for initial setup
 - `./inventario tenants list` - List all tenants with filtering
 - `./inventario tenants get <id-or-slug>` - Get detailed tenant information

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,9 +18,14 @@ This document describes how to run Inventario using Docker and Docker Compose wi
    Open your browser and navigate to http://localhost:3333
 
 4. **Seed the database** (optional):
-   ```bash
-   curl -X POST http://localhost:3333/api/v1/seed
-   ```
+
+   The compose stack seeds automatically: the `inventario-init-data` service
+   boots a throwaway server with the seed route enabled and POSTs `/seed`
+   when `SEED_DATABASE=true` (the default in `.env.example`). The long-running
+   `inventario` service deliberately does NOT expose `/api/v1/seed` — that
+   route runs a privileged, RLS-bypassing operation and is off by default
+   (#2039). To re-seed manually, set `SEED_DATABASE=true` and recreate the
+   `inventario-init-data` service rather than curling the app service.
 
 ## Configuration
 
@@ -105,8 +110,10 @@ docker-compose exec -T postgres psql -U inventario -d inventario < backup.sql
 # Execute commands in the application container
 docker-compose exec inventario ./inventario --help
 
-# Seed the database
-docker-compose exec inventario curl -X POST http://localhost:3333/api/v1/seed
+# Seed the database (handled automatically by the inventario-init-data
+# service; the long-running inventario service does NOT expose /api/v1/seed —
+# it is off by default, #2039). Re-seed by recreating inventario-init-data
+# with SEED_DATABASE=true.
 
 # Run database migrations
 docker-compose exec inventario ./inventario migrate

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,17 @@ version:
 	@echo "Build Date: $(BUILD_DATE)"
 
 # Run the backend server
+# --enable-seed-endpoint mounts the public /api/v1/seed route (used by the
+# seed-db target). It is OFF by default in the binary (#2039) and must stay
+# off in production; these are local dev targets, so it is safe to enable here.
 .PHONY: run-backend
 run-backend: build-backend
-	$(BINARY_PATH) run --addr $(SERVER_ADDR) --upload-location $(UPLOAD_LOCATION) --db-dsn $(DB_DSN)
+	$(BINARY_PATH) run --addr $(SERVER_ADDR) --upload-location $(UPLOAD_LOCATION) --db-dsn $(DB_DSN) --enable-seed-endpoint
 
 # Run the backend server with PostgreSQL
 .PHONY: run-backend-postgres
 run-backend-postgres: build-backend
-	$(BINARY_PATH) run --addr $(SERVER_ADDR) --upload-location $(UPLOAD_LOCATION) --db-dsn postgres://postgres:password@localhost:5432/inventario
+	$(BINARY_PATH) run --addr $(SERVER_ADDR) --upload-location $(UPLOAD_LOCATION) --db-dsn postgres://postgres:password@localhost:5432/inventario --enable-seed-endpoint
 
 # Run the React frontend dev server (Vite). Proxies /api to :3333.
 .PHONY: run-frontend
@@ -137,7 +140,8 @@ test: test-go test-frontend
 test-e2e:
 	cd e2e && npm install && npm run test
 
-# Seed the database
+# Seed the database (requires the server to run with --enable-seed-endpoint,
+# which the run-backend targets above pass; #2039).
 .PHONY: seed-db
 seed-db:
 	@echo "Seeding the database..."

--- a/README.md
+++ b/README.md
@@ -320,9 +320,11 @@ canonical worker types, the equivalent admin REST API, and the
    make all
    ```
 
-3. **Run the application**:
+3. **Run the application** (`--enable-seed-endpoint` mounts the public
+   `/api/v1/seed` route used by the next step — it is OFF by default and
+   must stay off in production):
    ```bash
-   cd bin && ./inventario run
+   cd bin && ./inventario run --enable-seed-endpoint
    ```
 
 4. **Seed the database** (optional, for development):
@@ -353,9 +355,11 @@ canonical worker types, the equivalent admin REST API, and the
    make all
    ```
 
-3. **Run the application**:
+3. **Run the application** (`--enable-seed-endpoint` mounts the public
+   `/api/v1/seed` route used by the next step — it is OFF by default and
+   must stay off in production):
    ```bash
-   cd bin && ./inventario run
+   cd bin && ./inventario run --enable-seed-endpoint
    ```
 
 4. **Seed the database** (optional, for development):
@@ -384,10 +388,12 @@ canonical worker types, the equivalent admin REST API, and the
    ```
    Note: If you don't have Make installed, you can use Git Bash which includes Make.
 
-3. **Run the application**:
+3. **Run the application** (`--enable-seed-endpoint` mounts the public
+   `/api/v1/seed` route used by the next step — it is OFF by default and
+   must stay off in production):
    ```powershell
    cd bin
-   .\inventario.exe run
+   .\inventario.exe run --enable-seed-endpoint
    ```
 
 4. **Seed the database** (optional, for development):

--- a/devdocs/frontend/screenshots.md
+++ b/devdocs/frontend/screenshots.md
@@ -46,8 +46,13 @@ for screenshots.
   --addr=":3333" \
   --db-dsn="memory://" \
   --no-auth-rate-limit \
-  --no-global-rate-limit
+  --no-global-rate-limit \
+  --enable-seed-endpoint
 ```
+
+`--enable-seed-endpoint` mounts the public `POST /api/v1/seed` route the next
+step curls. It is OFF by default — the route runs a privileged, RLS-bypassing
+operation — and must never be enabled in a real deployment (#2039).
 
 `memory://` means data lives in process memory and goes away on restart —
 fine for screenshots, useless for anything else. Drop the rate-limit

--- a/devdocs/security/admin-threat-model.md
+++ b/devdocs/security/admin-threat-model.md
@@ -46,7 +46,13 @@ they reach `/api/v1/admin/*`.
   `ensureSystemAdminUser` fixture, which is gated behind the
   `INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE` opt-in (off by default) — so
   the unauthenticated `/api/v1/seed` endpoint cannot mint a
-  cross-tenant admin in a production deployment.
+  cross-tenant admin in a production deployment. Defence in depth
+  (#2039): the `/api/v1/seed` route itself is now off by default and is
+  only mounted when `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true`
+  (`--enable-seed-endpoint`), set only on the throwaway init-data /
+  e2e seed servers — production app servers do not expose it at all,
+  so an anonymous caller gets a 404 rather than reaching the
+  privileged, RLS-bypassing seed path.
 - The JWT `is_system_admin` claim is signed (HS256) with the server
   secret; a tampered claim fails signature verification. The claim is
   an advisory FE hint only — backend authorization always re-queries

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -44,6 +44,10 @@ services:
       # admin. OFF by default in the binary — /api/v1/seed is
       # unauthenticated, so this must never be set in a real deployment.
       INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"
+      # Mount /api/v1/seed on the init-data seed server (#2039). The base
+      # compose already sets this on inventario-init-data; repeated here so
+      # the e2e seed path is self-documenting and survives any base change.
+      INVENTARIO_RUN_ENABLE_SEED_ENDPOINT: "true"
 
   inventario:
     image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,6 +148,11 @@ services:
       SEED_DATABASE: ${SEED_DATABASE:-true}
       # JWT secret required for seed endpoint
       INVENTARIO_RUN_JWT_SECRET: ${JWT_SECRET:-please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32}
+      # Mount the public /api/v1/seed route on the throwaway server that
+      # init-data.sh boots to curl it (#2039). Off by default everywhere else
+      # (it exposes a privileged RLS-bypassing operation); NEVER set on the
+      # long-running `inventario` service below.
+      INVENTARIO_RUN_ENABLE_SEED_ENDPOINT: ${ENABLE_SEED_ENDPOINT:-true}
     volumes:
       # Track initialization state to prevent re-running
       - ./.docker/init-state:/app/state

--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -7,9 +7,11 @@
 //        make build-frontend
 //   2. Build the binary with the with_frontend tag:
 //        cd go/cmd/inventario && go build -tags with_frontend -o ../../../bin/inventario .
-//   3. Run the binary:
+//   3. Run the binary (--enable-seed-endpoint mounts the public /seed
+//      route, which is OFF by default in production — #2039):
 //        ./bin/inventario run --db-dsn=memory:// \
-//          --no-auth-rate-limit --no-global-rate-limit
+//          --no-auth-rate-limit --no-global-rate-limit \
+//          --enable-seed-endpoint
 //   4. Seed the DB:
 //        curl -X POST http://localhost:3333/api/v1/seed
 //   5. Run this script:

--- a/e2e/setup/setup-stack.ts
+++ b/e2e/setup/setup-stack.ts
@@ -160,6 +160,12 @@ export async function startBackend(): Promise<void> {
       // deployment.
       INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE:
         process.env.INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE ?? 'true',
+      // Mount the public POST /api/v1/seed route (#2039) so seedDatabase()
+      // below can reach it. The endpoint is OFF by default in the binary —
+      // it runs a privileged, RLS-bypassing operation — and must never be
+      // enabled in a real deployment; here it backs the e2e fixture seed.
+      INVENTARIO_RUN_ENABLE_SEED_ENDPOINT:
+        process.env.INVENTARIO_RUN_ENABLE_SEED_ENDPOINT ?? 'true',
       // Currency-migration surface defaults on in the binary now
       // (Config.FeatureCurrencyMigration env-default since #1612). Pass
       // an explicit override through only if the operator wants to flip

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -260,6 +260,16 @@ type Params struct {
 	// AuthRateLimiter so existing callers/tests keep working.
 	PublicScanRateLimiter services.AuthRateLimiter
 
+	// SeedEndpointEnabled gates the PUBLIC, UNAUTHENTICATED POST /seed
+	// endpoint (#2039). Default FALSE: Seed runs a privileged,
+	// RLS-bypassing service-registry operation (debug/seeddata), so an
+	// anonymous caller could pollute the production tenant. It must be
+	// opted into explicitly and MUST stay off in production. When false
+	// the POST /api/v1/seed route is NOT mounted (404). It is enabled only
+	// where seeding is intended: dev / e2e stacks and the throwaway
+	// localhost server the Helm init-data Job boots to curl /seed.
+	SeedEndpointEnabled bool
+
 	// OAuthRegistry holds the third-party sign-in providers enabled in
 	// this deployment (#1394). Empty means OAuth is unconfigured — the
 	// /auth/oauth/providers endpoint surfaces an empty list and start /
@@ -558,9 +568,17 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 					CommodityScanPublic(params.CommodityScanService, params.CommodityScanMaxBodyBytes, params.CommodityScanMaxPhotoBytes),
 				)
 			}
-			// Seed endpoint is public for e2e testing and development.
-			// Seed uses a service registry set since it's a privileged operation in dev/test.
-			r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet, params.UploadLocation))
+			// Seed endpoint (#2039). Mounted ONLY when the operator opts in
+			// via SeedEndpointEnabled — otherwise the route stays absent
+			// (404). Seed uses a SERVICE registry set, so it is a privileged,
+			// RLS-bypassing operation with no auth wall: leaving it public by
+			// default lets an anonymous caller pollute the production tenant.
+			// It is enabled only where seeding is intended (dev / e2e stacks
+			// and the throwaway localhost server the Helm init-data Job boots);
+			// production app servers leave it off.
+			if params.SeedEndpointEnabled {
+				r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet, params.UploadLocation))
+			}
 		})
 
 		// Create user aware middlewares for protected routes

--- a/go/apiserver/seed_test.go
+++ b/go/apiserver/seed_test.go
@@ -15,6 +15,48 @@ import (
 	"github.com/denisvmedia/inventario/registry/memory"
 )
 
+// seedURL is the public, gated seed endpoint path (#2039).
+const seedURL = "/api/v1/seed"
+
+func postSeed(handler http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, seedURL, strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestSeed_FlagOff_NotMounted is the #2039 regression: /seed runs a
+// privileged, RLS-bypassing service operation, so it stays absent (404) when
+// SeedEndpointEnabled is false — the production default.
+func TestSeed_FlagOff_NotMounted(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.SeedEndpointEnabled = false // explicit: route must not be mounted
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := postSeed(handler)
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+// TestSeed_FlagOn_Mounted asserts the route is reachable and seeds when the
+// operator opts in via SeedEndpointEnabled (dev / e2e / init-data Job).
+func TestSeed_FlagOn_Mounted(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.SeedEndpointEnabled = true
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := postSeed(handler)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	var resp apiserver.SeedResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.Status, qt.Equals, "success")
+}
+
 func TestSeed_FirstCallReportsFreshSeed(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/apiserver/swagger_route_coverage_test.go
+++ b/go/apiserver/swagger_route_coverage_test.go
@@ -34,6 +34,10 @@ func TestSwaggerRouteCoverage(t *testing.T) {
 	// be (incorrectly) reported as stale.
 	params.PublicScanEnabled = true
 	params.CommodityScanService = services.NewCommodityScanService(nil, params.FactorySet.CommodityScanAuditRegistry, services.CommodityScanConfig{})
+	// /seed is gated off by default (#2039) but documented via its
+	// @Router annotation, so mount it here too or its operation reads as
+	// stale.
+	params.SeedEndpointEnabled = true
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 	router, ok := handler.(chi.Router)
 	if !ok {

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -130,6 +130,16 @@ type Config struct {
 	// takes effect when a real AI vision provider is also configured.
 	PublicAIVisionScanEnabled bool `yaml:"public_ai_vision_scan_enabled" env:"PUBLIC_AI_VISION_SCAN_ENABLED" env-default:"false"`
 
+	// SeedEndpointEnabled gates the PUBLIC, UNAUTHENTICATED POST /api/v1/seed
+	// endpoint (#2039). Default FALSE. Seed runs a privileged, RLS-bypassing
+	// service-registry operation, so leaving it public lets an anonymous
+	// caller pollute the production tenant — it MUST stay off in production.
+	// Enable it (env INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true /
+	// --enable-seed-endpoint) only where seeding is intended: dev / e2e
+	// stacks and the throwaway localhost server the Helm init-data Job boots
+	// to curl /seed.
+	SeedEndpointEnabled bool `yaml:"enable_seed_endpoint" env:"ENABLE_SEED_ENDPOINT" env-default:"false"`
+
 	// WorkersOnly / WorkersExclude restrict which background workers run in
 	// `inventario run workers`. See the run/workers package for the accepted
 	// syntax and mutual-exclusion rules. Both fields default to empty, meaning

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -104,6 +104,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.IntVar(&cfg.AIVisionRateLimitPerHour, "ai-vision-rate-limit-per-hour", cfg.AIVisionRateLimitPerHour, "Per-user hourly scan rate limit (0 disables the limit)")
 	flags.IntVar(&cfg.AIVisionMaxTokens, "ai-vision-max-tokens", cfg.AIVisionMaxTokens, "Cap on the vision model's structured output (must hold a multi-line invoice; 0 = provider default 4096)")
 	flags.BoolVar(&cfg.PublicAIVisionScanEnabled, "public-ai-vision-scan-enabled", cfg.PublicAIVisionScanEnabled, "Enable the unauthenticated public photo-scan endpoint for the landing-page CTA (#1988). Default false; spends vendor tokens.")
+	flags.BoolVar(&cfg.SeedEndpointEnabled, "enable-seed-endpoint", cfg.SeedEndpointEnabled, "Mount the public, unauthenticated POST /api/v1/seed route (#2039). Default false; runs a privileged RLS-bypassing op — keep off in prod.")
 
 	// OAuth third-party sign-in (issue #1394). Each provider requires
 	// BOTH a client id AND a client secret to be enabled; the redirect

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -181,6 +181,11 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 
 	params.FeatureCurrencyMigration = cfg.FeatureCurrencyMigration
 	params.MagicLinkLoginEnabled = resolveMagicLinkLoginEnabled(cfg)
+	// Public, unauthenticated /seed gate (#2039). Off by default; mounting
+	// the route exposes a privileged RLS-bypassing operation, so it must stay
+	// off in production and is opted into only on dev / e2e / the init-data
+	// seed server.
+	params.SeedEndpointEnabled = cfg.SeedEndpointEnabled
 
 	emailLifecycle, err := buildEmailService(cfg)
 	if err != nil {

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -306,6 +306,13 @@ spec:
             # MinIO demo, where the app can never read them.
             - name: INVENTARIO_RUN_UPLOAD_LOCATION
               value: {{ include "inventario.uploadLocation" . | quote }}
+            # Mount the public /api/v1/seed route ONLY on this throwaway
+            # in-Job seed server so the shell step can curl it (#2039). Seed
+            # runs a privileged, RLS-bypassing operation, so the route is off
+            # by default everywhere else; it is set here and NEVER on the main
+            # app Deployment / ConfigMap, keeping production unable to seed.
+            - name: INVENTARIO_RUN_ENABLE_SEED_ENDPOINT
+              value: "true"
             {{- if .Values.demo.redis.enabled }}
             - name: INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL
               value: {{ $redisUrl | quote }}

--- a/k8s/dev/inventario/deployment.yaml
+++ b/k8s/dev/inventario/deployment.yaml
@@ -256,6 +256,13 @@ spec:
                 secretKeyRef:
                   name: inventario-secrets
                   key: APP_DB_DSN
+            # Mount the public /api/v1/seed route ONLY on this throwaway
+            # init-data seed server (#2039). It is set as a direct env on the
+            # init container, NOT in inventario-config, so the long-running
+            # `inventario` container below (which shares that ConfigMap) keeps
+            # the privileged route off.
+            - name: INVENTARIO_RUN_ENABLE_SEED_ENDPOINT
+              value: "true"
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/k8s/prod/job-setup.yaml
+++ b/k8s/prod/job-setup.yaml
@@ -180,6 +180,16 @@ spec:
                 secretKeyRef:
                   name: inventario-secrets
                   key: jwt-secret
+            # Mount the public /api/v1/seed route ONLY on this throwaway
+            # one-shot setup-Job seed server (#2039). The server is curled by
+            # the step above when an operator opts in via SEED_DATABASE=true
+            # (default false); it runs to completion and dies, exposing
+            # nothing at runtime. Set as a direct env on the init container,
+            # NOT in inventario-config, so the long-running `inventario`
+            # Deployment (which shares that ConfigMap) keeps the privileged
+            # route off. Without this the opt-in seed would 404.
+            - name: INVENTARIO_RUN_ENABLE_SEED_ENDPOINT
+              value: "true"
           volumeMounts:
             - name: app-data
               mountPath: /data


### PR DESCRIPTION
## Summary

The public `POST /api/v1/seed` endpoint was mounted **unconditionally** inside the pre-auth route group (`apiserver.go`, inside `defaultAPIMiddlewares` which has no auth). The seed handler runs a **privileged, RLS-bypassing service-registry operation** (`debug/seeddata` via `CreateServiceRegistrySet()`), so an anonymous caller could seed/pollute the production tenant. This PR gates the route behind an opt-in flag that is **off by default**, so production app servers return 404 for `/seed` while dev / e2e / the seed-Job throwaway servers keep working.

The change mirrors the existing `PublicScanEnabled` plumbing exactly.

## Security rationale

`/seed` is unauthenticated and uses the service registry (no tenant isolation). Leaving it mounted by default means any anonymous HTTP client reaching a production app server could trigger a privileged seed. After this change the route is simply **not registered** unless the operator explicitly opts in — an attacker gets a 404, never reaching the handler. This is defence-in-depth on top of the existing `INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE` gate (which already blocked the worst case of minting a cross-tenant admin).

## The flag

| | Value |
|---|---|
| Config field | `Config.SeedEndpointEnabled` / `Params.SeedEndpointEnabled` |
| Env | `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT` |
| CLI flag | `--enable-seed-endpoint` |
| Default | `false` |

When false, `apiserver.go` does not mount `/seed` (404). When true, it mounts exactly as before.

## Where it is enabled (production stays off)

- **Helm** `templates/job-init-data.yaml` — the throwaway in-Job `inventario run` seed server only. Verified via `helm template`: the env appears on the `init-data` Job and is **absent** from the main app Deployment and the ConfigMap.
- **docker-compose.yaml** — `inventario-init-data` (which boots its own server via `scripts/init-data.sh` and curls `/seed`), via `ENABLE_SEED_ENDPOINT` (default `true`) documented in `.env.example`. The long-running `inventario` service does **not** get it.
- **docker-compose.e2e.yaml** — explicit on `inventario-init-data` (self-documenting; also inherited from base).
- **k8s/dev** `inventario/deployment.yaml` — direct env on the `init-data` init container only (not the shared `inventario-config` ConfigMap), so the long-running container stays off.
- **k8s/prod** `job-setup.yaml` — direct env on the setup-Job `init-data` init container only. **See deviation note below.**
- **e2e Playwright harness** `e2e/setup/setup-stack.ts` — added to the spawned backend's env so `seedDatabase()` can reach `/seed`.
- **Local dev** — `Makefile` `run-backend` / `run-backend-postgres` targets; README quickstart (all 3 OS sections), `DOCKER.md`, `devdocs/frontend/screenshots.md`, `e2e/screenshots.mjs` usage notes.

## Deviation from the spec

The task said "do not touch `k8s/prod/*`". However `k8s/prod/job-setup.yaml` has a real seed path: its `init-data` step boots a throwaway `inventario run` and curls `/api/v1/seed` **when an operator opts in via `SEED_DATABASE=true`** (default false). Without the flag that opt-in would silently 404. I enabled the flag **only on that one-shot setup-Job init container** (a throwaway server that runs to completion and dies — it never serves runtime traffic), set as a direct container env, never in the shared ConfigMap. The long-running prod app **Deployment** is untouched and stays off. This honours the stronger intent ("production must stay off") for the externally exposed app server while keeping the documented opt-in seed working.

## Swagger route coverage

`/seed` is documented via the `@Router /seed [post]` annotation. `TestSwaggerRouteCoverage` builds the full router and asserts bidirectional documented↔mounted parity. Resolved the least-surprising way (preferred option in the spec): the test now sets `params.SeedEndpointEnabled = true`, the same way it already sets `PublicScanEnabled = true` for the conditionally-gated public-scan route. No swagger regeneration needed — annotations are unchanged and `go/docs/` + `frontend/src/types/` show no drift.

## Test notes

- New regression tests in `apiserver/seed_test.go`: `TestSeed_FlagOff_NotMounted` (404 with flag false) and `TestSeed_FlagOn_Mounted` (200 with flag true), both via the full `APIServer`.
- The existing direct-handler seed tests are unaffected (they mount `Seed(...)` directly, bypassing the gate).

### Verification run

| Check | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./apiserver/... ./cmd/...` | pass |
| `golangci-lint run --fix` (apiserver + run bootstrap) | pass, 0 issues |
| `go tool nolintguard` (touched pkgs) | pass |
| `go tool qtlint` (touched pkgs) | pass |
| `go test ./apiserver/... ./cmd/...` | pass (16 pkgs ok) |
| `helm template` seed on/off | env on init-data Job only; absent from Deployment + ConfigMap |
| `docker compose config` (base + e2e) | env on `inventario-init-data` only |

Not run: `registry/postgres/...` and `services/files_backfill/...` Postgres-backed suites (no `POSTGRES_TEST_DSN` in this environment). This change does not touch those packages; the apiserver tests run against the in-memory backend.

Closes #2039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--enable-seed-endpoint` configuration flag to control access to the test data seeding endpoint.

* **Security**
  * Test data seeding endpoint is now disabled by default; requires explicit enablement in development environments.

* **Documentation**
  * Updated development and deployment guides to document the new seeding endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->