### PR TITLE
fix(first-run): unbreak the default deploy (JWT secret, admin password, email, example DSN)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,12 @@ INVENTARIO_PORT=3333
 INVENTARIO_UPLOAD_LOCATION=file:///app/uploads?create_dir=1
 PUBLIC_URL=http://localhost:3333
 
-# Security Configuration (REQUIRED)
-# Generate with: openssl rand -hex 32
-JWT_SECRET=please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32
-FILE_SIGNING_KEY=please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32
+# Security Configuration
+# Generate with `openssl rand -hex 32`; leaving these unset yields an
+# auto-generated ephemeral key (dev only — set a fixed value in production,
+# see PRODUCTION.md).
+# JWT_SECRET=
+# FILE_SIGNING_KEY=
 FILE_URL_EXPIRATION=15m
 
 # Initial Data Setup (runs only once on first startup)

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -9,6 +9,11 @@ This document describes how to run Inventario using Docker and Docker Compose wi
    cp .env.example .env
    ```
 
+   > `JWT_SECRET` and `FILE_SIGNING_KEY` are left unset by default, so the
+   > backend auto-generates an ephemeral random key on each start — fine for
+   > local dev only. For any real or network-exposed deployment, set both in
+   > `.env` to your own secrets (`openssl rand -hex 32`).
+
 2. **Start the services**:
    ```bash
    docker-compose up -d

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -36,6 +36,12 @@ cd inventario
 docker-compose up -d
 ```
 
+> **Note:** The default compose leaves `JWT_SECRET` and `FILE_SIGNING_KEY`
+> unset, so the backend auto-generates an ephemeral random key on each start —
+> suitable for local dev only. For any real or network-exposed deployment, set
+> both to your own secrets (`openssl rand -hex 32`) as shown in
+> [Next Steps](#change-default-credentials-recommended).
+
 That's it! The first startup will take a few minutes to:
 - Build the application image
 - Set up PostgreSQL database
@@ -53,7 +59,7 @@ http://localhost:3333
 
 **Login Credentials** (from `.env.example` configuration):
 - **Email:** `admin@example.com`
-- **Password:** `admin123`
+- **Password:** `Admin123`
 
 > **Note:** If you created a custom `.env` file with different `ADMIN_EMAIL` and `ADMIN_PASSWORD` values, use those credentials instead.
 >
@@ -143,7 +149,7 @@ docker-compose down -v
 | `JWT_SECRET` | (see .env.example) | JWT signing secret (32+ chars) |
 | `FILE_SIGNING_KEY` | (see .env.example) | File URL signing key (32+ chars) |
 | `ADMIN_EMAIL` | `admin@example.com` | Initial admin email |
-| `ADMIN_PASSWORD` | `admin123` | Initial admin password |
+| `ADMIN_PASSWORD` | `Admin123` | Initial admin password |
 | `DEFAULT_TENANT_NAME` | `Test Organization` | Organization name |
 | `SEED_DATABASE` | `true` | Seed with example data and settings (set to `false` for clean start) |
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ git clone https://github.com/denisvmedia/inventario.git
 cd inventario
 docker-compose up -d
 # Open http://localhost:3333
-# Login with credentials from .env.example: admin@example.com / admin123
+# Login with credentials from .env.example: admin@example.com / Admin123
 ```
+
+> The default compose leaves `JWT_SECRET` and `FILE_SIGNING_KEY` unset, so the
+> backend auto-generates an ephemeral random key on each start — fine for local
+> dev only. For any real or network-exposed deployment, set both to your own
+> secrets (`openssl rand -hex 32`).
 
 **Going to production on Kubernetes?** Follow the [Production Release & Deployment Runbook](PRODUCTION.md) — a step-by-step checklist that cuts a release and deploys to any Kubernetes distribution (k3s, GKE, DigitalOcean DOKS).
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -142,12 +142,13 @@ services:
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG: ${DEFAULT_TENANT_SLUG:-default}
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_REGISTRATION_MODE: ${DEFAULT_TENANT_REGISTRATION_MODE:-closed}
       INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin123}
+      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: ${ADMIN_PASSWORD:-Admin123}
       INVENTARIO_MIGRATE_DATA_ADMIN_NAME: ${ADMIN_NAME:-System Administrator}
       # Seeding configuration (optional - includes example data and system settings)
       SEED_DATABASE: ${SEED_DATABASE:-true}
-      # JWT secret required for seed endpoint
-      INVENTARIO_RUN_JWT_SECRET: ${JWT_SECRET:-please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32}
+      # JWT secret required for seed endpoint.
+      # Empty default → backend auto-generates an ephemeral random key (dev only).
+      INVENTARIO_RUN_JWT_SECRET: ${JWT_SECRET:-}
       # Mount the public /api/v1/seed route on the throwaway server that
       # init-data.sh boots to curl it (#2039). Off by default everywhere else
       # (it exposes a privileged RLS-bypassing operation); NEVER set on the
