### PR TITLE
fix(dashboard): open Recently Added rows in the slide-out item sheet

### DIFF
--- a/frontend/src/components/dashboard/RecentlyAdded.tsx
+++ b/frontend/src/components/dashboard/RecentlyAdded.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import { Package } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -18,13 +18,21 @@ interface RecentlyAddedProps {
   isLoading?: boolean
 }
 
-// RecentlyAdded is the right-hand list on the dashboard. Each row links
-// to /g/:slug/commodities/:id (the items detail page lives in #1410;
-// the placeholder mounted there today still renders a recognisable
-// "Coming soon" stub, so the click target is not a dead end).
+// RecentlyAdded is the right-hand list on the dashboard. A plain click on
+// a row opens the commodity detail in the slide-out sheet overlay (mock
+// parity, #1581 item 6) by stamping the current dashboard URL onto
+// `state.background` — the router (app/router.tsx) reads that state and
+// renders CommodityDetailSheet on top of the dashboard. This is the same
+// row→sheet pattern the items list uses (CommoditiesListPage's
+// `openCommodityInSheet`). Modifier / middle clicks fall through to the
+// underlying <Link> so "open in new tab" lands on the full detail page (a
+// new document carries no `state.background`, so the overlay tree stays
+// unmounted there).
 export function RecentlyAdded({ items, isLoading = false }: RecentlyAddedProps) {
   const { t } = useTranslation()
   const { currentGroup } = useCurrentGroup()
+  const navigate = useNavigate()
+  const location = useLocation()
   const slug = currentGroup?.slug
   return (
     <Card>
@@ -66,6 +74,18 @@ export function RecentlyAdded({ items, isLoading = false }: RecentlyAddedProps) 
                       ? `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(item.id)}`
                       : "#"
                   }
+                  onClick={(e) => {
+                    // Plain left-click → open the slide-out sheet over the
+                    // dashboard. Let modifier / middle clicks through so the
+                    // browser opens the full page in a new tab.
+                    if (!slug || !item.id) return
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+                    e.preventDefault()
+                    navigate(
+                      `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(item.id)}`,
+                      { state: { background: location } }
+                    )
+                  }}
                   className="flex w-full items-center justify-between gap-3 px-6 py-3.5 text-left transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 outline-none"
                   data-testid="recently-added-row"
                 >

--- a/frontend/src/components/dashboard/RecentlyAdded.tsx
+++ b/frontend/src/components/dashboard/RecentlyAdded.tsx
@@ -79,7 +79,7 @@ export function RecentlyAdded({ items, isLoading = false }: RecentlyAddedProps) 
                     // dashboard. Let modifier / middle clicks through so the
                     // browser opens the full page in a new tab.
                     if (!slug || !item.id) return
-                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
                     e.preventDefault()
                     navigate(
                       `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(item.id)}`,

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -100,6 +100,55 @@ describe("<DashboardPage />", () => {
     expect(rows[2]).toHaveTextContent("Office chair")
   })
 
+  // #1581 item 6: a plain click on a Recently-Added row opens the
+  // commodity detail in the slide-out sheet overlay — it navigates to the
+  // detail route AND stamps the current dashboard URL onto
+  // `state.background` (the signal app/router.tsx reads to render the
+  // sheet over the backdrop). Mirrors the items-list row→sheet pattern.
+  it("opens a Recently-Added row in the sheet overlay (navigates with state.background)", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c1", { name: "MacBook Pro", registered_date: "2026-04-20" }),
+      ]),
+      ...commodityHandlers.values(SLUG, { globalTotal: 1500 })
+    )
+    function NavSentinel() {
+      const location = useLocation()
+      const hasBackground = !!(location.state as { background?: unknown } | null)?.background
+      return (
+        <div>
+          <span data-testid="nav-sentinel-path">{location.pathname}</span>
+          <span data-testid="nav-sentinel-bg">{hasBackground ? "yes" : "no"}</span>
+        </div>
+      )
+    }
+    setAccessToken("good-token")
+    renderWithProviders({
+      initialPath: `/g/${SLUG}`,
+      routes: (
+        <>
+          <Route
+            path="/g/:groupSlug"
+            element={
+              <GroupProvider>
+                <DashboardPage />
+              </GroupProvider>
+            }
+          />
+          <Route path="/g/:groupSlug/commodities/:id" element={<NavSentinel />} />
+        </>
+      ),
+    })
+    const row = await screen.findByTestId("recently-added-row")
+    const user = userEvent.setup()
+    await user.click(row)
+    expect(await screen.findByTestId("nav-sentinel-path")).toHaveTextContent(
+      `/g/${SLUG}/commodities/c1`
+    )
+    expect(screen.getByTestId("nav-sentinel-bg")).toHaveTextContent("yes")
+  })
+
   // #1684: low-denomination currencies (HUF / IDR / VND / KRW / IRR / …)
   // hit 8–9 digit totals routinely and clip the half-screen stat-card
   // cell even with cents dropped. At ≥1e7 the hero hands off to


### PR DESCRIPTION
## What

Closes #1581 (item 6 — the last remaining gap; the other 5 items were verified already addressed, see the validation comment on the issue).

Recently-Added dashboard rows were clickable and showed warranty badges, but a click navigated to the **full bare detail page** instead of the **slide-out item sheet** the design mock calls for (`design-mocks/src/views/DashboardView.tsx:194` wires rows to the same `onItemClick` that opens item detail).

## How

`frontend/src/components/dashboard/RecentlyAdded.tsx`:
- A plain left-click now `preventDefault()`s and navigates imperatively with `state: { background: location }`, so `app/router.tsx` (which reads `location.state.background`) renders `CommodityDetailSheet` over the dashboard backdrop.
- Modifier / middle clicks fall through to the underlying `<Link>`, so "open in new tab" still lands on the full detail page (a fresh document carries no `state.background`, so the overlay tree stays unmounted there).
- Refreshed a stale doc-comment that referenced the long-gone `#1410` "Coming soon" detail stub.

This mirrors the established items-list row→sheet pattern (`CommoditiesListPage.tsx` `openCommodityInSheet` at `:334-337` and the modifier-aware row handlers at `:1238-1239` / `:1428-1431`).

No visual change to the component and **no design-mock deviation** — this aligns the behaviour *with* the mock.

## Tests

`frontend/src/pages/Dashboard.test.tsx`: new regression test asserting a Recently-Added click navigates to `/g/:slug/commodities/:id` **with** `state.background` set (via a `NavSentinel`, mirroring the existing mobile-CTA test).

Local gates green: `tsc -b --noEmit`, `vitest Dashboard.test.tsx` (13/13), ESLint (touched files), Prettier `--check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recently added commodities can now be clicked to open detailed information in a slide-out overlay on the dashboard, providing quick access without fully navigating away.
  * Standard link behaviors for modifier keys and middle-clicks are preserved for opening full detail pages.

* **Tests**
  * Added test coverage for overlay navigation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->