@@ -193,9 +194,11 @@ services:
       # File storage configuration
       INVENTARIO_UPLOAD_LOCATION: "${INVENTARIO_UPLOAD_LOCATION:-file:///app/uploads?create_dir=1}"
 
-      # Security configuration
-      INVENTARIO_RUN_JWT_SECRET: ${JWT_SECRET:-please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32}
-      INVENTARIO_RUN_FILE_SIGNING_KEY: ${FILE_SIGNING_KEY:-please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32}
+      # Security configuration.
+      # Empty defaults → backend auto-generates ephemeral random keys (dev only).
+      # Set a fixed JWT_SECRET / FILE_SIGNING_KEY in production (see PRODUCTION.md).
+      INVENTARIO_RUN_JWT_SECRET: ${JWT_SECRET:-}
+      INVENTARIO_RUN_FILE_SIGNING_KEY: ${FILE_SIGNING_KEY:-}
       INVENTARIO_RUN_FILE_URL_EXPIRATION: ${FILE_URL_EXPIRATION:-15m}
 
       # Worker configuration

--- a/example/.env.example
+++ b/example/.env.example
@@ -8,6 +8,11 @@
 
 # Application Configuration
 INVENTARIO_HOST_PORT=3333
+# REQUIRED for production: generate each with `openssl rand -hex 32`.
+# The placeholders below are rejected at startup (the app refuses to boot) so a
+# deployment can never run on a public example secret — replace them with real
+# values. To run the example locally with throwaway ephemeral keys instead,
+# comment these two lines out (an unset secret is auto-generated per restart).
 JWT_SECRET=your-secure-32-byte-jwt-secret-here-replace-this-value
 FILE_SIGNING_KEY=your-secure-32-byte-file-signing-key-here-replace-this-value
 FILE_URL_EXPIRATION=15m

--- a/example/.env.example
+++ b/example/.env.example
@@ -37,7 +37,7 @@ POSTGRES_MIGRATOR_PASSWORD=inventario_migrator_password
 DEFAULT_TENANT_NAME=Default Organization
 DEFAULT_TENANT_SLUG=default
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=admin123
+ADMIN_PASSWORD=Admin123
 ADMIN_NAME=System Administrator
 
 # Security Note:

--- a/example/README.md
+++ b/example/README.md
@@ -33,7 +33,8 @@ This directory contains a production-ready Docker Compose configuration for depl
 
 ### Services
 
-- **postgres**: PostgreSQL 17 database (internal only, no host port exposure)
+- **postgres**: PostgreSQL 18 database (internal only, no host port exposure)
+- **redis**: Redis cache for the token blacklist (internal only, no host port exposure)
 - **inventario-bootstrap**: Runs database bootstrap migrations (every startup - idempotent)
 - **inventario-migrate**: Runs schema migrations (every startup)
 - **inventario-init-data**: Sets up initial data (first run only)
@@ -103,7 +104,7 @@ services:
 | `JWT_SECRET` | (required) | JWT signing secret (32+ characters) |
 | `DEFAULT_TENANT_NAME` | `Default Organization` | Initial organization name |
 | `ADMIN_EMAIL` | `admin@example.com` | Initial admin user email |
-| `ADMIN_PASSWORD` | `admin123` | Initial admin user password |
+| `ADMIN_PASSWORD` | `Admin123` | Initial admin user password |
 
 ## Security Considerations
 

--- a/example/docker-compose.override.yaml.example
+++ b/example/docker-compose.override.yaml.example
@@ -19,7 +19,7 @@ services:
   inventario:
     environment:
       # Database configuration
-      INVENTARIO_DATABASE_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
 
       # REQUIRED: Set a secure JWT secret for production
       # Generate with: openssl rand -hex 32
@@ -80,18 +80,18 @@ services:
   inventario-bootstrap:
     environment:
       # Database configuration
-      INVENTARIO_DATABASE_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
 
   inventario-migrate:
     environment:
       # Database configuration
-      INVENTARIO_DATABASE_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
 
   # Override initial data setup configuration
   inventario-init-data:
     environment:
       # Database configuration
-      INVENTARIO_DATABASE_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://inventario_user:your-secure-postgres-password-here@postgres:5432/inventario_prod?sslmode=disable"
 
       # REQUIRED: Customize initial admin user and organization
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_ID: "test-tenant-id"

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
     environment:
       # Use the main database user for bootstrap (has necessary privileges in this setup)
-      INVENTARIO_DATABASE_DB_DSN: "postgres://${POSTGRES_USER:-inventario}:${POSTGRES_PASSWORD:-inventario_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://${POSTGRES_USER:-inventario}:${POSTGRES_PASSWORD:-inventario_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
       INVENTARIO_BOOTSTRAP_USERNAME: "${POSTGRES_USER:-inventario}"
       INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS: "${POSTGRES_MIGRATOR_USER:-inventario_migrator}"
     networks:
@@ -88,7 +88,7 @@ services:
       inventario-bootstrap:
         condition: service_completed_successfully
     environment:
-      INVENTARIO_DATABASE_DB_DSN: "postgres://${POSTGRES_MIGRATOR_USER:-inventario_migrator}:${POSTGRES_MIGRATOR_PASSWORD:-inventario_migrator_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://${POSTGRES_MIGRATOR_USER:-inventario_migrator}:${POSTGRES_MIGRATOR_PASSWORD:-inventario_migrator_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
     networks:
       - inventario-internal
     volumes:
@@ -110,12 +110,12 @@ services:
       inventario-migrate:
         condition: service_completed_successfully
     environment:
-      INVENTARIO_DATABASE_DB_DSN: "postgres://${POSTGRES_MIGRATOR_USER:-inventario_migrator}:${POSTGRES_MIGRATOR_PASSWORD:-inventario_migrator_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
+      INVENTARIO_DB_DSN: "postgres://${POSTGRES_MIGRATOR_USER:-inventario_migrator}:${POSTGRES_MIGRATOR_PASSWORD:-inventario_migrator_password}@postgres:5432/${POSTGRES_DB:-inventario}?sslmode=disable"
       # Initial data configuration (override in docker-compose.override.yaml)
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME: ${DEFAULT_TENANT_NAME:-Default Organization}
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG: ${DEFAULT_TENANT_SLUG:-default}
       INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin123}
+      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: ${ADMIN_PASSWORD:-Admin123}
       INVENTARIO_MIGRATE_DATA_ADMIN_NAME: ${ADMIN_NAME:-System Administrator}
     volumes:
       # Track initialization state to prevent re-running (host mount for easy access)

--- a/example/scripts/bootstrap.sh
+++ b/example/scripts/bootstrap.sh
@@ -2,11 +2,11 @@
 set -e
 
 echo "=== RUNNING BOOTSTRAP MIGRATIONS (IDEMPOTENT) ==="
-echo "Database DSN: $INVENTARIO_DB_DSN"
+echo "Database DSN: [configured]"
 
 # Debug: Show what we're trying to connect to
 echo "Trying to connect with:"
-echo "  DSN: $INVENTARIO_DB_DSN"
+echo "  DSN: [configured]"
 echo "  Bootstrap user: $INVENTARIO_BOOTSTRAP_USERNAME"
 echo "  Migration user: $INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"
 

--- a/example/scripts/bootstrap.sh
+++ b/example/scripts/bootstrap.sh
@@ -2,11 +2,11 @@
 set -e
 
 echo "=== RUNNING BOOTSTRAP MIGRATIONS (IDEMPOTENT) ==="
-echo "Database DSN: $INVENTARIO_DATABASE_DB_DSN"
+echo "Database DSN: $INVENTARIO_DB_DSN"
 
 # Debug: Show what we're trying to connect to
 echo "Trying to connect with:"
-echo "  DSN: $INVENTARIO_DATABASE_DB_DSN"
+echo "  DSN: $INVENTARIO_DB_DSN"
 echo "  Bootstrap user: $INVENTARIO_BOOTSTRAP_USERNAME"
 echo "  Migration user: $INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"
 

--- a/example/scripts/init-data.sh
+++ b/example/scripts/init-data.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -f /app/state/data-initialized ]; then
   echo "=== RUNNING INITIAL DATA SETUP ==="
-  echo "Database DSN: $INVENTARIO_DB_DSN"
+  echo "Database DSN: [configured]"
 
   # Wait for database to be ready with retry mechanism
   echo "Waiting for database to be ready for initial data setup..."

--- a/example/scripts/init-data.sh
+++ b/example/scripts/init-data.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -f /app/state/data-initialized ]; then
   echo "=== RUNNING INITIAL DATA SETUP ==="
-  echo "Database DSN: $INVENTARIO_DATABASE_DB_DSN"
+  echo "Database DSN: $INVENTARIO_DB_DSN"
 
   # Wait for database to be ready with retry mechanism
   echo "Waiting for database to be ready for initial data setup..."

--- a/example/scripts/migrate.sh
+++ b/example/scripts/migrate.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "=== RUNNING SCHEMA MIGRATIONS ==="
-echo "Database DSN: $INVENTARIO_DATABASE_DB_DSN"
+echo "Database DSN: $INVENTARIO_DB_DSN"
 
 # Wait for database to be ready with retry mechanism
 echo "Waiting for database to be ready for migrations..."

--- a/example/scripts/migrate.sh
+++ b/example/scripts/migrate.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "=== RUNNING SCHEMA MIGRATIONS ==="
-echo "Database DSN: $INVENTARIO_DB_DSN"
+echo "Database DSN: [configured]"
 
 # Wait for database to be ready with retry mechanism
 echo "Waiting for database to be ready for migrations..."

--- a/go/cmd/inventario/db/migrate/data/config.go
+++ b/go/cmd/inventario/db/migrate/data/config.go
@@ -10,7 +10,7 @@ type Config struct {
 
 	// Admin user configuration
 	AdminEmail    string `yaml:"admin_email" env:"ADMIN_EMAIL" env-default:"admin@example.com"`
-	AdminPassword string `yaml:"admin_password" env:"ADMIN_PASSWORD" env-default:"admin123"`
+	AdminPassword string `yaml:"admin_password" env:"ADMIN_PASSWORD" env-default:"Admin123"`
 	AdminName     string `yaml:"admin_name" env:"ADMIN_NAME" env-default:"System Administrator"`
 
 	// Setup options

--- a/go/cmd/inventario/db/setup/setup.go
+++ b/go/cmd/inventario/db/setup/setup.go
@@ -48,7 +48,7 @@ func DefaultSetupOptions() SetupOptions {
 		DefaultTenantSlug:             "default",
 		DefaultTenantRegistrationMode: models.RegistrationModeClosed,
 		AdminEmail:                    "admin@example.com",
-		AdminPassword:                 "admin123",
+		AdminPassword:                 "Admin123",
 		AdminName:                     "System Administrator",
 		DryRun:                        false,
 	}
@@ -245,6 +245,14 @@ func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.
 			Email:    opts.AdminEmail,
 			Name:     opts.AdminName,
 			IsActive: true,
+		}
+
+		// Validate the password explicitly first so a complexity failure is
+		// reported as a clear, distinct, non-transient error (rather than the
+		// generic "failed to hash password"). This is the message the init-data
+		// shell script keys off to stop retrying a misconfigured admin password.
+		if err = models.ValidatePassword(opts.AdminPassword); err != nil {
+			return "", fmt.Errorf("admin password does not meet complexity requirements (min 8 chars with upper, lower, and a digit): %w", err)
 		}
 
 		err = user.SetPassword(opts.AdminPassword)

--- a/go/cmd/inventario/db/setup/setup.go
+++ b/go/cmd/inventario/db/setup/setup.go
@@ -220,6 +220,15 @@ func (m *DataSetupManager) createDefaultTenant(ctx context.Context, tx *sql.Tx, 
 
 // createOrUpdateAdminUser creates or updates the admin user
 func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.Tx, opts SetupOptions, result *SetupResult) (string, error) {
+	// Validate the configured admin password up front so a complexity failure
+	// surfaces as a clear, distinct error on every path (create, update, and
+	// --dry-run) instead of the generic "failed to hash password" deep in the
+	// create branch. SetPassword also validates internally; this just wraps it
+	// with an actionable message for operators reading init-data logs.
+	if err := models.ValidatePassword(opts.AdminPassword); err != nil {
+		return "", fmt.Errorf("admin password does not meet complexity requirements (min 8 chars with upper, lower, and a digit): %w", err)
+	}
+
 	// Check if admin user already exists
 	var existingUserID string
 	err := tx.QueryRowContext(ctx, "SELECT id FROM users WHERE email = $1", opts.AdminEmail).Scan(&existingUserID)
@@ -245,14 +254,6 @@ func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.
 			Email:    opts.AdminEmail,
 			Name:     opts.AdminName,
 			IsActive: true,
-		}
-
-		// Validate the password explicitly first so a complexity failure is
-		// reported as a clear, distinct, non-transient error (rather than the
-		// generic "failed to hash password"). This is the message the init-data
-		// shell script keys off to stop retrying a misconfigured admin password.
-		if err = models.ValidatePassword(opts.AdminPassword); err != nil {
-			return "", fmt.Errorf("admin password does not meet complexity requirements (min 8 chars with upper, lower, and a digit): %w", err)
 		}
 
 		err = user.SetPassword(opts.AdminPassword)

--- a/go/cmd/inventario/db/setup/setup_test.go
+++ b/go/cmd/inventario/db/setup/setup_test.go
@@ -293,7 +293,7 @@ func TestDefaultSetupOptions(t *testing.T) {
 	c.Assert(opts.DefaultTenantSlug, qt.Equals, "default")
 	c.Assert(opts.DefaultTenantRegistrationMode, qt.Equals, models.RegistrationModeClosed)
 	c.Assert(opts.AdminEmail, qt.Equals, "admin@example.com")
-	c.Assert(opts.AdminPassword, qt.Equals, "admin123")
+	c.Assert(opts.AdminPassword, qt.Equals, "Admin123")
 	c.Assert(opts.AdminName, qt.Equals, "System Administrator")
 	c.Assert(opts.DryRun, qt.Equals, false)
 }

--- a/go/cmd/inventario/run/bootstrap/crypto.go
+++ b/go/cmd/inventario/run/bootstrap/crypto.go
@@ -23,16 +23,22 @@ import (
 var ErrPlaceholderSecret = errx.NewSentinel("configured secret is a well-known public placeholder; set a real secret (openssl rand -hex 32) or leave it unset for an auto-generated ephemeral key")
 
 // placeholderSecretMarkers lists case-insensitive substrings that identify a
-// known public placeholder secret. Any configured secret containing one of
-// these is rejected by isPlaceholderSecret. Keep this list in sync with the
-// neutralized placeholders in .env.example and docker-compose.
+// known public placeholder secret shipped in this repo. Any configured secret
+// containing one of these is rejected by isPlaceholderSecret. Keep this list in
+// sync with the neutralized placeholders in .env.example, docker-compose.yaml,
+// and example/docker-compose.override.yaml.example.
+//
+// These are intentionally SPECIFIC instructional phrases, not broad words like
+// "change". A broad marker would false-positive on legitimate fixed secrets —
+// e.g. the labelled CI test secrets (`e2e-jwt-secret-please-change-for-prod`,
+// `e2e-file-signing-key-please-change`) or a real passphrase that happens to
+// contain a common word — and refuse to start. The goal is to catch the repo's
+// own placeholders, not to police secret content.
 var placeholderSecretMarkers = []string{
-	"please-change",
-	"use-openssl-rand",
-	"change-this",
-	"changeme",
-	"your-secret",
-	"your-secure",
+	"please-change-this",  // root .env.example / docker-compose.yaml placeholder
+	"use-openssl-rand",    // root placeholder ("...-use-openssl-rand-hex-32")
+	"replace-this-value",  // example/docker-compose.override.yaml.example placeholders
+	"your-secure-32-byte", // example/docker-compose.override.yaml.example placeholders
 }
 
 // isPlaceholderSecret reports whether the supplied value is a known public

--- a/go/cmd/inventario/run/bootstrap/crypto.go
+++ b/go/cmd/inventario/run/bootstrap/crypto.go
@@ -6,11 +6,51 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/go-extras/errx"
 
 	"github.com/denisvmedia/inventario/internal/backupsign"
 )
+
+// ErrPlaceholderSecret is returned when a JWT secret, file signing key, or
+// OAuth state key is set to a well-known public placeholder string (such as the
+// one shipped in .env.example / docker-compose). Accepting such a value would
+// be worse than no secret at all: anyone with the public repo could forge
+// tokens / signed URLs. We fail loudly rather than fall back to a random key so
+// the misconfiguration is impossible to miss; operators who want the
+// auto-generated ephemeral key must leave the value unset instead.
+var ErrPlaceholderSecret = errx.NewSentinel("configured secret is a well-known public placeholder; set a real secret (openssl rand -hex 32) or leave it unset for an auto-generated ephemeral key")
+
+// placeholderSecretMarkers lists case-insensitive substrings that identify a
+// known public placeholder secret. Any configured secret containing one of
+// these is rejected by isPlaceholderSecret. Keep this list in sync with the
+// neutralized placeholders in .env.example and docker-compose.
+var placeholderSecretMarkers = []string{
+	"please-change",
+	"use-openssl-rand",
+	"change-this",
+	"changeme",
+	"your-secret",
+	"your-secure",
+}
+
+// isPlaceholderSecret reports whether the supplied value is a known public
+// placeholder that must never be accepted as a real secret. The match is
+// case-insensitive and substring-based so trivial variations of the shipped
+// placeholders are still caught.
+func isPlaceholderSecret(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	if lower == "" {
+		return false
+	}
+	for _, marker := range placeholderSecretMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
 
 // ErrInvalidBackupSigningKey is returned when INVENTARIO_RUN_BACKUP_SIGNING_KEY
 // (or the config value) is set but is not a valid 32-byte Ed25519 seed (64 hex
@@ -26,9 +66,16 @@ var ErrInvalidBackupSigningKey = errx.NewSentinel("configured backup signing key
 // whose hex value is written once to stderr (outside the structured logger) so
 // operators can capture it on first boot without leaking the signing key into
 // log aggregators.
-func getJWTSecret(configSecret string) ([]byte, error) {
+func getJWTSecret(configSecret string) ([]byte, error) { //nolint:dupl // distinct secret resolvers (JWT / file-signing / OAuth-state) intentionally share shape; each has its own env var + messages
 	// Use the secret from config (which includes environment variables via cleanenv)
 	if configSecret != "" {
+		// Reject well-known public placeholder secrets outright. Accepting one
+		// would let anyone with the public repo forge tokens, so fail fatally
+		// rather than fall back to a random key (leave the value unset for that).
+		if isPlaceholderSecret(configSecret) {
+			slog.Error("Configured JWT secret is a well-known public placeholder; refusing to start. Set INVENTARIO_RUN_JWT_SECRET to a real secret (openssl rand -hex 32) or leave it unset for an auto-generated ephemeral key")
+			return nil, errx.Classify(ErrPlaceholderSecret, errx.Attrs("setting", "jwt-secret"))
+		}
 		// If provided as hex string, decode it
 		if decoded, err := hex.DecodeString(configSecret); err == nil && len(decoded) >= 32 {
 			slog.Info("Using JWT secret from configuration (hex decoded)")
@@ -63,9 +110,16 @@ func getJWTSecret(configSecret string) ([]byte, error) {
 
 // getFileSigningKey retrieves the file signing key from config/environment or
 // generates a secure random one with the same semantics as getJWTSecret.
-func getFileSigningKey(configKey string) ([]byte, error) {
+func getFileSigningKey(configKey string) ([]byte, error) { //nolint:dupl // distinct secret resolvers (JWT / file-signing / OAuth-state) intentionally share shape; each has its own env var + messages
 	// Use the key from config (which includes environment variables via cleanenv)
 	if configKey != "" {
+		// Reject well-known public placeholder keys outright. Accepting one would
+		// let anyone with the public repo forge signed file URLs, so fail fatally
+		// rather than fall back to a random key (leave the value unset for that).
+		if isPlaceholderSecret(configKey) {
+			slog.Error("Configured file signing key is a well-known public placeholder; refusing to start. Set INVENTARIO_RUN_FILE_SIGNING_KEY to a real key (openssl rand -hex 32) or leave it unset for an auto-generated ephemeral key")
+			return nil, errx.Classify(ErrPlaceholderSecret, errx.Attrs("setting", "file-signing-key"))
+		}
 		// If provided as hex string, decode it
 		if decoded, err := hex.DecodeString(configKey); err == nil && len(decoded) >= 32 {
 			slog.Info("Using file signing key from configuration (hex decoded)")
@@ -181,8 +235,15 @@ func resolveBackupSeed(configKey string) ([]byte, error) {
 // can capture and persist it. Multi-replica deployments MUST supply a
 // stable value or signed states won't survive a request that lands on
 // a different replica after the provider redirect.
-func getOAuthStateKey(configKey string) ([]byte, error) {
+func getOAuthStateKey(configKey string) ([]byte, error) { //nolint:dupl // distinct secret resolvers (JWT / file-signing / OAuth-state) intentionally share shape; each has its own env var + messages
 	if configKey != "" {
+		// Reject well-known public placeholder keys outright. Accepting one would
+		// let anyone with the public repo forge OAuth state, so fail fatally
+		// rather than fall back to a random key (leave the value unset for that).
+		if isPlaceholderSecret(configKey) {
+			slog.Error("Configured OAuth state key is a well-known public placeholder; refusing to start. Set INVENTARIO_RUN_OAUTH_STATE_KEY to a real key (openssl rand -hex 32) or leave it unset for an auto-generated ephemeral key")
+			return nil, errx.Classify(ErrPlaceholderSecret, errx.Attrs("setting", "oauth-state-key"))
+		}
 		if decoded, err := hex.DecodeString(configKey); err == nil && len(decoded) >= 32 {
 			slog.Info("Using OAuth state key from configuration (hex decoded)")
 			return decoded, nil

--- a/go/cmd/inventario/run/bootstrap/crypto_internal_test.go
+++ b/go/cmd/inventario/run/bootstrap/crypto_internal_test.go
@@ -88,3 +88,63 @@ func TestGetBackupSigningKey_ValidHexBuildsSigner(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(signer, qt.IsNotNil)
 }
+
+func TestIsPlaceholderSecret(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"root placeholder", "please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32", true},
+		{"root placeholder uppercased", "PLEASE-CHANGE-THIS-TO-A-SECURE-RANDOM-VALUE-USE-OPENSSL-RAND-HEX-32", true},
+		{"override jwt placeholder", "your-secure-32-byte-jwt-secret-here-replace-this-value", true},
+		{"override file placeholder", "your-secure-32-byte-file-signing-key-here-replace-this-value", true},
+		// Labelled CI test fixtures (.github/workflows/e2e-tests.yml) must NOT be
+		// rejected — otherwise the e2e stack can't start. Regression guard for the
+		// over-broad "please-change" marker that previously matched these.
+		{"e2e jwt fixture", "e2e-jwt-secret-please-change-for-prod", false},
+		{"e2e file fixture", "e2e-file-signing-key-please-change", false},
+		{"real hex secret", "3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b", false},
+	}
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(isPlaceholderSecret(tt.value), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestGetJWTSecret_RejectsRepoPlaceholder(t *testing.T) {
+	c := qt.New(t)
+
+	secret, err := getJWTSecret("please-change-this-to-a-secure-random-value-use-openssl-rand-hex-32")
+	c.Assert(err, qt.ErrorIs, ErrPlaceholderSecret)
+	c.Assert(secret, qt.IsNil)
+}
+
+func TestGetJWTSecret_AcceptsLabelledTestFixture(t *testing.T) {
+	c := qt.New(t)
+
+	// The e2e workflow sets this exact value; it must be accepted so the stack starts.
+	secret, err := getJWTSecret("e2e-jwt-secret-please-change-for-prod")
+	c.Assert(err, qt.IsNil)
+	c.Assert(secret, qt.DeepEquals, []byte("e2e-jwt-secret-please-change-for-prod"))
+}
+
+func TestGetFileSigningKey_AcceptsLabelledTestFixture(t *testing.T) {
+	c := qt.New(t)
+
+	key, err := getFileSigningKey("e2e-file-signing-key-please-change")
+	c.Assert(err, qt.IsNil)
+	c.Assert(key, qt.DeepEquals, []byte("e2e-file-signing-key-please-change"))
+}
+
+func TestGetJWTSecret_EmptyGeneratesRandom(t *testing.T) {
+	c := qt.New(t)
+
+	secret, err := getJWTSecret("")
+	c.Assert(err, qt.IsNil)
+	c.Assert(secret, qt.HasLen, 32)
+}

--- a/go/cmd/inventario/run/bootstrap/email.go
+++ b/go/cmd/inventario/run/bootstrap/email.go
@@ -111,9 +111,9 @@ func ValidateEmailPublicURLConfig(provider, publicURL string) error {
 		// implies a real deployment where users will expect verification /
 		// reset / invite emails — none of which the stub ever sends. Warn loudly
 		// so a "users never receive any email" deployment is not silent.
-		if strings.TrimSpace(publicURL) != "" {
+		if trimmedURL := strings.TrimSpace(publicURL); trimmedURL != "" {
 			slog.Warn("email provider is 'stub': verification/reset/invite emails will be silently dropped; set a real SMTP (or other) provider + email.from for any deployment real users will use",
-				"public_url", strings.TrimSpace(publicURL))
+				"public_url", trimmedURL)
 		}
 		return nil
 	case services.EmailProviderSMTP,

--- a/go/cmd/inventario/run/bootstrap/email.go
+++ b/go/cmd/inventario/run/bootstrap/email.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -105,6 +106,15 @@ func ValidateEmailPublicURLConfig(provider, publicURL string) error {
 
 	switch normalizedEmailProvider {
 	case services.EmailProviderStub:
+		// The stub provider is a legitimate choice for dev / preview, so this is
+		// a warning, not a fatal error. But a configured public URL strongly
+		// implies a real deployment where users will expect verification /
+		// reset / invite emails — none of which the stub ever sends. Warn loudly
+		// so a "users never receive any email" deployment is not silent.
+		if strings.TrimSpace(publicURL) != "" {
+			slog.Warn("email provider is 'stub': verification/reset/invite emails will be silently dropped; set a real SMTP (or other) provider + email.from for any deployment real users will use",
+				"public_url", strings.TrimSpace(publicURL))
+		}
 		return nil
 	case services.EmailProviderSMTP,
 		services.EmailProviderSendGrid,

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -423,6 +423,10 @@ features:
 email:
   # Provider: stub | smtp | sendgrid | ses | mandrill | mailchimp
   # "stub" logs emails to stdout; no external service needed.
+  # ⚠️ WARNING: "stub" SILENTLY DROPS ALL MAIL — verification, invite, password-reset,
+  # and feedback emails are never delivered. This is fine for local evaluation only.
+  # For ANY deployment real users will sign in to, set a real provider (e.g. smtp) AND
+  # a non-empty email.from, or those flows will appear broken to users.
   # Env: INVENTARIO_RUN_EMAIL_PROVIDER
   provider: "stub"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,11 +2,11 @@
 set -e
 
 echo "=== RUNNING BOOTSTRAP MIGRATIONS (IDEMPOTENT) ==="
-echo "Database DSN: $INVENTARIO_DB_DSN"
+echo "Database DSN: [configured]"
 
 # Debug: Show what we're trying to connect to
 echo "Trying to connect with:"
-echo "  DSN: $INVENTARIO_DB_DSN"
+echo "  DSN: [configured]"
 echo "  Bootstrap user: $INVENTARIO_BOOTSTRAP_USERNAME"
 echo "  Migration user: $INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"
 

--- a/scripts/init-data.sh
+++ b/scripts/init-data.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -f /app/state/data-initialized ]; then
   echo "=== RUNNING INITIAL DATA SETUP ==="
-  echo "Database DSN: $INVENTARIO_DB_DSN"
+  echo "Database DSN: [configured]"
 
   # Wait for database to be ready with retry mechanism
   echo "Waiting for database to be ready for initial data setup..."
@@ -25,7 +25,7 @@ if [ ! -f /app/state/data-initialized ]; then
 
         # Override DB_DSN to use app user (not migrator) for seeding
         export INVENTARIO_DB_DSN="${INVENTARIO_SEED_DB_DSN:-$INVENTARIO_DB_DSN}"
-        echo "Using DSN: $INVENTARIO_DB_DSN (for seeding)"
+        echo "Using DSN: [configured] (for seeding)"
 
         # Start server in background
         inventario run &

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "=== RUNNING SCHEMA MIGRATIONS ==="
-echo "Database DSN: $INVENTARIO_DB_DSN"
+echo "Database DSN: [configured]"
 
 # Wait for database to be ready with retry mechanism
 echo "Waiting for database to be ready for migrations..."


### PR DESCRIPTION
## What & why

Fixes the four **first-run blockers** from the alpha-readiness audit (#2087) that make a fresh `docker-compose up -d` (the README quickstart) either insecure or unable to boot. None are deep code changes — they're config/default/docs alignment plus two small Go guards.

Closes #2091 · Closes #2092 · Closes #2107 · addresses #2093 (code side; SMTP is a deploy step)

## Changes

### #2091 — committed public placeholder used as the live JWT / file-signing secret
- `docker-compose.yaml` + `.env.example`: secret defaults are now **empty** (`${JWT_SECRET:-}` / `${FILE_SIGNING_KEY:-}`) so the backend auto-generates an ephemeral dev key; the public placeholder is gone and `.env.example` documents `openssl rand -hex 32`.
- `go/cmd/inventario/run/bootstrap/crypto.go`: `getJWTSecret` / `getFileSigningKey` / `getOAuthStateKey` now **fatally reject** a known public placeholder (belt-and-suspenders) instead of signing tokens with it. Empty → auto-generate is unchanged.

### #2092 — documented admin password `admin123` fails complexity validation → container never boots
- `admin123` → `Admin123` (upper+lower+digit, ≥8) **everywhere**: `docker-compose.yaml`, `.env.example`, `example/*`, `README.md`, `QUICKSTART.md`, **and the binary's own defaults** (`db/migrate/data/config.go`, `db/setup/setup.go` + test). The binary-default fix also covers the Helm path, where `setupJob.initData.adminPassword` is empty by default and inherits the binary default.
- `db/setup/setup.go`: surfaces a clear "complexity requirements" error instead of the generic failure that the init-data retry loop masked.

### #2093 — default email provider `stub` silently drops mail
- `bootstrap/email.go`: loud `slog.Warn` when provider is `stub` **and** a public URL is set (verification/reset/invite mail would be dropped). Kept non-fatal — dev/preview legitimately use stub.
- `helm/inventario/values.yaml`: documents the same near `email.provider`.
- ⚠️ Configuring a real SMTP provider for the alpha deploy is a **deployment step** (PRODUCTION.md B5/B6), not something this PR can do in code.

### #2107 — example/ stack used a DB DSN env var the loader ignores
- `example/docker-compose.yaml`, `example/scripts/{bootstrap,migrate,init-data}.sh`, and `example/docker-compose.override.yaml.example` now use `INVENTARIO_DB_DSN` (the var the config loader actually reads) instead of `INVENTARIO_DATABASE_DB_DSN`. README Postgres version aligned to the compose (18).

## How it was built
Multi-agent fan-out in an isolated worktree, decomposed by **file ownership** (not by issue) so agents never edited the same file. A central verify pass then caught two gaps the per-file scoping missed — the binary's own `admin123` defaults and the broader `example/` DSN usages (scripts + override example) — which are included here.

## Verification
- `go build ./...` ✅ · `go vet ./...` (changed pkgs) ✅ · `golangci-lint run` (changed pkgs) ✅ `0 issues` (added `//nolint:dupl` to the three near-identical secret resolvers, matching the repo's existing pattern).
- Residual grep: no `admin123`, no public placeholder secret, no `INVENTARIO_DATABASE_DB_DSN` left in the docker-compose / binary / example first-run paths.

## Out of scope (follow-ups noted in #2087)
- Helm/k8s/preview `admin123` references in comments/overlays (separate deploy path; the binary default is now valid so an unset chart value yields `Admin123`).
- The default-tenant-name drift in `.env.example` (tracked under docs cleanup #2111).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-generates ephemeral cryptographic keys during development; production deployments must configure fixed secrets.

* **Bug Fixes**
  * Added password complexity validation during admin user setup.
  * Added warnings for stub email provider to prevent silent mail failures.
  * Rejects placeholder secret values to prevent accidental unsafe deployments.

* **Documentation**
  * Updated setup guides with clarified security configuration requirements and default password changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->