### PR TITLE
docs: fix audit-driven documentation drift (#2087)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,10 +26,10 @@ items, their locations, and associated metadata. Please follow these guidelines 
   - `go/registry/`: Data storage implementations (memory, postgres)
   - `go/models/`: Data models and entity definitions
   - `go/apiserver/`: HTTP API server implementation
-  - `go/internal/`: Internal packages (log, errormarshal, etc.)
+  - `go/internal/`: Internal packages (errormarshal, metrics, etc.)
 - `frontend/`: React 19 + TypeScript frontend (Tailwind v4 + shadcn/ui)
 - `e2e/`: End-to-end tests using Playwright
-- `docs/`: Swagger API documentation (auto-generated)
+- `go/docs/`: Swagger API documentation (auto-generated)
 - `bin/`: Build output directory
 
 ## Key Guidelines
@@ -37,8 +37,7 @@ items, their locations, and associated metadata. Please follow these guidelines 
 ### Go Development
 - `cd go` before operating on go code
 - Use `github.com/go-extras/errx` (and `github.com/go-extras/errx/stacktrace` imported as `errxtrace`) for error wrapping and stack traces. Define sentinel errors with `errx.NewSentinel(...)` (see `go/services/errors.go`); reach for the std `errors` package only for `errors.Is` / `errors.As` checks.
-- Use `github.com/denisvmedia/inventario/internal/log` for logging (never use std `log` package). Using `log/slog` is
-   acceptable but internal log is preferred
+- Use the standard library `log/slog` for structured logging (never use the std `log` package)
 - Use `github.com/frankban/quicktest` for tests, always imported with `qt` alias
 - Write table-driven unit tests when possible, separating happy and unhappy paths
 - Follow Go best practices and idiomatic patterns
@@ -48,7 +47,7 @@ items, their locations, and associated metadata. Please follow these guidelines 
 
 ### Go version and modern syntax (review-time guidance)
 
-**This module targets Go 1.26+** (`go/go.mod` declares `go 1.26.0`; CI runs Go 1.26.x).
+**This module targets Go 1.26+** (`go/go.mod` declares `go 1.26.3`; CI runs Go 1.26.x).
 Do **not** flag the following as compile errors or "doesn't compile in Go" — they are valid:
 
 - **Range over integer** — `for i := range n { ... }` where `n` is an `int` is valid since
@@ -95,9 +94,9 @@ For deeper Go-specific review guidance see [`.github/instructions/go.instruction
 - All tests must pass before committing
 
 ### API Documentation
-- When changing Go API entities, regenerate Swagger docs:
+- When changing Go API entities, regenerate Swagger docs (and the paired frontend codegen):
   ```bash
-  go tool swag init --output docs
+  make swagger
   ```
 
 ### Database Support

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -108,9 +108,9 @@ guides you may have been trained on.
   reverse.
 - **Comma-ok type assertions** required outside test code
   (`revive unchecked-type-assertion`).
-- **Filename format** `^[_a-z][_a-z0-9]*\.go$` — no camelCase, no dashes
-  (except generated migration files under `registry/postgres/migrations/`
-  which are exempt).
+- **Filename format** `^[_a-z][_a-z0-9]*\.go$` — no camelCase, no dashes.
+  (Generated SQL migrations live under `schema/migrations/_sqldata/` and are
+  `.sql`, so the Go filename rule never applies to them.)
 - **Function limits** (`funlen`): 240 lines / 160 statements. Cognitive
   complexity ≤ 30 (`gocognit`). Cyclomatic ≤ 20 (`gocyclo`). Nested-if depth
   ≤ 6 (`nestif`). Line length ≤ 240 (`lll`). Test files are exempt from these.
@@ -128,10 +128,9 @@ guides you may have been trained on.
 - **`gosec`** suppressions: `G117` (false positive on struct field names
   containing "Secret"/"Token") and `G706` (structured `slog` logging is not
   log-injection-vulnerable) are project-wide exclusions. Don't re-raise them.
-- **Structured logging** uses `log/slog` with key/value pairs:
-  `slog.Error("Security violation", "user_id", user.ID, ...)`. The repo's
-  internal `github.com/denisvmedia/inventario/internal/log` wrapper is also
-  fine. Never the std `log` package.
+- **Structured logging** uses the standard library `log/slog` with key/value
+  pairs: `slog.Error("Security violation", "user_id", user.ID, ...)`. Never the
+  std `log` package.
 - **Standard layout differs:** the module lives in `go/`, not at repo root.
   Sub-packages: `apiserver/` (HTTP handlers), `registry/` (data layer
   interface + memory/postgres implementations), `services/` (business

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ The system implements enterprise-grade multi-tenancy with:
 ### Linting
 - `make lint` - Run all linters
 - `make lint-go` - Run golangci-lint on Go code
-- `make lint-frontend` - Run ESLint and Stylelint on frontend code
+- `make lint-frontend` - Run ESLint on frontend code (`eslint .`)
 
 ### Development Server
 - `make run-backend` - Run backend server on :3333
@@ -70,7 +70,7 @@ The system implements enterprise-grade multi-tenancy with:
   4. Review the generated SQL, run `go test ./schema/migrations/...` locally, then commit both files.
   If the generator output looks wrong, fix the **model annotations** and regenerate — don't edit the SQL by hand.
   **Hand-written migrations exception.** Some changes can't be expressed via model annotations (data backfills, view refactors, multi-step `ALTER`s, one-off custom DDL). In those rare cases — **STOP and ask the user for explicit permission before writing SQL by hand**. Do not improvise. The user will tell you whether to handcraft the migration or land it as a follow-up using a different approach (e.g. a runtime backfill worker). The CI check still has to pass afterward, so the user's approval includes the trade-off of suppressing drift detection for that specific file.
-- `curl http://localhost:3333/api/v1/seed` - Seed the database with test data (the route is gated off by default since #2039; run the server with `--enable-seed-endpoint` / `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true` first)
+- `curl -X POST http://localhost:3333/api/v1/seed` - Seed the database with test data (POST only; the route is gated off by default since #2039; run the server with `--enable-seed-endpoint` / `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true` first)
 - `./inventario tenants create` - Create tenants for initial setup
 - `./inventario tenants list` - List all tenants with filtering
 - `./inventario tenants get <id-or-slug>` - Get detailed tenant information
@@ -79,7 +79,7 @@ The system implements enterprise-grade multi-tenancy with:
 - `./inventario users create` - Create users for initial setup
 - `./inventario users list` - List all users with filtering
 - `./inventario users get <id-or-email>` - Get detailed user information
-- `./inventario users update <id-or-email>` - Update user properties
+- `./inventario users update <id-or-email>` - **Not yet implemented** (placeholder; prints a message and exits without changes)
 - `./inventario users delete <id-or-email>` - Delete users with confirmation
 - For PostgreSQL: Set POSTGRES_TEST_DSN environment variable for testing
 
@@ -191,10 +191,8 @@ Support for multiple database backends via DSN:
 - `memory://` - In-memory (development/testing)
 - `postgres://user:pass@host:port/db` - PostgreSQL (production)
 
-### Multi-Tenant Configuration
-- `--tenant-mode` - single, multi-header, multi-subdomain
-- `--jwt-secret` - Required for multi-tenant authentication
-- `--default-tenant-id` - For single-tenant mode
+### Authentication Configuration
+- `--jwt-secret` - JWT secret for authentication (minimum 32 characters; auto-generated if not provided)
 
 ### File Storage Configuration
 - `--upload-location` - Supports file://, s3://, azblob://, gs://

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ask+coc@stokaro.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing to Inventario
+
+Thanks for your interest in contributing! Inventario is a personal inventory
+management system with a Go backend and a React frontend. This guide covers how
+to set up your environment, the build/test/lint commands, the migration policy,
+and the conventions we expect on pull requests.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md). Security issues must **not** be filed as
+public issues — see [SECURITY.md](SECURITY.md) for the private disclosure
+process.
+
+## Where things live
+
+- **Backend (`go/`)** — Go 1.26+ with a Chi router and PostgreSQL.
+  - `go/models` — domain models with Ptah migration annotations.
+  - `go/registry` — repository-pattern implementations (PostgreSQL, in-memory).
+  - `go/apiserver` — HTTP API handlers and tenant-context middleware.
+  - `go/services` — business logic.
+  - `go/internal` — internal utilities (validation, error handling, logging).
+  - `go/backup` — export/import functionality.
+  - `go/schema/migrations/_sqldata` — **generated** SQL migrations (see below).
+- **Frontend (`frontend/`)** — React 19 + TypeScript + Tailwind v4 + shadcn/ui.
+  - `frontend/src/app` — application shell, providers, router.
+  - `frontend/src/pages` — one folder per route.
+  - `frontend/src/features` — feature slices (auth, group, commodity, file, …).
+  - `frontend/src/components/ui` — shadcn primitives.
+  - `frontend/src/types` — OpenAPI-generated DTOs plus hand-written types.
+- **End-to-end tests (`e2e/`)** — Playwright tests for full user workflows.
+- **Design mock (`design-mocks/`)** — read-only mirror of the upstream
+  `inventario-design` repo. **Never edit anything under `design-mocks/`**; local
+  changes are wiped on the next sync. It is the canonical visual contract for the
+  frontend.
+
+For the full architecture and developer guidance, read [AGENTS.md](AGENTS.md).
+Before touching anything under `frontend/src/`, also read
+[`devdocs/frontend/README.md`](devdocs/frontend/README.md).
+
+## Prerequisites
+
+- **Go** 1.26 or higher.
+- **Node.js** 24.16.0 (managed via [Volta](https://volta.sh/); the version is
+  pinned in `frontend/package.json`).
+- **Git**.
+- **PostgreSQL** for anything beyond the in-memory backend (user/tenant CLI
+  commands, integration tests, and migrations require it).
+
+## Building
+
+Run from the repository root:
+
+- `make build` — build both frontend and backend.
+- `make build-frontend` — build the React frontend only.
+- `make build-backend` — build the Go backend with the embedded frontend.
+- `make build-backend-nofe` — build the Go backend without the frontend.
+
+## Running locally
+
+- `make run-backend` — run the backend server on `:3333`.
+- `make run-frontend` — run the React (Vite) dev server.
+- `make run-dev` — run both servers concurrently.
+
+The default in-memory database loses data on restart. To seed development data,
+start the server with `--enable-seed-endpoint` (off by default, never enable in
+production) and then `curl -X POST http://localhost:3333/api/v1/seed`.
+
+## Testing
+
+- `make test` — run all tests (Go + frontend, excluding PostgreSQL).
+- `make test-go` — run Go tests (excluding PostgreSQL registry tests).
+- `make test-go-postgres` — run PostgreSQL registry tests (requires the
+  `POSTGRES_TEST_DSN` environment variable).
+- `make test-go-all` — run all Go tests including PostgreSQL.
+- `make test-frontend` — run frontend unit tests with Vitest.
+- `make test-e2e` — run the Playwright end-to-end tests.
+
+Integration tests skip automatically when `POSTGRES_TEST_DSN` is unset; there is
+no build tag to enable them.
+
+## Linting and formatting
+
+- `make lint` — run all linters (`lint-go` + `lint-frontend`).
+- `make lint-go` — run `golangci-lint` on the Go code. Prefer
+  `golangci-lint run --fix` to auto-correct import order and formatting; do not
+  invoke `gci`/`gofmt`/`gofumpt` binaries directly.
+- `make lint-frontend` — run ESLint (`eslint .`) on the frontend.
+- Frontend formatting is checked separately by Prettier. ESLint does **not**
+  catch Prettier drift, so run `npm run format:check` (or `npm run format` to
+  fix) from `frontend/` before pushing frontend changes.
+- `npm run typecheck` (from `frontend/`) — TypeScript type checking.
+
+## Database migrations (important)
+
+**Never hand-write migration SQL.** Schema migrations under
+`go/schema/migrations/_sqldata/` are **generated** from the Go model annotations
+(Ptah `//migrator:schema:*` tags). The CI schema-drift check regenerates from
+the models and fails on any mismatch, so a freehand file will not pass review.
+
+To add or change a migration:
+
+1. Edit the Go model in `go/models/` — add fields, indexes, and RLS policies via
+   `//migrator:schema:*` annotations.
+2. Run `./scripts/generate-migration.sh <descriptive_name>`. It spins up an
+   ephemeral Postgres container, applies every existing migration, diffs the
+   live schema against your model annotations, and writes the resulting
+   `<unix-timestamp>_<name>.up.sql` / `.down.sql` pair.
+3. Review the generated SQL and commit both files. If the output looks wrong,
+   fix the **model annotations** and regenerate — do not edit the SQL by hand,
+   and do not rename a generated file to bump its timestamp prefix.
+
+The generator picks its own timestamp (a real UTC Unix timestamp at or before
+wall-clock now); a CI guard fails the build if any prefix is in the future.
+
+**Exception:** some changes (data backfills, multi-step `ALTER`s, custom DDL)
+cannot be expressed via annotations. In those rare cases, **stop and ask the
+maintainer for explicit approval before writing SQL by hand.**
+
+## Pull request conventions
+
+- **Branch** off `master`; do not push directly to `master`.
+- Keep each PR focused on a single change. Reference the related issue (for
+  example, `Closes #1234`) in the PR description.
+- Run the relevant `make` targets locally before opening a PR: at minimum
+  `make lint` and `make test`, plus `npm run format:check` for frontend changes.
+- If your change adds or modifies API endpoints, update the Swagger
+  documentation and regenerate the OpenAPI-derived frontend types.
+- If you change the database schema, follow the migration workflow above and
+  ensure the schema-drift / `make lint-migrations` check passes.
+- Write tests for new behavior; add or update unit, integration, and e2e tests
+  as appropriate for the layer you touched.
+
+## Questions
+
+If something here is unclear or out of date, open a regular issue (for
+non-security topics) so we can fix the docs.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,16 +1,31 @@
-# Inventario Production Deployment Guide
+# Inventario Bare-Metal / systemd Deployment Guide
 
-This guide covers how to deploy and run the Inventario application in a production environment.
+This guide covers how to deploy and run the Inventario application directly on a
+single host (bare metal or VM) under systemd.
+
+> **Kubernetes is the canonical production target.** For a Helm/Kubernetes deploy
+> — including the full configuration surface, secret handling, Redis, object
+> storage, email, AI vision, ingress/TLS, monitoring, and backups — use the
+> [`PRODUCTION.md`](PRODUCTION.md) runbook. The authoritative source of truth for
+> every config key and env var is [`helm/inventario/values.yaml`](helm/inventario/values.yaml)
+> and the `run` config in `go/cmd/inventario/run/bootstrap/config.go`. This bare-metal
+> guide mirrors the same env vars; where it is terser, defer to `PRODUCTION.md`.
 
 ## Prerequisites
 
 ### System Requirements
 
 - **Operating System**: Linux, macOS, or Windows
-- **PostgreSQL**: Version 12 or higher
+- **PostgreSQL**: Version 12 or higher (`memory://` is dev-only — data is lost on restart)
+- **Redis**: Recommended. Backs the token blacklist, auth + global rate limiting, CSRF,
+  and the email queue. Without it the app uses an in-memory fallback that logs a
+  "not suitable for multi-instance" warning and loses that state on restart.
+- **Object storage**: `file://` (single host) or S3/R2/GCS/Azure for the upload location
+- **SMTP / email provider**: Required for real email (registration, password reset,
+  invites, magic-link). The default `stub` provider only logs.
 - **Disk Space**: Minimum 1GB for application and initial data storage
 - **Memory**: Minimum 512MB RAM (1GB+ recommended)
-- **Network**: Access to PostgreSQL database and file storage location
+- **Network**: Access to PostgreSQL database, Redis, and the file storage location
 
 ### Required Tools
 
@@ -87,6 +102,23 @@ Create the initial tenant and admin user:
   --default-tenant-name="Your Organization"
 ```
 
+### 5. Create the Back-Office (Platform-Operator) Account
+
+`db migrate data` creates the **tenant** and the tenant **admin** user. The
+**back-office / platform-operator** account lives in a separate auth plane and
+is created with the `backoffice` CLI (run it on the application host with the
+DB DSN available in the environment, e.g. `INVENTARIO_DB_DSN`):
+
+```bash
+# Create the operator account (a strong random password is generated if --password is omitted)
+./inventario backoffice bootstrap \
+  --email="ops@yourcompany.com" \
+  --name="Operations"
+
+# Enroll TOTP for the operator (required by default — bootstrap sets --mfa-enforced=true)
+./inventario backoffice mfa setup --email="ops@yourcompany.com"
+```
+
 ## Application Configuration
 
 ### Environment Variables
@@ -94,15 +126,47 @@ Create the initial tenant and admin user:
 Create a production configuration using environment variables:
 
 ```bash
-# Database configuration
+# Database configuration (top-level key — NOT under a run/ prefix)
 export INVENTARIO_DB_DSN="postgres://inventario:your_secure_password@localhost:5432/inventario?sslmode=disable"
 
 # Server configuration
-export INVENTARIO_ADDR=":8080"
-export INVENTARIO_UPLOAD_LOCATION="file:///var/lib/inventario/uploads?create_dir=1"
+# The default port is :3333. The run server reads its settings under the
+# INVENTARIO_RUN_ prefix; INVENTARIO_ADDR / INVENTARIO_UPLOAD_LOCATION (no prefix)
+# are NOT consumed.
+export INVENTARIO_RUN_ADDR=":3333"
+export INVENTARIO_RUN_UPLOAD_LOCATION="file:///var/lib/inventario/uploads?create_dir=1"
+export INVENTARIO_RUN_PUBLIC_URL="https://inventario.example.com"   # used in email links
 
-# Security configuration (REQUIRED for production)
+# Security configuration (BOTH REQUIRED for production)
+# If either is left empty the app auto-generates an ephemeral key at boot and logs
+# it — that breaks user sessions / MFA (JWT) and every signed file URL (file signing
+# key) across restarts, so set stable values and keep them constant forever.
 export INVENTARIO_RUN_JWT_SECRET="$(openssl rand -hex 32)"
+export INVENTARIO_RUN_FILE_SIGNING_KEY="$(openssl rand -hex 32)"
+
+# Optional: backup signing key for signed .inb backups (#534).
+# Auto-generated if empty; set it stably to keep .inb archives verifiable.
+export INVENTARIO_RUN_BACKUP_SIGNING_KEY="$(openssl rand -hex 32)"
+
+# CORS (the bundled SPA is same-origin; leave empty to deny cross-origin)
+export INVENTARIO_RUN_ALLOWED_ORIGINS=""
+
+# Redis (recommended). Wire each Redis-backed feature to your Redis instance;
+# without these the app uses single-instance in-memory fallbacks.
+export INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL="redis://localhost:6379/0"
+export INVENTARIO_RUN_AUTH_RATE_LIMIT_REDIS_URL="redis://localhost:6379/0"
+export INVENTARIO_RUN_GLOBAL_RATE_LIMIT_REDIS_URL="redis://localhost:6379/0"
+export INVENTARIO_RUN_CSRF_REDIS_URL="redis://localhost:6379/0"
+export INVENTARIO_RUN_EMAIL_QUEUE_REDIS_URL="redis://localhost:6379/0"
+
+# Email provider (default "stub" only logs; use "smtp" for real delivery)
+export INVENTARIO_RUN_EMAIL_PROVIDER="smtp"
+export INVENTARIO_RUN_EMAIL_FROM="no-reply@example.com"
+export INVENTARIO_RUN_SMTP_HOST="smtp.example.com"
+export INVENTARIO_RUN_SMTP_PORT="587"
+export INVENTARIO_RUN_SMTP_USERNAME="smtp-user"
+export INVENTARIO_RUN_SMTP_PASSWORD="smtp-password"
+export INVENTARIO_RUN_SMTP_USE_TLS="true"
 
 # Worker configuration (optional)
 export INVENTARIO_RUN_MAX_CONCURRENT_EXPORTS="3"
@@ -122,13 +186,24 @@ export TZ="UTC"
 Instead of environment variables, you can create a `config.yaml` file:
 
 ```yaml
-database:
-  db-dsn: "postgres://inventario:your_secure_password@localhost:5432/inventario?sslmode=disable"
+# db-dsn is a top-level key (not nested under a "database:" key).
+db-dsn: "postgres://inventario:your_secure_password@localhost:5432/inventario?sslmode=disable"
 
 run:
-  addr: ":8080"
+  addr: ":3333"
   upload-location: "file:///var/lib/inventario/uploads?create_dir=1"
+  public-url: "https://inventario.example.com"
   jwt-secret: "your-secure-32-byte-secret-here"
+  file-signing-key: "your-secure-32-byte-file-signing-key-here"
+  allowed-origins: ""
+  token-blacklist-redis-url: "redis://localhost:6379/0"
+  csrf-redis-url: "redis://localhost:6379/0"
+  email-provider: "smtp"
+  email-from: "no-reply@example.com"
+  smtp-host: "smtp.example.com"
+  smtp-port: 587
+  smtp-username: "smtp-user"
+  smtp-use-tls: true
   max-concurrent-exports: 3
   max-concurrent-imports: 1
   thumbnail-max-concurrent-per-user: 5
@@ -138,10 +213,15 @@ run:
 
 ### Security Considerations
 
-1. **JWT Secret**: Generate a secure 32+ character secret:
+1. **JWT Secret & File Signing Key**: Both are required in production. Generate
+   each as a secure 32+ byte value and keep them constant across restarts:
    ```bash
-   openssl rand -hex 32
+   openssl rand -hex 32   # INVENTARIO_RUN_JWT_SECRET
+   openssl rand -hex 32   # INVENTARIO_RUN_FILE_SIGNING_KEY
    ```
+   Leaving either empty makes the app auto-generate an ephemeral key at boot:
+   rotating the JWT secret invalidates all sessions and MFA enrollments, and a
+   changing file signing key breaks every outstanding signed download URL.
 
 2. **Database Passwords**: Use strong, unique passwords for database users
 
@@ -169,7 +249,7 @@ run:
 
 # Or with command line flags
 ./inventario run \
-  --addr=":8080" \
+  --addr=":3333" \
   --db-dsn="postgres://inventario:password@localhost:5432/inventario?sslmode=disable" \
   --upload-location="file:///var/lib/inventario/uploads?create_dir=1"
 ```
@@ -195,9 +275,10 @@ RestartSec=5
 
 # Environment variables
 Environment=INVENTARIO_DB_DSN=postgres://inventario:password@localhost:5432/inventario?sslmode=disable
-Environment=INVENTARIO_ADDR=:8080
-Environment=INVENTARIO_UPLOAD_LOCATION=file:///var/lib/inventario/uploads?create_dir=1
+Environment=INVENTARIO_RUN_ADDR=:3333
+Environment=INVENTARIO_RUN_UPLOAD_LOCATION=file:///var/lib/inventario/uploads?create_dir=1
 Environment=INVENTARIO_RUN_JWT_SECRET=your-secure-32-byte-secret-here
+Environment=INVENTARIO_RUN_FILE_SIGNING_KEY=your-secure-32-byte-file-signing-key-here
 
 # Security settings
 NoNewPrivileges=true
@@ -227,10 +308,10 @@ Once the application is running, verify it's working:
 
 ```bash
 # Check readiness endpoint (DB/Redis dependencies reachable)
-curl http://localhost:8080/readyz
+curl http://localhost:3333/readyz
 
 # Check web interface
-curl http://localhost:8080/
+curl http://localhost:3333/
 ```
 
 ### Database Connection
@@ -350,10 +431,11 @@ second factor on next sign-in, and can re-enable MFA from Settings.
 
 ### Logs and Debugging
 
-Enable verbose logging by setting log level:
+There is no log-level knob (`LOG_LEVEL` / `INVENTARIO_LOG_LEVEL` are not consumed).
+The only logging control is the output format — set it to `json` for structured logs:
 
 ```bash
-export LOG_LEVEL=debug
+export INVENTARIO_LOG_FORMAT=json
 ./inventario run
 ```
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -45,9 +45,16 @@ The application can be configured using environment variables in the `.env` file
 | `POSTGRES_PASSWORD` | `inventario_password` | PostgreSQL password |
 | `POSTGRES_PORT` | `5432` | PostgreSQL port (host mapping) |
 | `INVENTARIO_PORT` | `3333` | Inventario application port (host mapping) |
-| `INVENTARIO_ADDR` | `:3333` | Inventario bind address |
-| `INVENTARIO_UPLOAD_LOCATION` | `file:///app/uploads?create_dir=1` | Upload storage location |
+| `INVENTARIO_RUN_ADDR` | `:3333` | Inventario bind address |
+| `INVENTARIO_RUN_UPLOAD_LOCATION` | `file:///app/uploads?create_dir=1` | Upload storage location |
 | `TZ` | `UTC` | Timezone |
+
+> The `run` server reads its settings under the `INVENTARIO_RUN_` prefix
+> (`INVENTARIO_RUN_ADDR`, `INVENTARIO_RUN_UPLOAD_LOCATION`, …). The bundled
+> `docker-compose.yaml` still passes the un-prefixed `INVENTARIO_ADDR` /
+> `INVENTARIO_UPLOAD_LOCATION`, which the server ignores — it works only because
+> the built-in defaults happen to be the same values. Use the prefixed names for
+> anything you actually want to take effect.
 
 ### Data Persistence
 
@@ -55,7 +62,7 @@ Data is stored in the `.docker` directory:
 
 - **PostgreSQL data**: `.docker/postgresql/`
 - **Uploaded files**: `.docker/inventario/uploads/`
-- **Application data**: `.docker/inventario/data/`
+- **Init/seed state**: `.docker/init-state/` (mounted into the `inventario-init-data` service at `/app/state`)
 
 These directories are automatically created when you start the services.
 
@@ -113,7 +120,8 @@ docker-compose exec -T postgres psql -U inventario -d inventario < backup.sql
 ### Application Operations
 ```bash
 # Execute commands in the application container
-docker-compose exec inventario ./inventario --help
+# (the binary is on PATH at /usr/local/bin/inventario; WORKDIR is /app)
+docker-compose exec inventario inventario --help
 
 # Seed the database (handled automatically by the inventario-init-data
 # service; the long-running inventario service does NOT expose /api/v1/seed —
@@ -121,7 +129,7 @@ docker-compose exec inventario ./inventario --help
 # with SEED_DATABASE=true.
 
 # Run database migrations
-docker-compose exec inventario ./inventario migrate
+docker-compose exec inventario inventario db migrate up
 ```
 
 ## Development
@@ -142,7 +150,8 @@ Create a `docker-compose.override.yml` file for development-specific settings:
 services:
   inventario:
     environment:
-      INVENTARIO_LOG_LEVEL: debug
+      # The only logging knob is the output format; there is no log-level env var.
+      INVENTARIO_LOG_FORMAT: json
     volumes:
       - ./custom-config:/app/config
 ```
@@ -208,7 +217,7 @@ See [`deploy/monitoring/README.md`](deploy/monitoring/README.md) for the dashboa
 For production deployment, consider:
 
 1. **Use external PostgreSQL**: Set `INVENTARIO_DB_DSN` to point to your production database
-2. **Use cloud storage**: Set `INVENTARIO_UPLOAD_LOCATION` to S3, GCS, or Azure Blob
+2. **Use cloud storage**: Set `INVENTARIO_RUN_UPLOAD_LOCATION` to S3, GCS, or Azure Blob
 3. **Enable HTTPS**: Use a reverse proxy like nginx or Traefik
 4. **Set strong passwords**: Generate secure passwords for database access
 5. **Regular backups**: Implement automated database and file backups
@@ -220,7 +229,7 @@ services:
   inventario:
     environment:
       INVENTARIO_DB_DSN: "postgres://user:pass@prod-db:5432/inventario"
-      INVENTARIO_UPLOAD_LOCATION: "s3://my-bucket/uploads?region=us-east-1"
+      INVENTARIO_RUN_UPLOAD_LOCATION: "s3://my-bucket/uploads?region=us-east-1"
     deploy:
       resources:
         limits:

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test-go-postgres:
 		echo "   Example: export POSTGRES_TEST_DSN='postgres://user:password@localhost:5432/inventario_test?sslmode=disable'"; \
 		exit 1; \
 	fi
-	cd $(BACKEND_DIR) && $(GO_CMD) test -v ./registry/postgres/... ./services/files_backfill/...
+	cd $(BACKEND_DIR) && $(GO_CMD) test -v ./registry/postgres/...
 
 # Run all Go tests including PostgreSQL
 .PHONY: test-go-all

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -218,7 +218,7 @@ than one replica (set `persistence.enabled=false`).
 
 - [ ] Put the R2 credentials in the Secret as `AWS_ACCESS_KEY_ID` /
   `AWS_SECRET_ACCESS_KEY`.
-- [ ] ⚠️ **R2 checksum caveat.** `aws-sdk-go-v2` (v1.41) defaults to sending request
+- [ ] ⚠️ **R2 checksum caveat.** `aws-sdk-go-v2` (v1.42.0) defaults to sending request
   checksums (CRC32) that R2 has historically rejected (uploads fail with HTTP 501 /
   signature errors). If you hit that, set these two env vars — the chart loads the whole
   Secret as env, so just add them as keys in the runtime Secret (or via a ConfigMap in
@@ -342,13 +342,15 @@ than one replica (set `persistence.enabled=false`).
     inventario backoffice mfa setup --email ops@example.com   # enroll TOTP
   ```
 
-- [ ] ⚠️ **Block the unauthenticated seed endpoint.** `POST /api/v1/seed` is currently
-  mounted in every environment and runs a privileged, RLS-bypassing seed — an anonymous
-  caller can pollute your tenant and lock your main currency (#201). A config flag to
-  disable it (off by default) is tracked in
-  [#2039](https://github.com/denisvmedia/inventario/issues/2039); once it ships, production
-  simply leaves `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT` unset. **Until then, deny the path at
-  the ingress** and verify `curl -X POST https://<DOMAIN>/api/v1/seed` returns 404:
+- [ ] **Confirm the unauthenticated seed endpoint stays off.** `POST /api/v1/seed` runs a
+  privileged, RLS-bypassing seed (an anonymous caller could pollute your tenant and lock
+  your main currency — #201). As of [#2039](https://github.com/denisvmedia/inventario/issues/2039)
+  the route is **only mounted when `INVENTARIO_RUN_ENABLE_SEED_ENDPOINT=true`** (default
+  `false`), so a production install that leaves the flag unset never exposes it — verify
+  `curl -X POST https://<DOMAIN>/api/v1/seed` returns `404`.
+- [ ] (Optional) **Defense-in-depth: also deny the path at the ingress.** No longer required
+  now that the route is unmounted by default, but a belt-and-braces block keeps the path
+  404 even if someone later flips the flag by mistake:
 
   ```yaml
   # ingress-nginx: add to the Inventario Ingress annotations

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -302,52 +302,43 @@ curl http://localhost:3333/readyz
 
 For advanced use cases, you can run migrations manually:
 
-#### Check Migration Status
+#### List Migrations
 
 ```bash
-# See which migrations have been applied
-docker-compose exec inventario ./inventario db migrate status
-
-# Expected output:
-# Migration: 001_initial_schema.up.sql - Applied
-# Migration: 002_add_user_roles.up.sql - Applied
-# Migration: 003_add_file_signing.up.sql - Pending
+# See the available migrations and which have been applied
+docker-compose exec inventario inventario db migrate list
 ```
 
 #### Run Migrations Manually
 
 ```bash
 # Run all pending migrations
-docker-compose exec inventario ./inventario db migrate up
-
-# Run specific number of migrations
-docker-compose exec inventario ./inventario db migrate up --steps 1
+docker-compose exec inventario inventario db migrate up
 
 # Preview migrations without executing (dry-run)
-docker-compose exec inventario ./inventario db migrate up --dry-run
+docker-compose exec inventario inventario db migrate up --dry-run
 ```
 
 #### Rollback Migrations
 
+`down` takes a target version (the migration version to roll back to) as a positional argument.
+
 ```bash
-# Rollback last migration
-docker-compose exec inventario ./inventario db migrate down --steps 1
+# Roll back to a specific migration version (find versions with `db migrate list`)
+docker-compose exec inventario inventario db migrate down <target-version>
 
 # Preview rollback without executing
-docker-compose exec inventario ./inventario db migrate down --steps 1 --dry-run
+docker-compose exec inventario inventario db migrate down <target-version> --dry-run
 
-# Check status after rollback
-docker-compose exec inventario ./inventario db migrate status
+# Skip the confirmation prompt (dangerous!)
+docker-compose exec inventario inventario db migrate down <target-version> --confirm
+
+# List migrations after rollback
+docker-compose exec inventario inventario db migrate list
 ```
 
-#### Force Migration Version
-
-```bash
-# Mark a migration as applied without running it
-docker-compose exec inventario ./inventario db migrate force --version 3
-
-# Useful for recovery scenarios
-```
+> **Warning:** Down migrations can cause data loss. Always back up your database
+> before rolling back in production.
 
 ### Migration Troubleshooting
 
@@ -392,7 +383,7 @@ docker-compose logs inventario-migrate | grep -i "error\|failed"
 docker-compose exec postgres pg_isready -U inventario
 
 # 4. Verify database schema
-docker-compose exec inventario ./inventario db migrate status
+docker-compose exec inventario inventario db migrate verify
 
 # 5. If database is corrupted, restore from backup
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -84,21 +84,13 @@ Inventario supports dry run mode for all database operations, allowing you to pr
 
 # Create tenants and users for initial setup
 ./inventario tenants create --name="My Organization" --slug="my-org" --dry-run
-./inventario users create --email="admin@example.com" --tenant="my-org" --role="admin" --dry-run
+./inventario users create --email="admin@example.com" --tenant="my-org" --dry-run
 ```
 
-For schema management operations using the Ptah tool:
-
-```bash
-# Preview schema creation
-go run ./ptah/cmd write-db --root-dir ./models --db-url postgres://user:pass@localhost/db --dry-run
-
-# Preview schema deletion
-go run ./ptah/cmd drop-schema --root-dir ./models --db-url postgres://user:pass@localhost/db --dry-run
-
-# Preview complete database cleanup
-go run ./ptah/cmd drop-all --db-url postgres://user:pass@localhost/db --dry-run
-```
+Schema migrations are generated from the Go model annotations (Ptah is an
+external module — `github.com/stokaro/ptah`) via `scripts/generate-migration.sh`
+and applied with `./inventario db migrate up`. See [AGENTS.md](AGENTS.md) for the
+migration workflow.
 
 Dry run mode is especially useful for:
 - Testing configurations before applying to production
@@ -134,25 +126,21 @@ Complete CRUD (Create, Read, Update, Delete) operations for users and tenants:
 # Get detailed tenant information
 ./inventario tenants get acme
 
-# Update tenant properties
-./inventario tenants update acme --name="Acme Corp Ltd" --domain="newdomain.com"
-
-# Update tenant interactively
-./inventario tenants update acme --interactive
+# Update tenant registration mode (open, approval, closed)
+./inventario tenants update acme --registration-mode=approval
 
 # Delete tenant with confirmation
 ./inventario tenants delete acme
 
 # Preview operations without making changes
 ./inventario tenants create --dry-run --name="Test Org"
-./inventario tenants update acme --name="New Name" --dry-run
 ./inventario tenants delete acme --dry-run
 ```
 
 #### User Management
 ```bash
-# Create an admin user
-./inventario users create --email="admin@acme.com" --tenant="acme" --role="admin"
+# Create a user
+./inventario users create --email="admin@acme.com" --tenant="acme"
 
 # Create a user interactively with secure password input
 ./inventario users create
@@ -163,8 +151,8 @@ Complete CRUD (Create, Read, Update, Delete) operations for users and tenants:
 # List users in specific tenant
 ./inventario users list --tenant=acme
 
-# List admin users only
-./inventario users list --role=admin
+# List active users only
+./inventario users list --active=true
 
 # Search users
 ./inventario users list --search=john
@@ -172,29 +160,18 @@ Complete CRUD (Create, Read, Update, Delete) operations for users and tenants:
 # Get detailed user information
 ./inventario users get admin@acme.com
 
-# Update user properties
-./inventario users update admin@acme.com --name="New Name" --role="user"
-
-# Change user password
-./inventario users update admin@acme.com --password
-
-# Move user to different tenant
-./inventario users update admin@acme.com --tenant="other-tenant"
-
-# Deactivate user
-./inventario users update admin@acme.com --active=false
-
-# Update user interactively
-./inventario users update admin@acme.com --interactive
-
 # Delete user with confirmation
 ./inventario users delete admin@acme.com
 
 # Preview operations without making changes
 ./inventario users create --dry-run --email="test@example.com" --tenant="acme"
-./inventario users update admin@acme.com --role="user" --dry-run
 ./inventario users delete admin@acme.com --dry-run
 ```
+
+> **Note:** `users update` is **not yet implemented** — the command currently
+> prints a placeholder message and exits 0 without modifying anything. To grant
+> platform-wide system-admin privileges, use `admin grant-system-admin` (see
+> [System Administrators](#system-administrators) below).
 
 **Important**: User and tenant commands only work with PostgreSQL databases. Memory databases are not supported for persistent operations.
 
@@ -266,9 +243,9 @@ canonical worker types, the equivalent admin REST API, and the
 
 **User Commands:**
 - `create`: Create new users with secure password input and validation
-- `list`: List users with filtering by tenant, role, active status, and search
+- `list`: List users with filtering by tenant, active status, and search
 - `get`: Get detailed user information including tenant details
-- `update`: Update user properties including password changes and tenant moves
+- `update`: Not yet implemented (placeholder — exits without modifying anything)
 - `delete`: Delete users with confirmation prompts
 
 **Common Flags:**
@@ -283,7 +260,6 @@ canonical worker types, the equivalent admin REST API, and the
 - `--offset`: Number of results to skip (default: 0)
 - `--search`: Search by name, slug, or email
 - `--status`: Filter by status (tenants: active, suspended, inactive)
-- `--role`: Filter by role (users: admin, user)
 - `--active`: Filter by active status (users: true, false)
 - `--tenant`: Filter by tenant (users only)
 
@@ -303,7 +279,7 @@ canonical worker types, the equivalent admin REST API, and the
 ### Prerequisites
 
 - **Go**: Version 1.26 or higher
-- **Node.js**: Version 22.15 or higher (managed via Volta)
+- **Node.js**: Version 24.16.0 (managed via Volta)
 - **Git**: For cloning the repository
 
 ### macOS
@@ -432,8 +408,11 @@ For integration tests with PostgreSQL:
 
 ```bash
 export POSTGRES_TEST_DSN="postgres://user:password@localhost:5432/test_db?sslmode=disable"
-go test -tags=integration ./...
+cd go && go test ./...
 ```
+
+Integration tests gate on the `POSTGRES_TEST_DSN` environment variable: when it
+is unset, the relevant tests call `t.Skip`. There is no build tag to enable them.
 
 ### CLI Workflow Integration Test
 
@@ -445,7 +424,7 @@ export POSTGRES_TEST_DSN="postgres://user:password@localhost:5432/test_db?sslmod
 
 # Run the CLI workflow integration test
 cd go
-go test -tags=integration ./integration_test/cli_workflow_integration_test.go -v
+go test ./integration/ -run TestCLIWorkflowIntegration -v
 
 # Or use the provided scripts
 ./scripts/run-integration-tests.sh  # Linux/macOS
@@ -463,9 +442,16 @@ This test validates:
 
 - [Production Release & Deployment Runbook](PRODUCTION.md) - Cut a release and deploy to Kubernetes (k3s/GKE/DOKS), distribution-agnostic
 - [Production Deployment (bare-metal / systemd)](DEPLOYMENT.md) - Single-host install without Kubernetes
-- [Signed URLs for Secure File Access](SIGNED_URLS.md) - Comprehensive guide to the secure file access system
 - [System Admin Operations Runbook](devdocs/admin-runbook.md) - Bootstrapping system admins, audit-log inspection, lockout recovery
 - [Admin Section Threat Model](devdocs/security/admin-threat-model.md) - Security model for the cross-tenant admin surface
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the security policy and how to report a vulnerability.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up your environment and submit changes.
 
 ## License
 This module is licensed under the MIT License. See the [LICENSE](LICENSE) file for details. You are free to use, modify, and distribute this software in accordance with the terms of the license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+Inventario is currently in **private alpha** and does not yet publish versioned
+releases with independent maintenance windows. Security fixes land on the
+`master` branch, and the only supported version is the **latest `master`**.
+Please reproduce any issue against the latest `master` before reporting.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| latest `master`  | :white_check_mark: |
+| older commits    | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue, pull request, or discussion for
+security vulnerabilities.** Public disclosure before a fix is available puts
+alpha testers — some of whom store real inventory data — at risk.
+
+Use one of these **private** channels instead:
+
+1. **GitHub Private Vulnerability Reporting (preferred).** Go to the
+   repository's **Security** tab and choose **Report a vulnerability**
+   (<https://github.com/denisvmedia/inventario/security/advisories/new>).
+   This keeps the report private and lets us coordinate a fix and advisory
+   directly through GitHub.
+2. **Email (fallback).** If you cannot use GitHub's private reporting, email
+   the maintainer at **ask+security@stokaro.com**. Use a clear subject line such as
+   `[SECURITY] Inventario vulnerability report`.
+
+When reporting, please include as much detail as you can:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce (a proof of concept is ideal).
+- The affected component, endpoint, or file, and the `master` commit you
+  tested against.
+- Any suggested remediation, if you have one.
+
+## Response and Disclosure
+
+- We aim to **acknowledge** your report within **3 business days**.
+- We aim to provide an initial **assessment** (severity, whether we can
+  reproduce, and a rough remediation plan) within **7 business days**.
+- We follow a **coordinated disclosure** model: we will work with you on a fix
+  and a disclosure timeline, and we ask that you keep the details private until
+  a fix is available and affected users have had a reasonable window to update.
+- With your permission, we are happy to credit you in the resulting advisory.
+
+Thank you for helping keep Inventario and its users safe.

--- a/devdocs/CSRF_PROTECTION.md
+++ b/devdocs/CSRF_PROTECTION.md
@@ -10,9 +10,9 @@ Inventario implements comprehensive CSRF protection for all state-changing opera
 
 ### Components
 
-1. **CSRF Service** (`go/services/csrf_service.go`)
-   - Manages CSRF token lifecycle (generation, validation, deletion)
-   - Supports multiple backends: Redis (production), In-Memory (development), No-op (testing)
+1. **CSRF Service factory** (`go/services/csrf_service.go`) and backends (`go/csrf/{inmemory,redis,noop}`)
+   - `NewCSRFService(redisURL)` selects the backend: Redis when a URL is set, otherwise in-memory with a warning.
+   - The token lifecycle (generation, validation, revocation, expiry) lives in the backend packages under `go/csrf/` — `inmemory` (default), `redis` (production / multi-instance), and `noop` (testing).
    - Tokens expire after 1 hour and are refreshed on token refresh
 
 2. **CSRF Middleware** (`go/apiserver/csrf_middleware.go`)
@@ -20,10 +20,10 @@ Inventario implements comprehensive CSRF protection for all state-changing opera
    - Bypasses safe methods (GET, HEAD, OPTIONS)
    - Implements fail-open design for backend errors
 
-3. **Frontend Integration** (`frontend/src/services/api.ts`)
-   - Stores CSRF tokens in memory
-   - Automatically includes tokens in mutating requests
-   - Recovers tokens from login/refresh responses
+3. **Frontend Integration** (`frontend/src/lib/http.ts`)
+   - The single fetch-based HTTP wrapper (no axios) stores the CSRF token in memory
+   - Automatically includes the token in mutating requests
+   - Recovers the token from login/refresh responses
 
 ## Token Flow
 
@@ -41,7 +41,7 @@ Inventario implements comprehensive CSRF protection for all state-changing opera
 ### Request Flow
 ```
 1. Frontend makes mutating request (POST/PUT/PATCH/DELETE)
-2. Axios interceptor adds X-CSRF-Token header
+2. The fetch wrapper (src/lib/http.ts) adds the X-CSRF-Token header
 3. CSRF middleware validates token against stored value
 4. Request proceeds if token is valid
 5. Request is rejected with 403 if token is missing/invalid
@@ -82,12 +82,18 @@ export INVENTARIO_RUN_CSRF_REDIS_URL="redis://localhost:6379/0"
 CSRF protection requires proper CORS configuration:
 
 ```bash
-# Development (allows all origins)
+# Development with the in-memory backend (memory:// DSN): a fixed local
+# dev allowlist (DefaultDevAllowedOrigins) is applied automatically.
 ./inventario run
 
 # Production (whitelist specific origins)
 ./inventario run --allowed-origins="https://example.com,https://app.example.com"
 ```
+
+CORS is **fail-closed**: when `AllowedOrigins` is empty the middleware rejects
+every cross-origin request (`AllowOriginFunc` returns `false`). The convenience
+dev allowlist is only seeded when the database DSN is `memory://`; `*` and `null`
+origins are rejected outright. See `go/apiserver/cors_config.go`.
 
 The CORS configuration automatically includes:
 - `AllowCredentials: true` (required for httpOnly cookies)
@@ -125,13 +131,16 @@ The CORS configuration automatically includes:
 
 ### Unit Tests
 
-**CSRF Service Tests** (`go/services/csrf_service_test.go`):
+**CSRF backend tests** (`go/csrf/inmemory/service_test.go`, `go/csrf/redis/service_test.go`, `go/csrf/noop/service_test.go`):
 - Token generation and retrieval
-- Token deletion
-- Token replacement
+- Token revocation / delete-all
 - Multi-user isolation
+- LRU eviction
 - Concurrent access
 - No-op service behavior
+
+**CSRF factory tests** (`go/services/csrf_service_test.go`):
+- Backend selection (`TestNewCSRFService_FallbackToInMemory`, `TestNewCSRFService_InvalidRedisURL`)
 
 **CSRF Middleware Tests** (`go/apiserver/csrf_middleware_test.go`):
 - Safe method bypass
@@ -148,11 +157,12 @@ The CORS configuration automatically includes:
 ```bash
 # Run all CSRF tests
 cd go
+go test -v ./csrf/...
 go test -v ./services -run CSRF
 go test -v ./apiserver -run CSRF
 
-# Run specific test
-go test -v ./services -run TestInMemoryCSRFService_GenerateAndGetToken
+# Run a specific backend test
+go test -v ./csrf/inmemory -run TestService_GenerateToken
 ```
 
 ## Troubleshooting
@@ -194,5 +204,4 @@ go test -v ./services -run TestInMemoryCSRFService_GenerateAndGetToken
 
 - Issue: [#837 - MVP Phase 1.3: Implement CSRF Protection](https://github.com/denisvmedia/inventario/issues/837)
 - Related: [#497 - CRITICAL SECURITY: Missing Security Headers](https://github.com/denisvmedia/inventario/issues/497)
-- Documentation: `.research/phase-1-security-and-auth.md` lines 691-835
 

--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -17,7 +17,7 @@ requiring them to re-enter credentials every 15 minutes.
 | Storage (client) | `localStorage` | Browser cookie (not accessible via JS) |
 | Storage (server) | Stateless (validated by signature) | SHA-256 hash in DB |
 | Revocable | Yes (via blacklist) | Yes (DB `revoked_at` field) |
-| Scope | Any API endpoint | Auth endpoints only (`/api/v1/auth`) |
+| Scope | Any API endpoint | Cookie path `/api/v1` (covers `/api/v1/auth/*` + `/api/v1/admin/impersonation/end`) |
 
 The refresh token cookie is set with `HttpOnly`, `Secure`, and `SameSite=Strict` flags,
 which means JavaScript cannot read it and it will not be sent to third-party origins.
@@ -82,7 +82,7 @@ user interaction:
 ```mermaid
 sequenceDiagram
     participant C as Client (Browser)
-    participant I as Axios Interceptor
+    participant I as http.ts wrapper
     participant A as Auth API
     participant DB as Database
 
@@ -104,7 +104,7 @@ sequenceDiagram
     I->>C: Retry original request with new token
 ```
 
-Key properties of the refresh interceptor:
+Key properties of the refresh logic (`frontend/src/lib/http.ts`, fetch-based — no axios):
 - **Deduplication**: if multiple requests fail with 401 simultaneously, only one refresh
   call is made; other requests are queued and retried once the new token arrives.
 - **Loop prevention**: auth endpoint requests (`/auth/*`) are never retried to avoid
@@ -201,13 +201,19 @@ The JWT payload contains:
 
 ```
 {
-  "jti":     "<uuid>",        // unique token ID for blacklisting
-  "user_id": "<uuid>",        // user identifier
-  "role":    "admin|viewer",  // user role
-  "iat":     <unix timestamp>,
-  "exp":     <unix timestamp> // iat + 15 minutes
+  "jti":             "<uuid>",  // unique token ID for blacklisting
+  "user_id":         "<uuid>",  // user identifier
+  "is_system_admin": false,     // advisory FE hint (#1784); never the authz gate
+  "token_type":      "access",  // distinguishes access from mfa_token, etc.
+  "iat":             <unix timestamp>,
+  "exp":             <unix timestamp>, // iat + 15 minutes
+  "rti":             "<uuid>"   // optional: refresh-token row id (for /users/me/sessions)
 }
 ```
+
+See `issueAccessToken` in `go/apiserver/auth.go`. There is **no** `role` claim;
+authorization is enforced server-side (`is_system_admin` is re-checked against
+`system_admin_grants`, and per-group roles come from the membership tables).
 
 The token is signed with HMAC-SHA256 using the server's `--jwt-secret`.
 
@@ -276,17 +282,17 @@ Three implementations are provided:
 ### Request Pipeline
 
 ```
-┌──────────────┐   attach Bearer token   ┌──────────────────┐
-│  Vue component│ ──── API request ──────►│  Request          │
-│  / Pinia store│                         │  Interceptor      │
-└──────────────┘                         └─────────┬────────┘
+┌─────────────────┐   attach Bearer token   ┌──────────────────┐
+│  React component │ ──── API request ──────►│  http.ts wrapper  │
+│  / TanStack hook │                         │  (request stage)  │
+└─────────────────┘                         └─────────┬────────┘
                                                    │
                                           ┌────────▼────────┐
                                           │  Backend API     │
                                           └────────┬────────┘
                                                    │
                                           ┌────────▼────────────────────┐
-                                          │  Response Interceptor        │
+                                          │  http.ts (response stage)    │
                                           │                              │
                                           │  200 → pass through          │
                                           │                              │
@@ -337,7 +343,10 @@ unusable hashes; the raw token only ever exists in transit and in the browser co
 - `HttpOnly` — not readable by JavaScript
 - `Secure` — only sent over HTTPS
 - `SameSite=Strict` — not sent on cross-site requests; prevents CSRF
-- `Path=/api/v1/auth` — scope limited to auth endpoints only; not sent on regular API calls
+- `Path=/api/v1` — the common ancestor of the auth endpoints (`/api/v1/auth/*`)
+  and `POST /api/v1/admin/impersonation/end`, so the impersonation end-of-session
+  flow can read the cookie. A legacy cookie at `/api/v1/auth` is actively cleared
+  (`clearLegacyRefreshCookie`). See `refreshTokenCookiePath` in `go/apiserver/auth.go`.
 
 ### JTI and Immediate Revocation
 

--- a/devdocs/SYSTEM_DESIGN.md
+++ b/devdocs/SYSTEM_DESIGN.md
@@ -56,7 +56,7 @@ Locations (Top-level containers)
   - Status: Draft, Active, Sold, Lost, Disposed, Written Off
   - Dates: Purchase Date, Registration Date, Last Modified
   - Organization: Tags, Comments, URLs
-- **Relationships**: Belongs to one Area, has multiple Files (Images, Invoices, Manuals)
+- **Relationships**: Optionally filed under one Area — `AreaID` is nullable (#1986), so a commodity may be unassigned ("No location"); has multiple Files (Images, Invoices, Manuals)
 
 #### File Management
 - **File Types**: Images, Invoices, Manuals

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -198,7 +198,8 @@ Operational constraints:
   A `support_agent` is rejected with `403` and
   `admin.role_required`.
 - Default TTL is **30 minutes**, configurable via
-  `INVENTARIO_IMPERSONATION_TTL` (capped at 30 minutes).
+  `INVENTARIO_RUN_IMPERSONATION_TTL` (or `--impersonation-ttl`; capped at
+  30 minutes).
 - The impersonation token carries `is_system_admin = false` and the
   cross-plane operator claims
   `impersonator_id = <backoffice_users.id>` and
@@ -338,9 +339,10 @@ The pausable worker types (stable identifiers used by the CLI, the API,
 and the `worker_control.worker_type` column):
 
 `export`, `import`, `restore`, `thumbnail`, `refresh-token-cleanup`,
-`email-verification-cleanup`, `login-event-retention`, `group-purge`,
-`warranty-reminder`, `storage-quota-reminder`, `loan-reminder`,
-`maintenance-reminder`, `currency-migration`.
+`email-verification-cleanup`, `magic-link-token-cleanup`,
+`login-event-retention`, `group-purge`, `warranty-reminder`,
+`storage-quota-reminder`, `loan-reminder`, `maintenance-reminder`,
+`currency-migration`.
 
 > Email delivery is intentionally **not** in this set — it is a Redis
 > subscriber rather than a polling worker, with a separate pause story.

--- a/devdocs/backend/files-backfill.md
+++ b/devdocs/backend/files-backfill.md
@@ -1,5 +1,16 @@
 # Files backfill runbook
 
+> **HISTORICAL — NO LONGER RUNNABLE.** The `inventario migrate files-backfill`
+> command described below never shipped in its final form and does not exist
+> today (`inventario db migrate` exposes only `up` / `list` / `down` / `data` /
+> `verify`). The `services/files_backfill/` package was removed in PR
+> [#1479](https://github.com/denisvmedia/inventario/pull/1479), and the legacy
+> `images` / `invoices` / `manuals` tables were dropped by migration
+> `1777734471_drop_legacy_file_tables`. The only real backfill command today is
+> `inventario backfill blobs` ([#1793](https://github.com/denisvmedia/inventario/issues/1793)),
+> which is a different feature (tenant-namespaced blob keys, not the legacy
+> file-table merge). This document is retained for historical context only.
+
 `inventario migrate files-backfill` copies the legacy commodity-scoped
 `images`, `invoices`, and `manuals` tables into the unified `files` table
 introduced under epic [#1397](https://github.com/denisvmedia/inventario/issues/1397).

--- a/devdocs/frontend/README.md
+++ b/devdocs/frontend/README.md
@@ -50,7 +50,9 @@ codebase uses.
 Hard bans live in [imports-and-bans.md](imports-and-bans.md). The short list:
 no `next-themes` (Vite SPA, not Next.js), no `@base-ui/react` (we lock to
 Radix), no FontAwesome / PrimeIcons (Lucide only), no leftover Bolt
-scaffolding artifacts (asserted by `go/apiserver/frontend_embed_test.go`).
+scaffolding artifacts (keep `<title>Inventario</title>`). The Go embed smoke
+test `go/apiserver/frontend_embed_test.go` separately guards that the build
+embeds underscore-prefixed assets via the `dist/_inventario-embed.txt` marker.
 
 ## How this differs from the design mock
 

--- a/devdocs/frontend/accessibility.md
+++ b/devdocs/frontend/accessibility.md
@@ -154,9 +154,9 @@ it("has no axe violations", async () => {
 })
 ```
 
-End-to-end: import `runAxe` from `e2e/utils/axe.ts` and call it inside
-the relevant `test()` block. The default severity floor is `serious` +
-`critical`. See [testing.md](testing.md).
+End-to-end: import `axeAudit` from `e2e/utils/axe.ts` and call it
+(`await axeAudit(page)`) inside the relevant `test()` block. The default
+severity floor is `serious` + `critical`. See [testing.md](testing.md).
 
 ## Anti-patterns
 

--- a/devdocs/frontend/coding-standards.md
+++ b/devdocs/frontend/coding-standards.md
@@ -6,8 +6,10 @@ practical, otherwise enforced by review. If a rule disagrees with the
 
 ## TypeScript
 
-- **Strict mode is on** — see `frontend/tsconfig.json`. Never weaken `strict`
-  to land a PR; fix the typing instead.
+- **Strict mode is on** — set in `frontend/tsconfig.app.json` and
+  `frontend/tsconfig.node.json` (the root `frontend/tsconfig.json` is a
+  solution file that only references them). Never weaken `strict` to land a
+  PR; fix the typing instead.
 - **`any` is a warning, not an error** — `@typescript-eslint/no-explicit-any:
   warn` (see `frontend/eslint.config.js`). Treat each `any` as a TODO and
   prefer `unknown` + a narrowing guard, or a typed schema (`zod`,

--- a/devdocs/frontend/i18n.md
+++ b/devdocs/frontend/i18n.md
@@ -33,6 +33,10 @@ export const I18N_NAMESPACES = [
   "commodities",
   "files",
   "tags",
+  "loans",
+  "maintenance",
+  "services",
+  "supplies",
   "exports",
   "settings",
   "members",
@@ -40,6 +44,12 @@ export const I18N_NAMESPACES = [
   "search",
   "stubs",        // PlaceholderPage titles
   "errors",
+  "warranties",
+  "feedback",
+  "admin",
+  "backoffice",
+  "reports",
+  "landing",
 ] as const
 ```
 

--- a/devdocs/frontend/imports-and-bans.md
+++ b/devdocs/frontend/imports-and-bans.md
@@ -12,7 +12,7 @@ in the issues that drove each ban.
 | `@base-ui/react` | The design mock shipped both `radix-ui` and `@base-ui/react`. Two headless primitive libraries doing the same job is one too many. | `radix-ui` (the umbrella package). |
 | `@tailwindcss/animate` | Replaced by `tw-animate-css` (works with Tailwind v4's `@theme inline`). | `tw-animate-css` — already in `package.json`, imported at the top of `src/index.css`. |
 | `@fortawesome/react-fontawesome` (and any FA icon set), `primeicons`, `react-icons`, `@heroicons/react`, `@material-ui/icons` | One icon library. Mixing icon libraries breaks the visual rhythm and bloats the bundle. | `lucide-react`. See [icons.md](icons.md). |
-| Bolt scaffolding artifacts (`bolt-*` packages, `BoltGlobals`, `bolt:` data attributes, the literal string `"Bolt"` in `<title>`) | Leftover from the React scaffold's origin. They have no runtime purpose and act as a tripwire. | Delete on sight. The Go embed test (`go/apiserver/frontend_embed_test.go`) asserts the bundled HTML's title is `Inventario` and contains no Bolt artifacts. |
+| Bolt scaffolding artifacts (`bolt-*` packages, `BoltGlobals`, `bolt:` data attributes, the literal string `"Bolt"` in `<title>`) | Leftover from the React scaffold's origin. They have no runtime purpose and act as a tripwire. | Delete on sight. The `<title>` is `Inventario` (`frontend/index.html`); keep it that way. |
 | Vue, Vue Router, Pinia, PrimeVue, PrimeFlex, vue-i18n, sass | Legacy frontend dependencies, deleted at cutover (#1423, PR #1457). | The React stack — see [README.md](README.md). |
 | Framer Motion, react-spring, popmotion | Animation needs are met by `tw-animate-css` + Tailwind utilities; a runtime animation library is dead weight. | `animate-in`, `fade-in-0`, `slide-in-from-top-2`, etc. (see [styles-and-tokens.md](styles-and-tokens.md)). |
 | `axios`, `superagent`, `ky` | We have one fetch wrapper (`src/lib/http.ts`) that owns CSRF, group-rewriting, refresh, and JSON:API content type — none of which a generic HTTP library handles for us. | `src/lib/http.ts` via the feature slice's `api.ts`. See [data.md](data.md). |
@@ -26,10 +26,13 @@ The conventions above are enforced by:
 
 1. **PR review.** `package.json` adds get scrutiny — every new
    dependency justifies itself in the PR body.
-2. **Embed smoke tests.** `go/apiserver/frontend_embed_test.go` asserts
-   the bundled HTML's `<title>` is `Inventario` and contains no Bolt
-   artifacts. Catches accidental scaffolding leftovers and HTML edits
-   that swap in something else.
+2. **Embed smoke test.** `go/apiserver/frontend_embed_test.go`
+   (`TestFrontendEmbed_UnderscorePrefixedFilesArePresent`) asserts the
+   stable marker file `dist/_inventario-embed.txt` (copied verbatim from
+   `frontend/public/_inventario-embed.txt`) is present in the embedded
+   filesystem — proving the `//go:embed all:dist` directive ships
+   underscore-prefixed files (Go silently skips `_`/`.`-prefixed names
+   without the `all:` prefix). It does not inspect the HTML title.
 3. **Lighthouse `best-practices`.** Console errors from a banned-but-
    somehow-installed library (e.g. `next-themes` complaining about a
    missing context) tank the score and trip the gate.

--- a/devdocs/frontend/migration-conventions.md
+++ b/devdocs/frontend/migration-conventions.md
@@ -98,10 +98,12 @@ follow-up in the other, with the PR cross-linked. See
 
 ### Smoke test on the embed
 
-`go/apiserver/frontend_embed_test.go` asserts the bundled HTML's
-`<title>` and absence of Bolt artifacts. Predates cutover; survives as
-the cheapest tripwire for "did the build accidentally inline the wrong
-HTML?".
+`go/apiserver/frontend_embed_test.go`
+(`TestFrontendEmbed_UnderscorePrefixedFilesArePresent`) asserts the marker
+file `dist/_inventario-embed.txt` (copied from
+`frontend/public/_inventario-embed.txt`) made it into the embedded
+filesystem — the cheapest tripwire for "did `//go:embed all:dist` silently
+drop the underscore-prefixed Vite chunks?". Predates cutover.
 
 ## Cutover criteria (for the historical record)
 

--- a/devdocs/frontend/perf.md
+++ b/devdocs/frontend/perf.md
@@ -8,8 +8,8 @@ Config: `frontend/.size-limit.json`. Three groups:
 
 | Group                                   | Limit (gzip) | Why                                                                                              |
 | --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
-| Initial JS (main + jsx-runtime + button) | 200 KB       | First-paint cost. Today: ~178 KB after auth (#1407) + dashboard (#1408). ~20 KB of headroom for items list (#1410) + widgets. |
-| CSS                                     | 14 KB        | Tailwind v4 + tokens. Today: ~12.5 KB after the dashboard's stat-card grid + the `Card` primitive shadow tier; was 12 KB before #1408. |
+| Initial JS (entry chunk — all eager code) | 230 KB       | First-paint cost. Headroom for items list (#1410) + widgets. |
+| CSS                                     | 20 KB        | Tailwind v4 + tokens. |
 | Lazy real pages (Dashboard / NotFound / RootRedirect) | 6 KB | Code-split chunks. Today: ~3.7 KB after the dashboard widgets landed (#1408); was 3 KB while the page was a placeholder. |
 
 Run locally:
@@ -33,7 +33,7 @@ CI: `.github/workflows/frontend-size.yml` runs `npm ci && npm run build && npm r
 
 1. `npm run size:why` — opens an interactive bundle inspector. Look for new dependencies that landed in the same PR.
 2. `dist/assets/index-*.js` — the entry chunk. If a feature page added eagerly (not via `React.lazy()`), it lands here.
-3. `vite.config.ts` — confirm `build.rolldownOptions.output.codeSplitting` is on; sometimes an unintentional side-effect import breaks a chunk.
+3. Code-splitting relies on Vite's default per-`React.lazy()` chunking (`vite.config.ts` doesn't override `build.rollupOptions`); sometimes an unintentional eager (static) import of a lazy page pulls it back into the entry chunk.
 
 ## Lighthouse — LHCI
 

--- a/devdocs/frontend/routing.md
+++ b/devdocs/frontend/routing.md
@@ -208,7 +208,7 @@ new chunk only loads when the user navigates to that route. Watch for:
 ## Anti-patterns
 
 - **Nested `<BrowserRouter>`s.** There is exactly one `BrowserRouter`,
-  in `src/main.tsx`. Tests use `MemoryRouter` via `renderWithProviders`.
+  in `src/app/providers.tsx`. Tests use `MemoryRouter` via `renderWithProviders`.
 - **`window.location.href = …` to navigate.** Use `useNavigate()` or
   `<Navigate>`. The hard exception is `navigateToLogin()` in
   `src/lib/navigation.ts`, which fires from non-React HTTP code.

--- a/devdocs/frontend/screenshots.md
+++ b/devdocs/frontend/screenshots.md
@@ -8,7 +8,7 @@ The script we use is `e2e/screenshots.mjs`.
 
 ## Prerequisites
 
-- Node.js 24.14.1, npm
+- Node.js 24.16.0, npm
 - Go 1.26+
 - Playwright browsers installed in `e2e/` (one-time):
   ```bash

--- a/devdocs/frontend/testing.md
+++ b/devdocs/frontend/testing.md
@@ -9,17 +9,25 @@ frontend/src/test/
 ├── setup.ts          # global hooks: jest-dom, jest-axe, MSW server, sonner mock, i18n boot, matchMedia stub
 ├── server.ts         # shared msw `setupServer()` instance
 ├── render.tsx        # `renderWithProviders()` helper
-└── handlers/         # per-endpoint MSW factories
+└── handlers/         # per-endpoint MSW factories (18 modules)
     ├── index.ts      # public surface — re-exports + apiUrl helper
+    ├── areas.ts
     ├── auth.ts
-    ├── groups.ts
+    ├── backoffice.ts
     ├── commodities.ts
-    ├── locations.ts
-    ├── files.ts
-    ├── tags.ts
+    ├── commodityScan.ts
+    ├── currencyMigrations.ts
     ├── exports.ts
+    ├── files.ts
+    ├── groups.ts
+    ├── loans.ts
+    ├── locations.ts
+    ├── maintenance.ts
     ├── members.ts
-    └── search.ts
+    ├── search.ts
+    ├── services.ts
+    ├── supplies.ts
+    └── tags.ts
 ```
 
 ## `renderWithProviders`
@@ -169,10 +177,10 @@ Enforced in `vitest.config.ts` — CI fails if coverage drops below:
 
 | Metric     | Threshold |
 | ---------- | --------- |
-| Statements | 80%       |
-| Lines      | 80%       |
-| Functions  | 80%       |
-| Branches   | 70%       |
+| Statements | 76%       |
+| Lines      | 79%       |
+| Functions  | 75%       |
+| Branches   | 67%       |
 
 Excluded paths:
 
@@ -182,7 +190,7 @@ Excluded paths:
 - `src/i18n/i18next.config.ts` — lazy backend for cs/ru exercised by the Settings page locale toggle (#1414).
 - `src/main.tsx`, `src/types/**`, `src/vite-env.d.ts` — entry / generated.
 
-Bump thresholds upward as feature pages land — never downward without a written reason in the PR body.
+Bump thresholds upward as feature pages land; only lower them with a written reason in the PR body (the current numbers reflect the #1629 Radix-Select coverage gap — see the rationale comment in `vitest.config.ts`).
 
 ## Snapshot policy
 

--- a/devdocs/infra/dev/README.md
+++ b/devdocs/infra/dev/README.md
@@ -14,7 +14,7 @@
 | **What does it give a contributor?** | Label a PR `preview` → within ~5 min the PR comment posts a hostname `inv-vcl01-prN`. Any tailnet member opens `https://inv-vcl01-prN.<tailnet>.ts.net/` and gets a fully-functional Inventario with that PR's code, demo Postgres/Redis/MinIO, and seeded sample data. Unlabel or close the PR → preview disappears within a poll cycle. |
 | **What is the cluster?** | A single-VM Kubernetes cluster on Proxmox (VM 101 @ host `your-proxmox-host`, Ubuntu 26.04) running [vcluster](https://www.vcluster.com) standalone with [ArgoCD](https://argo-cd.readthedocs.io) on top and the [Tailscale Kubernetes Operator](https://tailscale.com/kb/1236/kubernetes-operator) for tailnet-bound Ingresses. |
 | **How does a PR turn into a preview?** | ArgoCD's [ApplicationSet](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/) PR generator polls GitHub every 60 s, sees PRs labeled `preview`, spawns an `Application` per PR that templates the helm chart at the PR's head commit. ArgoCD syncs the chart into a per-PR namespace. The Tailscale Operator notices the chart's Ingress, provisions a tailnet proxy node with a `tailscale.com/hostname` annotation, and the URL becomes reachable. |
-| **What's NOT in scope (yet)?** | Auto-rollout when only the `master` tag's digest changes ([#1885](https://github.com/denisvmedia/inventario/issues/1885)); production-grade admin password from sops ([#1883](https://github.com/denisvmedia/inventario/issues/1883)); in-place migrations under ArgoCD upgrade ([#1884](https://github.com/denisvmedia/inventario/issues/1884)); chart-side `tls[].secretName` polish ([#1882](https://github.com/denisvmedia/inventario/issues/1882)); direct tailnet exposure of the ArgoCD UI and vcluster API ([#1892](https://github.com/denisvmedia/inventario/issues/1892)). |
+| **What's NOT in scope (yet)?** | Production-grade admin password from sops ([#1883](https://github.com/denisvmedia/inventario/issues/1883)); in-place migrations under ArgoCD upgrade ([#1884](https://github.com/denisvmedia/inventario/issues/1884)); chart-side `tls[].secretName` polish ([#1882](https://github.com/denisvmedia/inventario/issues/1882)); direct tailnet exposure of the ArgoCD UI and vcluster API ([#1892](https://github.com/denisvmedia/inventario/issues/1892)). |
 
 ---
 
@@ -134,14 +134,16 @@ Nothing in this layout is exposed to the public internet:
 flowchart TD
     appproj["AppProject 'previews'<br/>scoped to inv-vcl01-* namespaces<br/>(infra/argocd/appproject.yaml)"]
     appset["ApplicationSet 'inventario-pr-previews'<br/>PR generator + GH App auth<br/>(infra/argocd/applicationset-pr.yaml)"]
-    appmaster["Application 'inv-vcl01-master'<br/>static, tracks master branch<br/>(infra/argocd/application-master.yaml)"]
+    appsetmaster["ApplicationSet 'inventario-master-preview'<br/>git generator, SHA-pinned ({{ .sha }})<br/>(infra/argocd/applicationset-master.yaml)"]
+    appmaster["Application 'inv-vcl01-master'<br/>generated from the master pin file<br/>(spawned by ApplicationSet)"]
     appprN["Application 'inv-vcl01-prN'<br/>generated per PR with label 'preview'<br/>(spawned by ApplicationSet)"]
 
-    appproj --> appmaster
+    appproj --> appsetmaster
     appproj --> appset
+    appsetmaster --> appmaster
     appset --> appprN
 
-    appmaster -->|"sources: chart at master HEAD<br/>image.tag: master, pullPolicy: Always"| chartmaster["helm/inventario chart"]
+    appmaster -->|"sources: chart at master pin SHA<br/>image.tag: sha-&lt;7&gt;"| chartmaster["helm/inventario chart"]
     appprN -->|"sources: chart at PR head SHA<br/>image.tag: sha-&lt;7&gt;"| chartpr["helm/inventario chart"]
 
     chartmaster --> overlay["preview-base.values.yaml<br/>(shared overlay via $values multi-source)"]
@@ -153,7 +155,7 @@ Three ArgoCD resources land at bootstrap time (applied by `bootstrap.sh` via `ku
 | Resource | File | Purpose |
 |---|---|---|
 | `AppProject previews` | `infra/argocd/appproject.yaml` | Restricts both source repos (`denisvmedia/inventario` only) and destination namespaces (`inv-vcl01-*` only). Belt-and-suspenders so a malformed Application can't reach into `argocd`, `tailscale`, `inv-system`, etc. |
-| `Application inv-vcl01-master` | `infra/argocd/application-master.yaml` | Continuously deploys the master branch to namespace `inv-vcl01-master`. Image pinned to the moving `master` tag with `pullPolicy: Always`. |
+| `ApplicationSet inventario-master-preview` | `infra/argocd/applicationset-master.yaml` | Continuously deploys master to namespace `inv-vcl01-master`. A **git generator** reads the pin file `infra/argocd/master-image.json` (`{ "sha": ..., "imageTag": "sha-<7>" }`) off the dedicated CI-maintained orphan branch `argocd/master-pin` (`revision: argocd/master-pin`, **not** master), exposing `{{ .sha }}` / `{{ .imageTag }}`. Chart + `$values` are pinned to `{{ .sha }}` and the image to the immutable `{{ .imageTag }}` (`pullPolicy: IfNotPresent`) — a master push triggers `docker.yml`, which force-pushes the updated pin file to `argocd/master-pin`, moving the SHA the generator reads and triggering a sync ([#1885](https://github.com/denisvmedia/inventario/issues/1885)). |
 | `ApplicationSet inventario-pr-previews` | `infra/argocd/applicationset-pr.yaml` | Per-PR previews. `goTemplate: true` + `goTemplateOptions: [missingkey=error]`. Generates one Application per open PR labeled `preview`; image pinned to the PR's `sha-<7>` (immutable). |
 
 Both Applications layer the **shared overlay** `infra/helm-overlays/preview-base.values.yaml` via ArgoCD's multi-source `$values` mechanism — same demo deps (Postgres/Redis/MinIO), same `argocdMode: true` for the setup Job, same admin credentials. Per-Application bits (image tag, ingress hostname, FQDN) layer on top via inline `helm.values`.
@@ -281,26 +283,38 @@ flowchart LR
 
 **AppProject** scopes both source repo and destination namespaces — sourceRepos `denisvmedia/inventario` only, destinations `inv-vcl01-*` only. So an Application can't accidentally try to deploy into `argocd` or `tailscale`.
 
-**Application `inv-vcl01-master`** is static. Two sources via `$values` multi-source pattern:
+**ApplicationSet `inventario-master-preview`** deploys master. It is a **git generator** that reads the pin file `infra/argocd/master-image.json` off the dedicated CI-maintained orphan branch `argocd/master-pin` (`revision: argocd/master-pin` — the file does **not** live on `master`) and templates one `inv-vcl01-master` Application, pinned to the pinned SHA (chart + `$values` at `{{ .sha }}`, image at the immutable `{{ .imageTag }}`). A master push triggers `docker.yml`, which force-pushes the new `{ sha, imageTag }` pin file to `argocd/master-pin`; the SHA change on that branch is what ArgoCD diffs on and syncs ([#1885](https://github.com/denisvmedia/inventario/issues/1885)).
 
 ```yaml
-sources:
-  - repoURL: https://github.com/denisvmedia/inventario
-    targetRevision: master
-    path: helm/inventario
-    helm:
-      valueFiles:
-        - $values/infra/helm-overlays/preview-base.values.yaml
-      values: |
-        image:
-          tag: master
-          pullPolicy: Always
-        ingress:
-          annotations: { tailscale.com/hostname: inv-vcl01-master }
-          ...
-  - repoURL: https://github.com/denisvmedia/inventario
-    targetRevision: master
-    ref: values        # exposes the repo for $values lookups
+spec:
+  goTemplate: true
+  goTemplateOptions: [missingkey=error]
+  generators:
+    - git:
+        repoURL: https://github.com/denisvmedia/inventario
+        revision: argocd/master-pin              # CI-maintained orphan branch (NOT master)
+        files:
+          - path: infra/argocd/master-image.json   # { "sha": ..., "imageTag": "sha-<7>" }
+  template:
+    metadata:
+      name: inv-vcl01-master
+    spec:
+      project: previews
+      sources:
+        - repoURL: https://github.com/denisvmedia/inventario
+          targetRevision: '{{ .sha }}'
+          path: helm/inventario
+          helm:
+            valueFiles: [$values/infra/helm-overlays/preview-base.values.yaml]
+            values: |
+              image:
+                tag: '{{ .imageTag }}'   # immutable sha-<7>, pullPolicy: IfNotPresent
+              ingress:
+                annotations: { tailscale.com/hostname: inv-vcl01-master }
+                ...
+        - repoURL: https://github.com/denisvmedia/inventario
+          targetRevision: '{{ .sha }}'
+          ref: values        # exposes the repo for $values lookups
 ```
 
 **ApplicationSet `inventario-pr-previews`** is the live one for PR previews. Critical config:
@@ -354,7 +368,7 @@ The chart at `helm/inventario` is the same one shipped to production users (it's
 
 | Value | Why |
 |---|---|
-| `image.repository: ghcr.io/denisvmedia/inventario` | Pin registry. `image.tag` is layered per-Application (immutable sha-7 for PR, moving `master` for master). |
+| `image.repository: ghcr.io/denisvmedia/inventario` | Pin registry. `image.tag` is layered per-Application — the immutable `sha-<7>` in both cases (the PR's head SHA for previews, the pinned master SHA from `master-image.json` for the master preview). |
 | `run.all.enabled: true`, `replicaCount: 1` | Combined-mode Deployment (apiserver + workers in one pod). Single replica is right for ephemeral state. |
 | `demo.{postgresql,redis,minio}.enabled: true` | In-cluster sidecars instead of external databases. No persistence — preview wipes on rebuild by design. |
 | `setupJob.argocdMode: true` | See "argocdMode" below. |
@@ -540,7 +554,7 @@ selfHeal handles cluster-side drift continuously — `kubectl delete` anything A
 | ArgoCD ApplicationSet PR generator vs a custom Go controller / labels bot | Out-of-the-box, declarative, well-documented, multi-tenant by design (AppProject scopes). Custom controller would have to re-implement PR-list polling, GH auth, sync-on-change, prune-on-removal. Trade-off accepted: harder to do non-standard things like sticky comments (now done in a separate GH Actions workflow) or per-PR feature gating. See #1867 spike for the alternatives considered. |
 | Single VM (vcluster standalone) vs a managed k8s | Phase 1 is one-developer + occasional contributors. Managed k8s costs money continuously; a Hetzner-ish single VM is < €15/mo with snapshots for DR. vcluster standalone gives a real k8s without the operational overhead of kubeadm. |
 | Tailscale Operator Ingress vs cert-manager + public DNS | No public exposure of preview environments was a hard requirement (PRs touch real data shapes). Tailscale gives us tailnet-only HTTPS with automatic cert provisioning for free. cert-manager + public DNS would still need a tailnet-gated reverse proxy in front; more moving parts. |
-| `image.tag: master` mutable for master Application vs `sha-<7>` immutable | Master needs continuous deployment. With a moving tag, the rendered chart doesn't change between commits → ArgoCD sees no diff → no sync. This is a Phase 1 known limit, tracked under #1885 (the cleaner answer is a git-generator ApplicationSet with `head_sha`). PR Applications pin `sha-<7>` because reproducibility per-commit is what reviewers want. |
+| Git-generator pin file for master vs a moving `image.tag: master` | Master needs continuous deployment, but with a moving tag the rendered chart doesn't change between commits → ArgoCD sees no diff → no sync. The fix ([#1885](https://github.com/denisvmedia/inventario/issues/1885)) is the `inventario-master-preview` git-generator ApplicationSet: a master push triggers `docker.yml`, which force-pushes `infra/argocd/master-image.json` with the new `{ sha, imageTag }` to the dedicated orphan branch `argocd/master-pin` (the file is **not** on master); the generator reads it from there, ArgoCD diffs on the changed SHA and syncs the immutable `sha-<7>` image. PR Applications pin `sha-<7>` for the same per-commit reproducibility reviewers want. |
 | `argocdMode: true` (drop helm hook) for setup Job vs sync-wave -5 | First attempt (a4800814) used `sync-wave: -5` so the Job ran before the rest. That created a chicken-and-egg with the ServiceAccount + Secret + ConfigMap (also wave 0) — Job tried to spawn its pod before its own SA existed and FailedCreate. Dropping the wave lets the Job run alongside everything else; its existing `pg_isready` loop in the bootstrap init container handles the ordering against Postgres. |
 | Cleanup CronJob in cluster vs GH Actions step on PR-close | First attempt (3d44bff1) was a GH Actions step. Replaced with in-cluster CronJob (b31617e7) because: (1) single source of OAuth credentials (sops bundle, not duplicated into GH Actions secrets); (2) catches orphans from non-PR-event paths (snapshot rollback, `kubectl delete namespace`, operator restart); (3) survives GH Actions outages. Trade-off: up to 1 h delay vs immediate cleanup — acceptable since only the next deploy of the same PR number is gated on cleanup. |
 | `ttlSecondsAfterFinished` dropped on setup Job in argocdMode | Without dropping it: K8s GC's the completed Job after 24 h, ArgoCD selfHeal sees it missing in cluster + present in git, re-creates → migrations re-run every 24 h. Migrations are idempotent so it's harmless but noisy. Dropping TTL leaves the Completed Job in place; ArgoCD's Force=true,Replace=true delete-then-creates it on the next genuine sync triggered by a commit. |
@@ -597,6 +611,7 @@ selfHeal handles cluster-side drift continuously — `kubectl delete` anything A
 | Epic | [#1852](https://github.com/denisvmedia/inventario/issues/1852) — preview-env infrastructure |
 | Issues that landed | [#1853](https://github.com/denisvmedia/inventario/issues/1853), [#1854](https://github.com/denisvmedia/inventario/issues/1854), [#1855](https://github.com/denisvmedia/inventario/issues/1855), [#1856](https://github.com/denisvmedia/inventario/issues/1856), [#1858](https://github.com/denisvmedia/inventario/issues/1858), [#1890](https://github.com/denisvmedia/inventario/issues/1890) |
 | Spikes / decision threads | [#1867](https://github.com/denisvmedia/inventario/issues/1867) — vcluster + ArgoCD pivot discussion |
-| Open follow-ups | [#1882](https://github.com/denisvmedia/inventario/issues/1882) (chart TLS secretName), [#1883](https://github.com/denisvmedia/inventario/issues/1883) (admin password from sops), [#1884](https://github.com/denisvmedia/inventario/issues/1884) (in-place ArgoCD migrations), [#1885](https://github.com/denisvmedia/inventario/issues/1885) (master auto-rollout), [#1892](https://github.com/denisvmedia/inventario/issues/1892) (expose ArgoCD UI + vcluster API as tailnet services) |
+| Open follow-ups | [#1882](https://github.com/denisvmedia/inventario/issues/1882) (chart TLS secretName), [#1883](https://github.com/denisvmedia/inventario/issues/1883) (admin password from sops), [#1884](https://github.com/denisvmedia/inventario/issues/1884) (in-place ArgoCD migrations), [#1892](https://github.com/denisvmedia/inventario/issues/1892) (expose ArgoCD UI + vcluster API as tailnet services) |
+| Shipped follow-ups | [#1885](https://github.com/denisvmedia/inventario/issues/1885) (master auto-rollout via the git-generator `inventario-master-preview` ApplicationSet) |
 | User-facing README | [#1863](https://github.com/denisvmedia/inventario/issues/1863) (in flight) |
 | PR that landed everything described here | [#1881](https://github.com/denisvmedia/inventario/pull/1881) |

--- a/devdocs/security/admin-threat-model.md
+++ b/devdocs/security/admin-threat-model.md
@@ -84,7 +84,7 @@ or `imp: true` / `impersonator_id`, or replays a captured one.
 - All tokens are HS256-signed with the server secret and verified on
   every request; the algorithm is pinned (no `alg:none` downgrade).
 - Access tokens are short-lived; impersonation tokens are shorter still
-  (≤30 min, `INVENTARIO_IMPERSONATION_TTL`).
+  (≤30 min, `INVENTARIO_RUN_IMPERSONATION_TTL`).
 - The `is_system_admin` claim is **not** the authorization gate (#1784):
   `RequireSystemAdmin` queries `system_admin_grants` on every admin
   request, so a forged claim that escaped signature verification
@@ -212,8 +212,12 @@ admin request from a malicious page.
   impersonation end (back to the operator).
 - `POST /admin/impersonation/end` is the one mutation mounted outside
   CSRF middleware; it is self-authorising — it requires a validly
-  signed impersonation token *and* the matching browser-bound marker
-  cookie, which together provide equivalent assurance.
+  signed impersonation token (`imp=true`) whose `impersonator_id` matches
+  the JTI-keyed server-side return slot (`OperatorUserID`, with
+  `OperatorKind == backoffice_user`). The browser-bound `imp:<jti>`
+  marker cookie that previously co-authenticated this endpoint was retired
+  in #1785 Phase 5; the signed token + return-slot binding now provides the
+  assurance on its own.
 
 **Residual risk.** Minimal; same posture as the rest of the app.
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,22 @@
+# Inventario user guide
+
+End-user documentation for Inventario. If you're setting up or operating a
+server, see the developer and operator docs under [`devdocs/`](../../devdocs)
+instead.
+
+## Guides
+
+- [Getting started](getting-started.md) — add your first item, organise with
+  locations/areas/tags, attach files, scan items with AI, export and back up
+  your data, and invite people to your group.
+
+## In-app help
+
+The app has help built in, too:
+
+- **Product tour** — a short walkthrough on first run. Restart it any time from
+  the user menu (**Restart product tour**).
+- **Keyboard shortcuts** — **Settings → Help & support → Keyboard shortcuts**,
+  or press `?` anywhere.
+- **Contact support / share feedback** — **Settings → Help & support** opens a
+  form to ask a question, report a bug, or suggest a feature.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,0 +1,199 @@
+# Getting started with Inventario
+
+Welcome! Inventario helps you keep track of everything you own — what it is,
+where it lives, what it cost, and which warranties are still active. This guide
+walks you through the things you'll do most often. You don't need to read it
+top to bottom: jump to whatever you need.
+
+The app also has a short product tour built in. If you ever want to see it
+again, open the user menu and choose **Restart product tour**.
+
+## Contents
+
+- [Add your first item](#add-your-first-item)
+- [Organise with locations, areas, and tags](#organise-with-locations-areas-and-tags)
+- [Attach files (receipts, manuals, photos)](#attach-files-receipts-manuals-photos)
+- [Scan an item with AI](#scan-an-item-with-ai)
+- [Export and back up your data](#export-and-back-up-your-data)
+- [Invite people to your group](#invite-people-to-your-group)
+
+---
+
+## Add your first item
+
+An **item** is anything you want to keep track of — an appliance, a laptop, a
+piece of furniture, a tool.
+
+1. Click **Add item** (the button is on the Dashboard and on the All Items
+   page).
+2. The **Add item** dialog opens. You can start two ways:
+   - **Fill with AI** — drop in a photo or a receipt/invoice PDF and let AI
+     pre-fill the form for you (see [Scan an item with AI](#scan-an-item-with-ai)).
+   - **Fill manually** — type the details yourself.
+3. Work through the steps:
+   - **Basics** — name, quantity, price, and other core details.
+   - **Extras** — optional fields, including tags.
+   - **Files** — optionally attach photos, receipts, or manuals (you can also
+     add these later).
+4. Click the create button to save. Your new item opens so you can review it.
+
+Items don't have to be placed in a location to be saved. If you skip that, the
+item appears with a small banner offering to **Place in location** — you can do
+that whenever you like, or leave it unassigned.
+
+If you're trying Inventario from the public landing page before creating an
+account, you can draft your first item right there. After you sign up, the app
+finishes adding it for you — your draft is never lost.
+
+---
+
+## Organise with locations, areas, and tags
+
+Inventario gives you three ways to organise, and you can mix and match.
+
+### Locations
+
+A **location** is a physical place where you keep things — a house, a flat, a
+garage, a storage unit, a vehicle.
+
+1. Go to **Locations** in the sidebar.
+2. Click **Add location**.
+3. Give it a name. The address and description fields are optional — the
+   address can be a street address, a room, or any free-text note.
+
+### Areas
+
+An **area** is a subdivision inside a location — Kitchen, Garage, Office, a
+specific shelf. Areas are where items actually live.
+
+1. Open a location, or use **Add area** from the Locations page.
+2. Choose the parent location, pick an icon, and name the area (for example
+   "Kitchen").
+3. Items you assign to an area show up on that area's page, along with a few
+   quick stats.
+
+### Tags
+
+**Tags** are flexible labels you can apply across items — think "fragile",
+"electronics", or "to sell". They're independent of where an item is stored.
+
+- Add tags to an item on the **Extras** step of the Add item dialog.
+- Browse and manage them on the **Tags** page. Tags are split into two types:
+  **Item tags** and **File tags** — use the switcher at the top to choose which
+  set you're looking at.
+
+A tag starts showing up in these lists once it's actually used somewhere, so a
+brand-new account will have an empty Tags page until you apply your first tag.
+
+---
+
+## Attach files (receipts, manuals, photos)
+
+You can attach files — photos, receipts, manuals, warranty certificates,
+anything — to your items.
+
+- **While adding an item:** use the **Files** step in the Add item dialog. Drop
+  files onto the dropzone or click to browse.
+- **From an existing item:** open the item, go to its **Files** tab, and upload
+  there.
+- **From the Files page:** the **Files** section in the sidebar lists every file
+  in your group; you can switch between a grid and a list view.
+
+Inventario sorts each file automatically based on its type — into **Photos**,
+**Documents**, or **Other** — and you can change a file's category later from
+its detail page. Files are always optional: if you skip them while creating an
+item, you can add them at any time.
+
+---
+
+## Scan an item with AI
+
+If AI vision is enabled on your server, you can let it read a photo or document
+and pre-fill the item form for you.
+
+1. In the **Add item** dialog, choose **Fill with AI**.
+2. Drop in your files, or click to browse. Supported formats: **JPG, PNG, WEBP,
+   HEIC/HEIF, or PDF** — up to **5 files** at a time. A clear photo of the item
+   plus its label (or a receipt/invoice PDF) works best.
+3. AI reads the files and shows you the details it extracted, with a confidence
+   indicator for each.
+4. On the **Review extracted details** step, untick anything that looks wrong,
+   then choose **Use these values** to pre-fill the form.
+5. Finish and save the item as usual. The files you scanned are attached to the
+   item automatically — you can manage them on the Files step.
+
+A few things to know:
+
+- If AI finds more than one product in the files, it pre-fills the most
+  prominent one and lets you add the others separately afterwards.
+- If AI vision isn't enabled on your server, you'll see a message saying so —
+  just use **Fill manually** to continue.
+- Scanning is rate-limited to keep usage fair, so you may occasionally be asked
+  to wait a moment before trying again.
+
+---
+
+## Export and back up your data
+
+Inventario can export your data so you have your own copy, or so you can move it
+to another instance. Find this under **Backup** in the sidebar.
+
+### Create an export
+
+1. Go to **Backup** and start a **New export**.
+2. Choose what to include:
+   - **Full database** — everything: locations, areas, items, files, and tags.
+   - **Selected items** — pick specific locations, areas, or items.
+3. Optionally add a description. If you leave it blank, Inventario names the
+   export for you (for example, "Backup · Full database · 2026-05-13 10:42 UTC").
+4. The export runs in the background. When it finishes, **Download** it from the
+   list.
+
+Backups download as `.inb` files — Inventario's signed backup format.
+
+### Import or restore a backup
+
+- **Import backup** lets you upload an existing `.inb` file. It's staged on the
+  server first and only inspected when you start the restore.
+- **Restore** brings the contents of an export into your current group. You pick
+  a strategy and can run a **dry run** first to preview exactly what would
+  change before anything is modified. You can also choose whether to restore the
+  attached file data alongside the metadata.
+
+Running a dry run before a real restore is a good habit — it shows you what
+would happen without touching your live data.
+
+---
+
+## Invite people to your group
+
+Inventario organises everything into **groups**. You can invite other people
+into a group and give each of them a role.
+
+1. Open **Members** in the sidebar.
+2. Click **Invite**.
+3. Enter the person's email address and choose a **role** (see below).
+4. Send the invite. They'll get an invite link to join. If you'd rather, you can
+   create a copy-paste invite link instead of sending an email.
+
+Pending invites show a **Pending** badge; you can **Resend** or **Revoke** them
+from the Members page.
+
+### Roles
+
+| Role | What they can do |
+| --- | --- |
+| **Owner** | Full access, including deleting the group and all its data. |
+| **Administrator** | Manage members, group info, locations, and areas. |
+| **User** | Add and remove items (but not locations or areas). |
+| **Viewer** | View everything, but can't make any changes. |
+
+---
+
+## Need more help?
+
+- **Keyboard shortcuts:** open **Settings → Help & support → Keyboard
+  shortcuts**, or press `?` anywhere in the app.
+- **Contact support / share feedback:** **Settings → Help & support → Contact
+  support / share feedback** opens a form to ask a question, report a bug, or
+  suggest a feature.

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -69,6 +69,18 @@ import { APP_VERSION, shortAppVersion } from "@/lib/app-version"
 
 type SectionId = "account" | "appearance" | "notifications" | "privacy" | "help"
 
+// End-user "Getting started" guide. Opened in a new tab from the Help
+// section's Documentation row, which no longer points at the coming-soon
+// /help stub (#2104) — the /help route itself still exists. Hosted
+// alongside the source so it tracks the running version.
+const DOCS_URL =
+  "https://github.com/denisvmedia/inventario/blob/master/docs/user-guide/getting-started.md"
+
+// GitHub Releases page. Opened in a new tab from the Help section's
+// "What's new" row, which no longer points at the coming-soon /whats-new
+// stub — the /whats-new route itself still exists.
+const RELEASES_URL = "https://github.com/denisvmedia/inventario/releases"
+
 interface SectionMeta {
   id: SectionId
   // Lucide icon for the nav rail.
@@ -911,23 +923,26 @@ function HelpSection() {
   const shortcutsDialog = useKeyboardShortcutsDialog()
   const [feedbackOpen, setFeedbackOpen] = useState(false)
 
-  // Four rows: docs (#1384), shortcuts (#1385 — opens the cheat-sheet
-  // modal in-place), what's new (#1386 — with a marketing v{Major.Minor}
-  // badge per design-audit #1536), and "Contact support / share
-  // feedback" (#1387 — opens the FeedbackDialog in-place). The dialog's
-  // "Question" type doubles as the contact-support channel, so the
-  // former static mailto row was folded into this single entry point.
-  // Real destinations behind each route are ComingSoonPage already;
-  // this section mostly acts as a discovery aid.
+  // Four rows: docs (#2104 — opens the end-user "Getting started" guide in
+  // a new tab; the row no longer points at the coming-soon /help stub, though
+  // the /help route still exists), shortcuts (#1385 — opens the cheat-sheet
+  // modal in-place), what's new (#1386 — opens the GitHub Releases page in a
+  // new tab instead of the coming-soon /whats-new stub, which still exists;
+  // carries a marketing v{Major.Minor} badge per design-audit #1536), and
+  // "Contact support / share feedback" (#1387 — opens the FeedbackDialog
+  // in-place). The dialog's "Question" type doubles as the contact-support
+  // channel, so the former static mailto row was folded into this single
+  // entry point.
   type HelpRowKey = "documentation" | "shortcuts" | "whatsNew" | "feedback"
   // `href: "modal:shortcuts"` → renders a click-to-open <button> wired
   //   to the keyboard-shortcuts dialog. `href: "modal:feedback"` →
-  //   opens the FeedbackDialog. Using a sentinel string keeps the row
-  //   map flat and the renderer easy to follow.
+  //   opens the FeedbackDialog. An `http(s)` href → external <a> opening
+  //   in a new tab. Anything else → in-app <Link>. Using a sentinel
+  //   string keeps the row map flat and the renderer easy to follow.
   const rows: Array<{ key: HelpRowKey; href: string }> = [
-    { key: "documentation", href: "/help" },
+    { key: "documentation", href: DOCS_URL },
     { key: "shortcuts", href: "modal:shortcuts" },
-    { key: "whatsNew", href: "/whats-new" },
+    { key: "whatsNew", href: RELEASES_URL },
     { key: "feedback", href: "modal:feedback" },
   ]
 
@@ -938,12 +953,13 @@ function HelpSection() {
       <SectionTitle>{t("settings:help.title")}</SectionTitle>
       <div className="rounded-xl border border-border divide-y divide-border">
         {rows.map(({ key, href }) => {
-          // Two-arm union: modal trigger (in-app dialog) or in-app
-          // route. Both use the same chrome — chevron-right + label +
-          // description. The version Badge only renders on the
-          // "whatsNew" row.
+          // Three-arm union: modal trigger (in-app dialog), external link
+          // (opens in a new tab), or in-app route. All use the same chrome
+          // — chevron-right + label + description. The version Badge only
+          // renders on the "whatsNew" row.
           const labelKey = key
           const isModal = href.startsWith("modal:")
+          const isExternal = href.startsWith("http")
           const RowInner = (
             <>
               <div className="flex items-center gap-2">
@@ -975,6 +991,21 @@ function HelpSection() {
                 <div>{RowInner}</div>
                 <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
               </button>
+            )
+          }
+          if (isExternal) {
+            return (
+              <a
+                key={key}
+                href={href}
+                target="_blank"
+                rel="noreferrer noopener"
+                data-testid={`help-row-${key}`}
+                className="flex items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
+              >
+                <div>{RowInner}</div>
+                <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
+              </a>
             )
           }
           return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -959,7 +959,7 @@ function HelpSection() {
           // renders on the "whatsNew" row.
           const labelKey = key
           const isModal = href.startsWith("modal:")
-          const isExternal = href.startsWith("http")
+          const isExternal = /^https?:\/\//.test(href)
           const RowInner = (
             <>
               <div className="flex items-center gap-2">

--- a/go/backup/export/README.md
+++ b/go/backup/export/README.md
@@ -1,75 +1,88 @@
 # Export Package
 
-The `export` package is a core Go package that handles XML export operations in the Inventario application. It provides comprehensive functionality to export inventory data to XML format with support for various export types, file attachments, and background processing.
+The `export` package is a core Go package that handles backup export generation in the Inventario application. By default it produces a **signed, streaming `.inb` archive** (issue #534): a tar containing a signed payload plus the gzip-compressed payload itself. The obsolete XML format is retained only behind the `legacy_xml_backup` build tag.
 
 ## Overview
 
-The export package is responsible for generating XML exports of inventory data, including locations, areas, commodities, and their associated files (images, invoices, manuals). It supports multiple export types and implements streaming approaches to handle large datasets efficiently without memory exhaustion.
+The export package generates backup archives of inventory data, including locations, areas, commodities, and their associated commodity files (images, invoices, manuals). The default build streams the archive directly to blob storage without ever holding the whole payload (or any single file) in memory.
+
+## Backup Format
+
+### Default: signed `.inb` (streaming JSON)
+
+Files in this package split by build tag:
+
+- `jsonexport.go`, `inb_types.go`, `inb_builder.go` (under `//go:build !legacy_xml_backup`) — the default `.inb` exporter.
+- `service_legacy_xml.go`, `worker_legacy_xml.go` (under `//go:build legacy_xml_backup`) — the deprecated XML exporter.
+- `service_shared.go`, `worker.go`, `userinput.go`, `errors.go` — build-agnostic glue (service struct, worker, file-entity creation).
+
+An `.inb` artifact is an **outer tar** (`internal/inb`) holding:
+
+1. `payload.tar.gz.sig` — an Ed25519 signature (`internal/backupsign`) over the streaming SHA-256 digest of the payload.
+2. `payload.tar.gz` — a gzip(tar) payload whose members are:
+   - `manifest.json` — written first; format, signing-key info, per-location index, and aggregate statistics (see `inb_types.go`).
+   - one `location-<slug>-<uuid>.json` member per location (location → areas → commodities, each commodity bundling its image/invoice/manual file references).
+   - `unassigned-commodities.json` — area-less commodities, written only when at least one is in scope (issue #1986).
+   - `files/<loc>/<commodity>/<bucket>/<name>` — the raw bytes of each referenced commodity file, streamed directly from blob storage.
+
+The exporter stamps the resulting `FileEntity` with `Ext=".inb"`, `MIMEType="application/x-inventario-backup"`, and `LinkedEntityMeta="inb-2.0"` (`exportFileMeta` in `jsonexport.go`).
+
+### Legacy: XML (build-tag-gated)
+
+The pre-#534 XML format (root `<inventory>` with base64-embedded file data) is **deprecated** and compiled only with `go build -tags legacy_xml_backup`. Do not write new code against it.
 
 ## Key Features
 
 ### 1. Multiple Export Types
 - **Full Database**: Complete export of all inventory data
 - **Selected Items**: Export specific locations, areas, or commodities
-- **Locations**: Export only location data
-- **Areas**: Export only area data
-- **Commodities**: Export only commodity data
-- **Imported**: Special type for externally imported exports
+- **Locations / Areas / Commodities**: Scoped exports
+- **Imported**: Placeholder type for externally imported backups (skipped by the worker)
 
 ### 2. File Data Handling
-- Optional inclusion of binary file data (images, invoices, manuals)
-- Base64 encoding of file content for XML embedding
-- Streaming approach to prevent memory issues with large files
-- Support for multiple file types with proper MIME type handling
+- Commodity files (images, invoices, manuals) are streamed straight from blob storage into the archive — never base64-buffered in memory.
+- Each file member carries its original basename and metadata so a restore reproduces the original filename.
 
 ### 3. Background Processing
 - Worker-based architecture for asynchronous export generation
 - Prevents API timeouts on large exports
 - Semaphore-based concurrency control
-- Automatic cleanup of deleted exports
+- Soft-pause aware (#1308)
 
 ### 4. Statistics Tracking
-- Comprehensive statistics collection during export generation
-- Counts for locations, areas, commodities, and files
-- Binary data size tracking
-- Performance metrics and error reporting
+- Counts for locations, areas, commodities, images, invoices, manuals, and total files
+- Binary data size tracking, surfaced both on the `Export` record and in `manifest.json`
 
-### 5. Streaming XML Generation
-- Memory-efficient streaming approach for large datasets
-- Direct file-to-XML streaming without loading into memory
-- Chunked processing to handle massive inventories
-- Real-time statistics collection during streaming
+### 5. Memory-Safe Streaming
+- The inner `payload.tar.gz` is spooled to a **local temp file** while a streaming SHA-256 digest is computed via `io.MultiWriter`.
+- The signature is taken over that digest (never over a buffered payload), then the finished container is streamed from the temp file into blob storage.
 
 ## Architecture
 
 ### Core Components
 
-#### ExportService (`service.go`)
+#### ExportService (`service_shared.go`, `jsonexport.go`)
 The main service responsible for export generation:
-- **ProcessExport()**: Main method that orchestrates export generation
-- **generateExport()**: Creates XML files using blob storage
-- **streamXMLExport()**: Streams XML generation with statistics tracking
-- **ParseXMLMetadata()**: Parses existing XML files to extract metadata
-- Supports multiple export types with specialized streaming methods
+- **ProcessExport()** (`service_shared.go`): orchestrates an export — loads the record, injects user/group context, calls the per-build `generateExport`, creates the backing `FileEntity`, and records statistics. Format-agnostic.
+- **generateExport()** (`jsonexport.go`): produces the signed `.inb` archive and returns its blob key plus statistics.
+- **writePayload() / writeContainerToBlob()** (`jsonexport.go`): build and sign the streaming payload, then stream the container to blob storage.
 
 #### ExportWorker (`worker.go`)
 Background worker that manages export processing:
-- **Start()**: Begins processing exports in the background
-- **Stop()**: Gracefully stops the export worker
-- **processPendingExports()**: Finds and processes pending export requests
-- **cleanupDeletedExports()**: Removes files for soft-deleted exports
-- Configurable poll intervals (default: 10 seconds for exports, 1 hour for cleanup)
+- **Start() / Stop() / IsRunning()**: lifecycle control
+- **processPendingExports()**: finds and processes pending export requests; skips imported exports and respects soft-pause
+- Configurable poll interval (default: 10 seconds)
 - Semaphore-based concurrency limiting
 
-#### Export Types (`types.go`)
-Defines XML structure and data types:
-- **XMLInventory**: Root element containing all export data
-- **XMLLocation**, **XMLArea**, **XMLCommodity**: Entity representations
-- **File**: File attachment structure with base64 data
-- **ExportStats**: Statistics tracking during generation
-- **ExportArgs**: Configuration options for export operations
+#### `.inb` Schemas (`inb_types.go`)
+Defines the JSON documents written into the inner tar (kept in sync with `backup/restore/types/types_inb.go`):
+- **INBManifest**, **INBManifestLoc**, **INBManifestStats**, **INBSignatureInfo**
+- **INBLocationDoc**, **INBLocation**, **INBArea**, **INBCommodity**, **INBFileRef**
+- **INBUnassignedDoc** (area-less commodities, #1986)
+- Format constants: `INBFormatVersion = "2.0"`, `INBManifestName`, `INBUnassignedName`, `INBFilesPrefix`
 
-### Export Types and Models
+#### Export Types (`models/export.go`)
+- `ExportTypeFullDatabase`, `ExportTypeSelectedItems`, `ExportTypeLocations`, `ExportTypeAreas`, `ExportTypeCommodities`, `ExportTypeImported`
 
 #### Export Status Flow
 ```
@@ -77,45 +90,39 @@ Pending → In Progress → Completed
                     ↘ Failed
 ```
 
-#### Export Types (`models/export.go`)
-- `ExportTypeFullDatabase`: Complete inventory export
-- `ExportTypeSelectedItems`: User-selected items export
-- `ExportTypeLocations`: Location-only export
-- `ExportTypeAreas`: Area-only export
-- `ExportTypeCommodities`: Commodity-only export
-- `ExportTypeImported`: External import placeholder
-
 ## Data Flow
 
 ### Standard Export Process
-1. **Request Creation**: User creates export request via API
+1. **Request Creation**: User creates an export request via API
 2. **Record Storage**: Export record created with "pending" status
-3. **Worker Detection**: ExportWorker polls and detects pending export
-4. **Processing**: ExportService generates XML file with streaming approach
-5. **Statistics Collection**: Real-time tracking of exported entities and file sizes
-6. **Completion**: Export record updated with file path, statistics, and "completed" status
-7. **Download**: Users can download generated XML files
-
-### Import Process (External Files)
-1. **File Upload**: User uploads external XML file
-2. **Import Record**: System creates export record with type "imported"
-3. **Metadata Extraction**: ParseXMLMetadata extracts statistics without data restoration
-4. **Catalog Integration**: Import appears in export catalog for management
+3. **Worker Detection**: `ExportWorker` polls and detects the pending export
+4. **Processing**: `ExportService` generates a signed `.inb` archive and streams it to blob storage
+5. **Statistics Collection**: real-time tracking of exported entities and file sizes
+6. **File Entity**: a `FileEntity` is created for the artifact and linked to the export
+7. **Completion**: export record updated with file id, statistics, size, and "completed" status
 
 ## Usage
 
 ### Creating an Export Service
 ```go
-import "github.com/denisvmedia/inventario/backup/export"
+import (
+    "github.com/denisvmedia/inventario/backup/export"
+    "github.com/denisvmedia/inventario/internal/backupsign"
+)
 
-// Create export service
-service := export.NewExportService(registrySet, uploadLocation)
+// signer is *backupsign.Signer (consumed by the .inb exporter; ignored by the
+// legacy XML exporter, so the signature is the same across both builds).
+service := export.NewExportService(factorySet, uploadLocation, signer)
 ```
 
 ### Starting the Export Worker
 ```go
-// Create worker with max 3 concurrent exports
-worker := export.NewExportWorker(exportService, registrySet, 3)
+// Create worker with max 3 concurrent exports.
+worker := export.NewExportWorker(exportService, factorySet, 3)
+
+// Optional configuration via functional options:
+//   export.WithPollInterval(5 * time.Second)
+//   export.WithPauseController(pauseController) // #1308 soft-pause
 
 // Start background processing
 ctx := context.Background()
@@ -134,119 +141,55 @@ if err != nil {
 }
 ```
 
-### Custom Export Arguments
+### Export Arguments
 ```go
 args := export.ExportArgs{
-    IncludeFileData: true, // Include binary file data
+    IncludeFileData: true, // Include commodity file bytes in the archive
 }
-```
-
-## XML Structure
-
-### Root Element
-```xml
-<inventory xmlns="http://inventario.example.com/schema"
-           exportDate="2024-01-15T10:30:00Z"
-           exportType="full_database">
-```
-
-### Entity Sections
-- `<locations>`: Location data with nested areas
-- `<areas>`: Standalone area data
-- `<commodities>`: Commodity data with file attachments
-
-### File Attachments
-```xml
-<file id="123" path="image_001" originalPath="uploads/image_001.jpg"
-      extension=".jpg" mimeType="image/jpeg">
-  <data>base64encodedcontent...</data>
-</file>
 ```
 
 ## Performance Considerations
 
 ### Memory Efficiency
-- **Streaming Approach**: XML generation streams directly to storage
-- **Chunked Processing**: Large datasets processed in manageable chunks
-- **File Streaming**: Binary files streamed without loading into memory
-- **Statistics Tracking**: Real-time collection without memory accumulation
+- **Temp-file spooling**: the payload is digested and signed via a local temp file, never buffered on the heap.
+- **File streaming**: commodity file bytes are copied straight from blob storage into the tar.
+- **Manifest-first layout**: statistics are fully known before any payload bytes are written, so the import metadata path reads them without inflating file bodies.
 
 ### Concurrency Control
-- **Semaphore Limiting**: Prevents resource exhaustion during concurrent exports
-- **Background Processing**: Asynchronous generation prevents API timeouts
-- **Worker Isolation**: Export and cleanup operations run independently
-
-### Storage Optimization
-- **Blob Storage**: Efficient file storage with cloud provider support
-- **Cleanup Automation**: Automatic removal of deleted export files
-- **Compression**: XML files benefit from HTTP compression during download
+- **Semaphore Limiting**: bounds concurrent exports
+- **Background Processing**: asynchronous generation prevents API timeouts
 
 ## Error Handling
-
-### Comprehensive Error Management
-- **Graceful Degradation**: Individual file failures don't stop entire export
-- **Status Tracking**: Failed exports marked with detailed error messages
-- **Retry Logic**: Worker automatically retries failed operations
-- **Logging**: Detailed logging for debugging and monitoring
-
-### Error Recovery
-- **Partial Success**: Statistics reflect successfully processed items
-- **File Fallbacks**: Missing files logged but don't fail entire export
-- **Status Updates**: Real-time status updates during processing
+- **Status Tracking**: failed exports are marked with a detailed error message
+- **Atomic completion**: the export record is only marked completed after the artifact and its `FileEntity` are written
 
 ## Testing
 
 ### Test Coverage
-- **Unit Tests**: `service_test.go`, `worker_test.go`, `types_test.go`
-- **Integration Tests**: End-to-end export generation and parsing
-- **Performance Tests**: Large dataset handling and memory usage
-- **Concurrency Tests**: Multi-worker scenarios and race conditions
-
-### Test Framework
+- **Unit Tests**: `service_test.go`, `streaming_test.go`, `worker_test.go`, `worker_pause_test.go`
 - Uses frankban's quicktest framework
-- Table-driven tests for multiple scenarios
-- Mock registries for isolated testing
+- Memory registries for isolated testing
 - Temporary file handling for integration tests
 
 ## Configuration
 
-### Environment Variables
-- **Upload Location**: Configurable blob storage location
-- **Worker Concurrency**: Maximum concurrent export operations
-- **Poll Intervals**: Export processing and cleanup frequencies
-- **File Size Limits**: Maximum export file sizes
+### Inputs
+- **Upload Location**: blob storage location for the generated artifact
+- **Signer**: `*backupsign.Signer` used to sign the `.inb` archive
+- **Worker Concurrency**: maximum concurrent export operations
+- **Poll Interval**: export queue polling frequency (`WithPollInterval`)
 
 ### Database Integration
-- **Export Registry**: Stores export metadata and status
-- **Entity Registries**: Access to locations, areas, commodities
-- **File Registries**: Access to images, invoices, manuals
-- **Settings Registry**: Global configuration access
+- **Export Registry**: export metadata and status
+- **Entity / File Registries**: access to locations, areas, commodities, and their files
+- **User / Group Registries**: resolved into context for worker-driven exports
 
 ## Integration Points
 
 ### API Server Integration
-- **REST Endpoints**: `/api/v1/exports` for CRUD operations
-- **Download Endpoints**: Streaming file downloads
-- **Import Endpoints**: External file upload and processing
-- **Status Endpoints**: Real-time export status checking
-
-### Frontend Integration
-- **Export Service**: TypeScript service for API communication
-- **Progress Tracking**: Real-time status updates
-- **Download Management**: File download handling
-- **Import Interface**: External file upload interface
+- **REST Endpoints**: `/api/v1/exports` for CRUD operations and downloads
+- **Public Key**: `/api/v1/backup/public-key` exposes the server's backup verification key
 
 ### Storage Integration
-- **Blob Storage**: Cloud-agnostic file storage
-- **Database Storage**: Metadata and status persistence
-- **File Management**: Automatic cleanup and organization
-
-## Future Enhancements
-
-Potential areas for future development:
-- **Progress Reporting**: Real-time progress updates during generation
-- **Compression Options**: Optional ZIP compression for large exports
-- **Format Support**: Revise the format to use tar.gz, which will contain XML file with DB records and files that the XML refers to
-- **Scheduling**: Automated export generation on schedules
-- **Validation**: XML schema validation for generated exports
-- **Encryption**: Optional encryption for sensitive data exports
+- **Blob Storage**: cloud-agnostic file storage, tenant-namespaced (#1793)
+- **Database Storage**: metadata and status persistence

--- a/go/backup/import/README.md
+++ b/go/backup/import/README.md
@@ -1,83 +1,89 @@
 # Import Package (`importpkg`)
 
-The `importpkg` is a Go package that handles XML import operations in the Inventario application. It provides functionality to process previously exported XML files and create new export records from them in the system.
+The `importpkg` package handles backup import operations in the Inventario application. It processes a previously-exported backup file and creates a new export record from it (for management and later restoration). By default it expects a **signed `.inb` archive** (issue #534); the obsolete XML format is supported only behind the `legacy_xml_backup` build tag.
 
 ## Overview
 
-The import package serves as a bridge between external XML export files and the system's export management functionality. It allows users to upload XML files that were previously downloaded from the system (or potentially from other compatible systems) and import them back as new export records for management and potential restoration.
+The import package is the bridge between an uploaded backup file and the system's export management. A user uploads a backup that was previously downloaded from the system (or a compatible one), and it is imported back as a new export record. Import only extracts **metadata** (statistics) from the archive — it does not restore data into the database (that is the `restore` package's job).
+
+## Backup Format
+
+Files in this package split by build tag:
+
+- `jsonimport.go` (under `//go:build !legacy_xml_backup`) — the default `.inb` import path: verifies the archive signature against the server's own key, then reads `manifest.json` for statistics.
+- `service_legacy_xml.go` (under `//go:build legacy_xml_backup`) — the deprecated XML import path (streams XML metadata via `backup/export/parser`).
+- `service_shared.go`, `worker.go`, `helpers_test.go` — build-agnostic glue (service struct, worker, file-entity creation).
+
+The default `.inb` import verifies the Ed25519 signature **before** inflating, spools the payload to a temp file while digesting (so verification never buffers the whole payload), and only reads the `manifest.json` member — file bytes are never inflated during import. A bad/missing signature or a non-`.inb` upload (e.g. legacy XML) fails hard; there is no bypass.
 
 ## Key Features
 
 ### 1. External File Integration
-- Processes XML export files that were previously downloaded from the system
-- Creates new export records from uploaded XML files
-- Supports importing external exports into the export catalog
+- Processes backup files previously downloaded from the system
+- Creates a new export record (type "imported") from the uploaded file
 
 ### 2. Background Processing
-- Implements a worker-based architecture for asynchronous processing
-- Prevents API server blocking and timeouts on large files
-- Uses polling mechanism to detect and process pending imports
+- Worker-based architecture for asynchronous processing
+- Polling mechanism to detect and process pending imports
+- Soft-pause aware (#1308)
 
 ### 3. Metadata Extraction
-- Parses uploaded XML files to extract comprehensive statistics
-- Extracts counts for locations, areas, commodities, and file attachments
-- Calculates file sizes and binary data sizes
-- Does not restore actual data to the database (only metadata extraction)
+- Reads `manifest.json` statistics: counts for locations, areas, commodities, images, invoices, manuals, total files, and total file size
+- Does **not** restore data to the database (metadata only)
 
 ### 4. Concurrency Control
-- Uses semaphore-based concurrency control
-- Limits the number of simultaneous import operations
-- Prevents resource exhaustion during heavy import loads
+- Semaphore-based limiting of simultaneous import operations
 
 ## Architecture
 
 ### Core Components
 
-#### ImportService (`service.go`)
-The main service responsible for processing XML imports:
-- **ProcessImport()**: Main method that processes an XML file and updates export record with metadata
-- **markImportFailed()**: Handles error cases and marks imports as failed
-- Integrates with the export service for XML parsing capabilities
+#### ImportService (`service_shared.go`, `jsonimport.go`)
+The main service responsible for processing imports:
+- **ProcessImport(ctx, exportID, sourceFilePath)** (`service_shared.go`): processes an uploaded backup file and stamps the export record with extracted statistics. Format-agnostic; delegates to the per-build `parseImportMetadata`.
+- **parseImportMetadata()** (`jsonimport.go` / `service_legacy_xml.go`): the per-build parser — verifies + reads the `.inb` manifest by default, or parses XML under the legacy build.
+- **markImportFailed()**: marks an import as failed with an error message.
 
 #### ImportWorker (`worker.go`)
 Background worker that manages import processing:
-- **Start()**: Begins processing imports in the background
-- **Stop()**: Gracefully stops the import worker
-- **processPendingImports()**: Finds and processes pending import requests
-- **processImport()**: Processes individual import operations
-- Uses configurable poll intervals (default: 10 seconds)
-- Implements semaphore-based concurrency limiting
+- **Start() / Stop() / IsRunning()**: lifecycle control
+- **processPendingImports()**: finds and processes pending imported exports; respects soft-pause
+- **processImport()**: processes a single import (`exportID`, `sourceFilePath`)
+- Configurable poll interval (default: 10 seconds)
+- Semaphore-based concurrency limiting
 
-#### XML Types (`types.go`)
-Defines the structure for parsing XML inventory exports:
-- **XMLInventory**: Root element of XML exports
-- **XMLLocations**, **XMLAreas**, **XMLCommodities**: Section containers
-- **ImportStats**: Tracks statistics during import processing
-- **ImportProgress**: Represents current progress of import operations
+## Data Flow
 
-### Data Flow
-
-1. **Upload**: User uploads an XML file through the API
+1. **Upload**: User uploads a backup file through the API
 2. **Record Creation**: System creates an export record with type "imported" and status "pending"
-3. **Worker Detection**: ImportWorker polls and detects the pending import
-4. **Processing**: ImportService processes the XML file and extracts metadata
-5. **Update**: Export record is updated with extracted statistics and marked as completed
-6. **Management**: Import is now available in the export catalog for management
+3. **Worker Detection**: `ImportWorker` polls and detects the pending import
+4. **Processing**: `ImportService` verifies the archive, reads its manifest, and extracts statistics
+5. **Update**: export record updated with statistics and marked completed
+6. **Management**: the import appears in the export catalog and can drive a restore
 
 ## Usage
 
 ### Creating an Import Service
 ```go
-import "github.com/denisvmedia/inventario/backup/import"
+import (
+    importpkg "github.com/denisvmedia/inventario/backup/import"
+    "github.com/denisvmedia/inventario/internal/backupsign"
+)
 
-// Create import service
-service := importpkg.NewImportService(registrySet, uploadLocation)
+// signer is *backupsign.Signer (used by the .inb path to verify the archive
+// signature; ignored by the legacy XML path, so the signature is identical
+// across both builds).
+service := importpkg.NewImportService(factorySet, uploadLocation, signer)
 ```
 
 ### Starting the Import Worker
 ```go
-// Create worker with max 3 concurrent imports
-worker := importpkg.NewImportWorker(importService, registrySet, 3)
+// Create worker with max 3 concurrent imports.
+worker := importpkg.NewImportWorker(importService, factorySet, 3)
+
+// Optional configuration via functional options:
+//   importpkg.WithPollInterval(5 * time.Second)
+//   importpkg.WithPauseController(pauseController) // #1308 soft-pause
 
 // Start background processing
 ctx := context.Background()
@@ -87,63 +93,46 @@ worker.Start(ctx)
 defer worker.Stop()
 ```
 
-### Custom Poll Interval
+### Processing an Import
 ```go
-// Create worker with custom 5-second poll interval
-worker := importpkg.NewImportWorkerWithPollInterval(
-    importService,
-    registrySet,
-    3,
-    5*time.Second,
-)
+// Process an import by export id and the uploaded file's blob key.
+err := service.ProcessImport(ctx, exportID, sourceFilePath)
+if err != nil {
+    log.Printf("Import failed: %v", err)
+}
 ```
 
 ## Integration with Export System
 
 The import package is tightly integrated with the export system:
 - Uses export records with type `models.ExportTypeImported`
-- Leverages export service's XML parsing capabilities
 - Stores import results in the same export record structure
 - Enables unified management of both exports and imports
 
 ## Error Handling
-
-The package implements comprehensive error handling:
 - Failed imports are marked with status `models.ExportStatusFailed`
 - Error messages are stored in the export record
-- Detailed logging for debugging and monitoring
-- Graceful handling of file access and parsing errors
+- A bad/missing signature or non-`.inb` upload fails the import
+- `ErrManifestTooLarge` caps the inflated `manifest.json` size (4 MiB) to prevent an out-of-memory DoS
 
 ## Testing
-
-The package includes comprehensive test coverage:
 - **Unit Tests**: `service_test.go`, `worker_test.go`
 - **Integration Tests**: `worker_integration_test.go`
 - Uses frankban's quicktest framework
-- Includes tests for concurrent operations and error scenarios
 
 ## Configuration
 
-### Environment Variables
-- Upload location is configurable via the service constructor
-- Worker concurrency limits are configurable
-- Poll intervals can be customized
+### Inputs
+- **Upload Location**: blob storage location for the uploaded backup file
+- **Signer**: `*backupsign.Signer` used to verify the `.inb` archive
+- **Worker Concurrency**: maximum concurrent import operations
+- **Poll Interval**: import queue polling frequency (`WithPollInterval`)
 
 ### Database Requirements
-- Requires export registry for storing import records
+- Requires the export registry for storing import records
 - Uses blob storage for file handling
-- Integrates with existing registry system
 
 ## Performance Considerations
-
-- **Memory Efficiency**: Uses streaming approaches to avoid loading entire XML files into memory
-- **Concurrency**: Semaphore-based limiting prevents resource exhaustion
-- **Background Processing**: Asynchronous processing prevents API timeouts
-- **Polling Optimization**: Configurable poll intervals balance responsiveness and resource usage
-
-## Future Enhancements
-
-Potential areas for future development:
-- Real-time progress reporting during import processing
-- Support for additional file formats beyond XML
-- Enhanced validation and conflict resolution
+- **Memory Efficiency**: the payload is verified via a temp-file digest; only `manifest.json` is inflated — file bytes are never decompressed during import
+- **Concurrency**: semaphore-based limiting prevents resource exhaustion
+- **Background Processing**: asynchronous processing prevents API timeouts

--- a/go/backup/restore/README.md
+++ b/go/backup/restore/README.md
@@ -1,182 +1,148 @@
 # Restore Package
 
-The `restore` package is a core Go package that handles XML restore operations in the Inventario application. It provides comprehensive functionality to restore inventory data from XML exports with support for multiple restore strategies, detailed logging, and background processing.
+The `restore` package handles backup restore operations in the Inventario application. It restores inventory data from a backup archive with support for multiple restore strategies, detailed step-by-step logging, and background processing. By default it restores from a **signed `.inb` archive** (issue #534); the obsolete XML format is supported only behind the `legacy_xml_backup` build tag.
 
 ## Overview
 
-The restore package is responsible for parsing XML export files and restoring inventory data back into the database. It supports multiple restore strategies to handle different scenarios, implements streaming approaches for large files, and provides detailed step-by-step logging of the restoration process.
+The restore package reads a backup archive and writes its inventory data back into the database. For the default `.inb` format it **verifies the Ed25519 signature against the server's own key before inflating**, then walks the inner tar applying each entity through strategy-aware model handlers. It supports multiple restore strategies, streams large file members without buffering, and logs the process step by step.
+
+## Backup Format
+
+The decode body splits by build tag; everything around it is format-agnostic.
+
+- `processor/processor.go` (under `//go:build !legacy_xml_backup`) — the default `.inb` restorer: `decodeAndRestore` verifies the signature, then `applyInbPayload` walks the inner tar.
+- `processor/processor_legacy_xml.go` (under `//go:build legacy_xml_backup`) — the deprecated XML restorer; this is where the build-tag-gated `RestoreFromXML` entry point lives (used only by the legacy XML test suite).
+- `processor/processor_shared.go` — build-agnostic processor glue: `Process`, option validation, strategy handlers, step logging.
+- `service.go` — the thin `RestoreService` that constructs a processor.
+- `worker.go`, `status_querier.go` — background worker and a query-only status helper.
+
+An `.inb` archive (see the `export` package) is an outer tar of `payload.tar.gz.sig` + `payload.tar.gz`. On restore the payload is spooled to a temp file while a streaming SHA-256 digest is computed, the signature is verified **before** inflate, and only then is the inner tar walked: per-location JSON members recreate entities, and `files/...` members stream their bytes into a re-minted tenant blob key. A bad/missing signature, a non-`.inb` upload, or any framing violation fails the restore hard.
 
 ## Key Features
 
 ### 1. Multiple Restore Strategies
-- **Full Replace (Destructive)**: Wipes current database and restores everything from backup
-- **Merge Add**: Only adds data missing in current database (matched by primary key)
+- **Full Replace (Destructive)**: Wipes current data and restores everything from backup
+- **Merge Add**: Only adds data missing in the current database (matched by immutable UUID)
 - **Merge Update**: Creates if missing, updates if exists, leaves other records untouched
 
-### 2. Streaming XML Processing
-- Memory-efficient streaming approach for large XML files
-- On-the-fly processing without loading entire files into memory
-- Chunked decoding to handle massive inventories with embedded base64 data
-- Real-time statistics collection during processing
+### 2. Memory-Safe Streaming
+- The verified payload is inflated and walked member-by-member; file bytes are streamed straight into blob storage, never buffered.
+- Per-member and total caps bound a hostile archive (`maxInbMembers`, `maxInbTotalUncompress` = 8 GiB, `maxLocationDocBytes` = 32 MiB).
 
 ### 3. Detailed Step Logging
-- Comprehensive step-by-step logging of restoration process
-- Emoji-based status indicators (📝, 🔄, ✅, ❌, ⏭️)
-- Individual item processing logs showing what was checked, skipped, updated
-- Real-time progress tracking with detailed action descriptions
+- Step-by-step logging of the restoration process with status updates per phase and per entity
+- Real-time progress tracking persisted as restore steps
 
 ### 4. File Data Restoration
-- Restoration of binary file attachments (images, invoices, manuals)
-- Base64 decoding and file recreation in blob storage
-- Proper MIME type and extension handling
-- Error resilience for corrupted or missing file data
+- Commodity file members are streamed into a re-minted tenant blob key (never the archive path or source key)
+- A declared file reference whose member never arrives fails the restore (`ErrMissingFileMembers`) rather than silently dropping data
+- Cover-photo cross-references (#1451) are patched after all files are restored
 
 ### 5. Background Processing
 - Worker-based architecture for asynchronous restoration
-- Prevents API timeouts on large restore operations
-- Semaphore-based concurrency control (only one restore at a time)
-- Graceful error handling and status reporting
+- Semaphore-based concurrency control (default: one restore at a time)
+- Soft-pause aware (#1308)
 
 ### 6. Dry Run Support
-- Preview mode to see what would be restored without making changes
-- Validation of XML structure and data integrity
-- Conflict detection and resolution preview
-- Safe testing of restore operations
+- Preview mode that drains file bytes (for the byte count) but writes nothing
 
 ## Architecture
 
-The restore package follows a processor-based architecture where each restore operation is handled by a dedicated `RestoreOperationProcessor` instance. This design provides better isolation, detailed logging, and cleaner separation of concerns.
+The restore package is processor-based: each restore operation is handled by a dedicated `RestoreOperationProcessor` instance (in the `processor` subpackage) for isolation, detailed logging, and cleaner separation of concerns.
 
 ### Core Components
 
 #### RestoreService (`service.go`)
-The main service responsible for restore operations:
-- **NewRestoreService()**: Creates a new restore service instance
-- **ProcessRestoreOperation()**: Delegates restore processing to RestoreOperationProcessor
-- Lightweight service that acts as a factory for restore processors
+A thin service that constructs and delegates to a processor:
+- **NewRestoreService()**: creates the service
+- **ProcessRestoreOperation()**: builds a `RestoreOperationProcessor` and calls its `Process()`
 
-#### RestoreOperationProcessor (`service.go`)
-Core processor that handles restore operations with detailed logging:
-- **Process()**: Main orchestration method for complete restore operations
-- **RestoreFromXML()**: Processes XML restore with streaming and detailed logging
-- **processRestoreWithDetailedLogging()**: Handles detailed step-by-step logging
-- **validateOptions()**: Validates restore configuration options
-- **clearExistingData()**: Handles full replace strategy data clearing
-- **markRestoreFailed()**: Error handling and status management
-- Supports multiple restore strategies with specialized processing methods
+#### RestoreOperationProcessor (`processor/`)
+Core processor that handles a restore with detailed logging:
+- **Process()** (`processor_shared.go`): main orchestration — status/step bookkeeping, blob open, then the per-build `decodeAndRestore`
+- **decodeAndRestore()** (`processor.go` / `processor_legacy_xml.go`): the per-build decode/verify/apply body
+- **applyInbPayload()** (`processor.go`): walks the verified inner tar
+- **RestoreFromXML()** (`processor_legacy_xml.go`, **build-tag-gated**): exported entry point used only by the legacy XML test suite
+- **validateOptions()**, **prepareRestore()**, **markRestoreFailed()**, and the strategy handlers (`applyStrategyForLocationModel`, `…AreaModel`, `…CommodityModel`, `…FileModel`) in `processor_shared.go`
 
 #### RestoreWorker (`worker.go`)
 Background worker that manages restore processing:
-- **Start()**: Begins processing restores in the background
-- **Stop()**: Gracefully stops the restore worker
-- **processPendingRestores()**: Finds and processes pending restore requests
-- **processRestore()**: Processes individual restore operations
-- Configurable poll intervals (default: 10 seconds)
-- Semaphore-based concurrency limiting (max 1 concurrent restore)
+- **Start() / Stop() / IsRunning()**: lifecycle control
+- **processPendingRestores()**: finds and processes pending restore operations; respects soft-pause
+- **processRestore()**: processes a single restore operation
+- **HasRunningRestores()**: delegates to `RegistryStatusQuerier`
+- Configurable poll interval (default: 10 seconds) and max-concurrency (default: 1)
 
-#### XML Types (`types.go`)
-Defines XML structure and conversion methods:
-- **XMLInventory**: Root element containing all restore data
-- **XMLLocation**, **XMLArea**, **XMLCommodity**: Entity representations
-- **XMLFile**: File attachment structure with base64 data
-- **RestoreStats**: Statistics tracking during restoration
-- **RestoreOptions**: Configuration options for restore operations
+#### `.inb` Schemas (`types/types_inb.go`)
+Decoded counterparts to the export-side `.inb` documents (kept in sync with `backup/export/inb_types.go`): `INBLocationDoc`, `INBLocation`, `INBArea`, `INBCommodity`, `INBFileRef`, `INBUnassignedDoc`, plus the member-name constants `INBManifestMember`, `INBUnassignedMember`.
 
-### Processor-Based Architecture
-
-The refactored architecture centers around the `RestoreOperationProcessor` pattern:
-
-#### Key Benefits
-- **Operation Isolation**: Each restore operation gets its own processor instance
-- **Detailed Logging**: Built-in step-by-step logging with emoji indicators
-- **Error Handling**: Comprehensive error tracking and status management
-- **Resource Management**: Proper cleanup and resource management per operation
-- **Testability**: Easier unit testing with dedicated processor instances
-
-#### Processor Lifecycle
-1. **Creation**: `NewRestoreOperationProcessor()` creates processor for specific operation
-2. **Validation**: Processor validates restore operation and export file existence
-3. **Processing**: `Process()` method orchestrates the complete restore workflow
-4. **Logging**: Detailed steps logged throughout the process with status updates
-5. **Completion**: Final status and statistics recorded in database
-
-#### Key Processor Methods
-- **`Process()`**: Main orchestration method that handles the complete restore workflow
-- **`processRestoreWithDetailedLogging()`**: Coordinates XML processing with step logging
-- **`restoreFromXMLWithStreamingLogging()`**: Core XML processing with streaming and logging
-- **`processLocationWithLogging()`**: Processes individual locations with detailed logging
-- **`processAreaWithLogging()`**: Processes individual areas with detailed logging
-- **`processCommodityWithLogging()`**: Processes individual commodities with detailed logging
-- **`createRestoreStep()`**: Creates new restore steps for progress tracking
-- **`updateRestoreStep()`**: Updates existing restore steps with results
-- **`predictAction()`**: Predicts what action will be taken based on strategy
-- **`markRestoreFailed()`**: Handles error scenarios and status updates
+#### Restore Types (`types/types.go`)
+- **RestoreOptions**: `Strategy`, `IncludeFileData`, `DryRun`
+- **RestoreStrategy** + constants: `RestoreStrategyFullReplace` (`"full_replace"`), `RestoreStrategyMergeAdd` (`"merge_add"`), `RestoreStrategyMergeUpdate` (`"merge_update"`)
+- **RestoreStats**, **ExistingEntities**, **IDMapping**
 
 ### Restore Strategies
 
 #### Full Replace Strategy
 ```go
-RestoreStrategyFullReplace
+types.RestoreStrategyFullReplace // "full_replace"
 ```
-- **Behavior**: Clears entire database before restoration
-- **Use Case**: Complete database replacement from backup
+- **Behavior**: Clears existing data before restoration
+- **Use Case**: Complete replacement from backup
 - **Risk**: All current data is lost
-- **Validation**: Requires explicit confirmation
 
 #### Merge Add Strategy
 ```go
-RestoreStrategyMergeAdd
+types.RestoreStrategyMergeAdd // "merge_add"
 ```
 - **Behavior**: Only adds missing data, skips existing items
-- **Use Case**: Adding new data from backup without conflicts
-- **Risk**: Low - existing data remains unchanged
-- **Matching**: Based on XML IDs and unique identifiers
+- **Risk**: Low — existing data remains unchanged
+- **Matching**: Based on immutable UUIDs
 
 #### Merge Update Strategy
 ```go
-RestoreStrategyMergeUpdate
+types.RestoreStrategyMergeUpdate // "merge_update"
 ```
 - **Behavior**: Creates missing items, updates existing ones
-- **Use Case**: Synchronizing with updated backup data
-- **Risk**: Medium - existing data may be overwritten
-- **Matching**: Based on XML IDs with update capability
+- **Risk**: Medium — existing data may be overwritten
+- **Matching**: Based on immutable UUIDs with update capability
 
 ## Data Flow
 
-### Standard Restore Process
-1. **Request Creation**: User creates restore operation via API
+1. **Request Creation**: User creates a restore operation via API
 2. **Record Storage**: Restore operation created with "pending" status
-3. **Worker Detection**: RestoreWorker polls and detects pending operation
-4. **Processor Creation**: RestoreOperationProcessor created for the specific operation
-5. **Initialization**: Processor begins processing with initial logging and validation
-6. **XML Parsing**: Streaming XML parser processes file sections
-7. **Data Processing**: Entities processed according to selected strategy with detailed logging
-8. **File Restoration**: Binary files decoded and stored in blob storage
-9. **Statistics Collection**: Real-time tracking of processed entities
-10. **Completion**: Restore operation marked as completed with final statistics
-
-### Detailed Logging Flow
-1. **Step Creation**: RestoreOperationProcessor creates restore steps for each major phase
-2. **Progress Updates**: Steps updated with in-progress, success, or error status via `createRestoreStep()` and `updateRestoreStep()`
-3. **Item Logging**: Individual items logged with emoji indicators using `processLocationWithLogging()`, `processAreaWithLogging()`, `processCommodityWithLogging()`
-4. **Action Prediction**: `predictAction()` method predicts what action will be taken for each item based on strategy
-5. **Result Tracking**: Actual results compared with predictions and logged accordingly
-6. **Error Handling**: Failed items logged with detailed error messages via `markRestoreFailed()`
+3. **Worker Detection**: `RestoreWorker` polls and detects the pending operation
+4. **Processor Creation**: a `RestoreOperationProcessor` is created for the operation
+5. **Verify**: for `.inb`, the signature is verified before inflate
+6. **Apply**: the inner tar is walked, recreating entities per the selected strategy with step logging
+7. **File Restoration**: file members stream into re-minted tenant blob keys
+8. **Completion**: restore operation marked completed with final statistics
 
 ## Usage
 
 ### Creating a Restore Service
 ```go
-import "github.com/denisvmedia/inventario/backup/restore"
+import (
+    "github.com/denisvmedia/inventario/backup/restore"
+    "github.com/denisvmedia/inventario/internal/backupsign"
+    "github.com/denisvmedia/inventario/services"
+)
 
-// Create restore service
-service := restore.NewRestoreService(registrySet, uploadLocation)
+// entityService is *services.EntityService; signer is *backupsign.Signer
+// (used by the .inb restorer to verify the archive; ignored by the legacy XML
+// restorer, so the signature is identical across both builds).
+service := restore.NewRestoreService(factorySet, entityService, uploadLocation, signer)
 ```
 
 ### Starting the Restore Worker
 ```go
-// Create worker with max 1 concurrent restore
-worker := restore.NewRestoreWorker(restoreService, registrySet, uploadLocation, 1)
+// registrySet is *registry.Set; the worker defaults to one concurrent restore.
+worker := restore.NewRestoreWorker(restoreService, registrySet, uploadLocation)
+
+// Optional configuration via functional options:
+//   restore.WithPollInterval(5 * time.Second)
+//   restore.WithMaxConcurrent(1)
+//   restore.WithPauseController(pauseController) // #1308 soft-pause
 
 // Start background processing
 ctx := context.Background()
@@ -188,7 +154,7 @@ defer worker.Stop()
 
 ### Processing a Restore Operation
 ```go
-// Process restore operation by ID
+// Process restore operation by ID.
 err := service.ProcessRestoreOperation(ctx, restoreOperationID, uploadLocation)
 if err != nil {
     log.Printf("Restore failed: %v", err)
@@ -197,152 +163,62 @@ if err != nil {
 
 ### Direct Processor Usage
 ```go
-// Create processor for specific restore operation
-processor := restore.NewRestoreOperationProcessor(restoreOperationID, registrySet, uploadLocation)
+import "github.com/denisvmedia/inventario/backup/restore/processor"
 
-// Process the restore operation
-err := processor.Process(ctx)
-if err != nil {
+p := processor.NewRestoreOperationProcessor(
+    restoreOperationID, factorySet, entityService, uploadLocation, signer,
+)
+if err := p.Process(ctx); err != nil {
     log.Printf("Restore failed: %v", err)
 }
 ```
 
 ### Restore Options Configuration
 ```go
-options := restore.RestoreOptions{
-    Strategy:        restore.RestoreStrategyMergeUpdate,
+options := types.RestoreOptions{
+    Strategy:        types.RestoreStrategyMergeUpdate,
     IncludeFileData: true,
     DryRun:          false,
 }
-
-// Using processor directly for XML restore
-processor := restore.NewRestoreOperationProcessor("operation-id", registrySet, uploadLocation)
-stats, err := processor.RestoreFromXML(ctx, xmlReader, options)
 ```
-
-## XML Processing
-
-### Streaming Approach
-The restore package uses a streaming XML parser to handle large files efficiently:
-
-```go
-decoder := xml.NewDecoder(reader)
-for {
-    tok, err := decoder.Token()
-    if err == io.EOF {
-        break
-    }
-    // Process tokens as they arrive
-}
-```
-
-### Entity Processing Order
-1. **Locations**: Processed first as they are referenced by areas
-2. **Areas**: Processed second as they are referenced by commodities
-3. **Commodities**: Processed last with full dependency resolution
-
-### File Data Handling
-- Base64 encoded data is decoded on-the-fly
-- Files are streamed directly to blob storage
-- MIME types and extensions are preserved
-- Corrupted files are logged but don't stop the restore
 
 ## Error Handling
-
-### Comprehensive Error Management
-- **Graceful Degradation**: Individual item failures don't stop entire restore
-- **Detailed Logging**: All errors logged with context and item information
-- **Status Tracking**: Failed restores marked with detailed error messages
-- **Rollback Support**: Dry run mode allows safe testing
-
-### Error Recovery
-- **Partial Success**: Statistics reflect successfully processed items
-- **File Fallbacks**: Missing or corrupted files logged but restore continues
-- **Validation Errors**: Data validation failures logged with specific field information
-- **Dependency Resolution**: Missing dependencies handled gracefully
+- **Graceful Degradation**: most per-item failures are tolerated and counted in `RestoreStats.Errors`
+- **Hard Failures**: signature verification failure, framing violations, missing file members (`ErrMissingFileMembers`), oversized members (`ErrLocationDocTooLarge`), and malformed entity fields (`ErrMalformedEntity`) abort the whole restore
+- **Status Tracking**: failed restores marked with a detailed error message
 
 ## Performance Considerations
 
 ### Memory Efficiency
-- **Streaming Processing**: XML processed without loading entire file into memory
-- **Chunked File Handling**: Large binary files processed in chunks
-- **Real-time Statistics**: Statistics collected without memory accumulation
-- **Garbage Collection**: Proper resource cleanup and memory management
+- **Verify-before-inflate**: the payload is digested via a temp file; nothing is decompressed until the signature is trusted
+- **Streaming file members**: file bytes are copied straight into blob storage
+- **Bounded walk**: per-member and total caps prevent decompression-bomb DoS
 
 ### Concurrency Control
-- **Single Restore Limit**: Only one restore operation allowed at a time
-- **Semaphore Protection**: Prevents resource conflicts and data corruption
-- **Background Processing**: Asynchronous processing prevents API timeouts
-- **Worker Isolation**: Restore operations isolated from other system processes
+- **Single Restore Default**: one restore operation at a time (`WithMaxConcurrent` to override)
+- **Background Processing**: asynchronous processing prevents API timeouts
 
 ## Testing
 
 ### Test Coverage
-- **Unit Tests**: `service_test.go`, `worker_test.go`, `types_test.go`
-- **Strategy Tests**: `merge_add_strategy_test.go` and other strategy-specific tests
-- **Integration Tests**: End-to-end restore operations with real XML files
-- **Error Tests**: Error handling and recovery scenarios
-
-### Test Framework
+- **Unit / Integration Tests**: `service_test.go`, `worker_test.go`, `streaming_test.go`, `restore_files_test.go`, `restore_tags_test.go`, `recursive_delete_integration_test.go`, `status_querier_test.go`
 - Uses frankban's quicktest framework
-- Table-driven tests for multiple restore strategies
-- RestoreOperationProcessor-based testing for realistic scenarios
 - Memory registries for isolated testing
-- Temporary file handling for integration tests
 
-## Configuration
+## Security Considerations
 
-### Environment Variables
-- **Upload Location**: Configurable blob storage location for file restoration
-- **Worker Concurrency**: Maximum concurrent restore operations (recommended: 1)
-- **Poll Intervals**: Restore processing frequency
-- **Timeout Settings**: Maximum restore operation duration
-
-### Database Integration
-- **Restore Operation Registry**: Stores restore metadata and status
-- **Restore Step Registry**: Tracks individual restore steps
-- **Entity Registries**: Access to locations, areas, commodities for restoration
-- **File Registries**: Access to images, invoices, manuals for file restoration
+### Data Protection
+- **Signature Verification**: `.inb` archives are verified against the server's own key before any inflate
+- **Path Sanitization**: inner-tar member names are sanitized (`blobkeys.SanitizeArchivePath`); unsafe names are rejected
+- **Key Re-minting**: file bytes are always written to a fresh tenant-namespaced blob key, never the archive path or source key (#1793)
+- **Ownership Validation**: commodity ownership is validated against the importing user before persisting
 
 ## Integration Points
 
 ### API Server Integration
 - **REST Endpoints**: `/api/v1/exports/{id}/restores` for restore operations
-- **Status Endpoints**: Real-time restore status and progress checking
-- **Step Endpoints**: Detailed step-by-step progress monitoring
-- **File Endpoints**: File restoration status and error reporting
-
-### Frontend Integration
-- **Restore Interface**: User interface for restore configuration
-- **Progress Tracking**: Real-time progress updates with step details
-- **Strategy Selection**: User-friendly restore strategy selection
-- **Dry Run Preview**: Preview mode for safe restore testing
+- **Status / Step Endpoints**: real-time restore status and step progress
 
 ### Storage Integration
-- **Blob Storage**: File restoration to cloud-agnostic storage
-- **Database Storage**: Metadata and status persistence
-- **File Management**: Automatic file organization and cleanup
-
-## Security Considerations
-
-### Data Protection
-- **Validation**: Comprehensive input validation for XML data
-- **Sanitization**: Proper sanitization of file paths and names
-- **Access Control**: Restore operations require appropriate permissions
-- **Audit Logging**: Complete audit trail of all restore operations
-
-### File Security
-- **Path Validation**: Prevention of directory traversal attacks
-- **File Type Validation**: MIME type and extension validation
-- **Size Limits**: Protection against oversized file uploads
-- **Virus Scanning**: Integration points for file scanning (future enhancement)
-
-## Future Enhancements
-
-Potential areas for future development:
-- **Selective Restoration**: Restore specific entities or date ranges
-- **Conflict Resolution UI**: Interactive conflict resolution interface
-- **Backup Validation**: Pre-restore backup integrity checking
-- **Progress Streaming**: Real-time progress updates (e.g. via WebSocket)
-- **Rollback Capability**: Automatic rollback on restore failures
-- **Format Support**: Revise the format to use tar.gz, which will contain XML file with DB records and files that the XML refers to
+- **Blob Storage**: file restoration to tenant-namespaced, cloud-agnostic storage
+- **Database Storage**: metadata and status persistence

--- a/go/cmd/internal/input/README.md
+++ b/go/cmd/internal/input/README.md
@@ -1,319 +1,219 @@
 # Interactive Input Abstraction
 
-This package provides a comprehensive interactive command input abstraction for Go CLI applications with support for various input types, validation, and user-friendly prompting.
+This package provides an interactive command-line input abstraction for the Inventario CLI, with support for several input types, per-field validation, and re-prompting on invalid input.
 
 ## Features
 
-- **Multiple Input Types**: Support for `bool`, `password`, `string`, and `int` input types
-- **Validation Integration**: Seamless integration with `github.com/jellydator/validation` package
-- **Fluent API**: Builder pattern for creating input prompts with method chaining
-- **Error Handling**: Automatic re-prompting on validation failures with clear error messages
-- **Default Values**: Support for optional fields with default values
-- **Secure Input**: Hidden password input with confirmation prompts
-- **Flexible Formatting**: Multiple boolean prompt formats (y/n, Y/n, y/N, yes/no)
-- **Range Validation**: Min/max constraints for numeric and string inputs
+- **Multiple Input Types**: `bool`, `string`, `password`, and `int` fields
+- **Reader-based I/O**: every field reads from a `*Reader` wrapping an `io.Reader` / `io.Writer`, so input/output are injectable (and easy to test)
+- **Fluent API**: chainable field configuration (each method returns a new field copy)
+- **Re-prompting**: on a validation error the user is re-prompted; non-validation errors (EOF, interrupts) are returned immediately
+- **Default Values**: optional fields can carry a default
+- **Secure Input**: hidden password input with an optional confirmation prompt
+- **Per-field Validation**: `ValidateEmail` / `ValidateSlug` / `ValidateStrength` / `ValidateCustom`
+
+## Core Types
+
+- **`Reader`** — wraps input/output; created with `NewReader(in io.Reader, out io.Writer)` or `NewDefaultReader()` (stdin/stdout).
+- **Field types** — `StringField`, `BoolField`, `PasswordField`, `IntField`, each created with `New<Type>Field(label string, reader *Reader)` and satisfying the `InputField` interface (`Prompt(ctx) (any, error)`).
+- **`Quick`** — one-off helpers; created with `NewQuick(in io.Reader, out io.Writer)` or `NewDefaultQuick()`.
+- **`Form`** — collects multiple fields at once; created with `NewForm(in io.Reader, out io.Writer)` or `NewDefaultForm()`.
+
+> There is no `Builder` type and no standalone validator constructors — validation lives on the field types as `Validate*` methods.
 
 ## Quick Start
 
-### Simple Usage with Quick API
+### Single fields
+
+This is the pattern the CLI commands use (see `cmd/inventario/users/create`):
 
 ```go
-package main
-
 import (
     "context"
-    "fmt"
+    "os"
+
     "github.com/denisvmedia/inventario/cmd/internal/input"
 )
 
-func main() {
-    ctx := context.Background()
-    quick := input.NewQuick()
+ctx := context.Background()
+reader := input.NewReader(os.Stdin, os.Stdout)
 
-    // Simple string input
-    name, err := quick.String(ctx, "Your name")
-    if err != nil {
-        panic(err)
-    }
+emailField := input.NewStringField("Email", reader).
+    Required().
+    ValidateEmail()
 
-    // String with default
-    email, err := quick.StringWithDefault(ctx, "Email", "user@example.com")
-    if err != nil {
-        panic(err)
-    }
-
-    // Boolean input
-    confirm, err := quick.Bool(ctx, "Confirm")
-    if err != nil {
-        panic(err)
-    }
-
-    // Password input
-    password, err := quick.Password(ctx, "Password")
-    if err != nil {
-        panic(err)
-    }
-
-    fmt.Printf("Name: %s, Email: %s, Confirm: %t\n", name, email, confirm)
+value, err := emailField.Prompt(ctx)
+if err != nil {
+    return err
 }
+email := value.(string)
+
+passwordField := input.NewPasswordField("Password", reader).
+    ValidateStrength()
+
+pwValue, err := passwordField.Prompt(ctx)
+if err != nil {
+    return err
+}
+password := pwValue.(string)
 ```
 
-### Advanced Usage with Builder API
+### Quick API
 
 ```go
-package main
+ctx := context.Background()
+quick := input.NewQuick(os.Stdin, os.Stdout) // or input.NewDefaultQuick()
 
-import (
-    "context"
-    "github.com/denisvmedia/inventario/cmd/internal/input"
-)
-
-func main() {
-    ctx := context.Background()
-    
-    builder := input.NewBuilder()
-
-    // String field with validation
-    builder.String("email").
-        Required().
-        Validate(input.EmailValidator())
-
-    // Password field with strength validation
-    builder.Password("password").
-        Validate(input.PasswordStrengthValidator())
-
-    // Boolean field with default
-    builder.Bool("newsletter").
-        DefaultYes()
-
-    // Integer field with range
-    builder.Int("age").
-        Range(18, 100)
-
-    // Collect all values
-    values, err := builder.Collect(ctx)
-    if err != nil {
-        panic(err)
-    }
-
-    // Access values
-    email := values["email"].(string)
-    password := values["password"].(string)
-    newsletter := values["newsletter"].(bool)
-    age := values["age"].(int)
-}
+name, err := quick.String(ctx, "Your name")
+email, err := quick.Email(ctx, "Email")   // string field with ValidateEmail
+slug, err := quick.Slug(ctx, "Slug")      // string field with ValidateSlug
+confirm, err := quick.Bool(ctx, "Confirm")
+password, err := quick.Password(ctx, "Password")
+age, err := quick.Int(ctx, "Age")
 ```
 
-### Form API with Struct Population
+### Form API
+
+`Form` collects all added fields and returns a `map[string]any` keyed by the field label.
 
 ```go
-package main
+ctx := context.Background()
+form := input.NewForm(os.Stdin, os.Stdout) // or input.NewDefaultForm()
 
-import (
-    "context"
-    "github.com/denisvmedia/inventario/cmd/internal/input"
-)
+form.AddString("name").Required().MinLength(2)
+form.AddString("email").Required().ValidateEmail()
+form.AddInt("age").Range(18, 100)
+form.AddBool("active").DefaultYes()
 
-type User struct {
-    Name     string `json:"name"`
-    Email    string `json:"email"`
-    Age      int    `json:"age"`
-    Active   bool   `json:"active"`
+values, err := form.Collect(ctx)
+if err != nil {
+    return err
 }
 
-func main() {
-    ctx := context.Background()
-    
-    form := input.NewForm()
-
-    form.String("name").Required().MinLength(2)
-    form.String("email").Required().Validate(input.EmailValidator())
-    form.Int("age").Range(18, 100)
-    form.Bool("active").DefaultYes()
-
-    var user User
-    err := form.CollectInto(ctx, &user)
-    if err != nil {
-        panic(err)
-    }
-
-    // user struct is now populated
-}
+name := values["name"].(string)
+email := values["email"].(string)
+age := values["age"].(int)
+active := values["active"].(bool)
 ```
 
 ## Input Types
 
-### String Input
+### String Input (`StringField`)
 
 ```go
-field := input.NewStringField("Name", prompter).
+reader := input.NewReader(os.Stdin, os.Stdout)
+field := input.NewStringField("Name", reader).
     Required().
     MinLength(2).
     MaxLength(50).
-    Validate(input.SlugValidator())
+    ValidateSlug()
 ```
 
 **Methods:**
-- `Required()` / `Optional()` - Set field requirement
-- `Default(value)` - Set default value
-- `MinLength(min)` - Set minimum length
-- `MaxLength(max)` - Set maximum length
-- `Length(min, max)` - Set both min and max length
-- `Validate(rules...)` - Add validation rules
+- `Required()` / `Optional()` — set field requirement
+- `Default(value)` — set default value
+- `MinLength(n)` / `MaxLength(n)` — length constraints
+- `ValidateEmail()` — require a valid email address
+- `ValidateSlug()` — require a valid slug (lowercase letters, numbers, hyphens)
+- `ValidateCustom(func(string) error)` — custom validation
+- `SetReader(*Reader)` — swap the reader (used in tests)
 
-### Boolean Input
+### Boolean Input (`BoolField`)
 
 ```go
-field := input.NewBoolField("Confirm", prompter).
-    DefaultYes().
-    YesNo()
+field := input.NewBoolField("Confirm", reader).DefaultYes()
 ```
 
 **Methods:**
-- `Required()` / `Optional()` - Set field requirement
-- `Default(value)` - Set default value
-- `DefaultYes()` - Set default to true with Y/n format
-- `DefaultNo()` - Set default to false with y/N format
-- `Format(format)` - Set prompt format
-- `YesNo()` - Use full words format
+- `Required()` / `Optional()` — set field requirement
+- `DefaultYes()` — default true (prompt shows `Y/n`)
+- `DefaultNo()` — default false (prompt shows `y/N`)
+- `SetReader(*Reader)` — swap the reader (used in tests)
 
-**Formats:**
-- `BoolFormatYN` - Equal weight (y/n)
-- `BoolFormatYesN` - Default yes (Y/n)
-- `BoolFormatYNo` - Default no (y/N)
-- `BoolFormatYesNo` - Full words (yes/no)
+Accepted answers: `y`/`Y`/`yes`/`Yes`/`YES` for true, `n`/`N`/`no`/`No`/`NO` for false.
 
-### Password Input
+### Password Input (`PasswordField`)
 
 ```go
-field := input.NewPasswordField("Password", prompter).
+field := input.NewPasswordField("Password", reader).
     MinLength(8).
-    Validate(input.PasswordStrengthValidator())
+    ValidateStrength()
 ```
 
-**Methods:**
-- `Required()` / `Optional()` - Set field requirement
-- `WithConfirmation()` / `NoConfirmation()` - Enable/disable confirmation
-- `MinLength(min)` - Set minimum length
-- `MaxLength(max)` - Set maximum length
-- `Length(min, max)` - Set both min and max length
-- `Validate(rules...)` - Add validation rules
+Passwords are **required and confirmed by default**.
 
-### Integer Input
+**Methods:**
+- `Required()` / `Optional()` — set field requirement
+- `WithConfirmation()` / `NoConfirmation()` — enable/disable the confirmation prompt
+- `MinLength(n)` — minimum length
+- `ValidateStrength()` — require 8+ chars with upper, lower, and a digit
+- `ValidateCustom(func(string) error)` — custom validation
+- `SetReader(*Reader)` — swap the reader (used in tests)
+
+### Integer Input (`IntField`)
 
 ```go
-field := input.NewIntField("Age", prompter).
+field := input.NewIntField("Age", reader).
     Range(18, 100).
     Default(25)
 ```
 
 **Methods:**
-- `Required()` / `Optional()` - Set field requirement
-- `Default(value)` - Set default value
-- `Min(min)` - Set minimum value
-- `Max(max)` - Set maximum value
-- `Range(min, max)` - Set both min and max value
-- `Positive()` - Constrain to positive values (> 0)
-- `NonNegative()` - Constrain to non-negative values (>= 0)
-- `Validate(rules...)` - Add validation rules
+- `Required()` / `Optional()` — set field requirement
+- `Default(value)` — set default value
+- `Min(n)` / `Max(n)` — value constraints
+- `Range(min, max)` — set both
+- `Positive()` — `> 0`
+- `NonNegative()` — `>= 0`
+- `SetReader(*Reader)` — swap the reader (used in tests)
 
-## Validation Helpers
+## Validation
 
-The package provides common validation helpers:
+Validation is attached per field via the `Validate*` methods listed above. Under the hood they use the package helpers in `patterns.go`:
 
-```go
-// Email validation
-input.EmailValidator()
+- `IsValidEmail(string) bool`
+- `IsValidSlug(string) bool`
+- `IsValidPassword(string) bool` (8+ chars with upper, lower, and a digit)
 
-// Password strength (8+ chars, upper, lower, digit)
-input.PasswordStrengthValidator()
+A failed validation surfaces as an `AnswerError` (see `errors.go`), which the field's `Prompt` loop catches and re-prompts on. A missing required field surfaces as a `RequiredFieldError`.
 
-// Slug format (lowercase, alphanumeric, hyphens)
-input.SlugValidator()
+## Integration with Cobra Commands
 
-// Length constraints
-input.MinLengthValidator(5)
-input.MaxLengthValidator(100)
-input.LengthValidator(5, 100)
-
-// Numeric constraints
-input.MinValidator(0)
-input.MaxValidator(100)
-input.RangeValidator(0, 100)
-
-// Custom validation
-input.CustomValidator(func(value any) error {
-    // Custom validation logic
-    return nil
-})
-```
-
-## Integration with Commands
-
-### Using with Cobra Commands
+Build a `*Reader` from the command's output writer so prompts go to the right stream:
 
 ```go
-func (c *Command) collectUserInput() (*UserRequest, error) {
-    ctx := context.Background()
-
-    // Create fields with command output
-    emailField := input.NewStringField("Email", input.NewDefaultPrompter()).
+func (c *Command) collectEmail(ctx context.Context) (string, error) {
+    reader := input.NewReader(os.Stdin, c.Cmd().OutOrStdout())
+    emailField := input.NewStringField("Email", reader).
         Required().
-        Validate(input.EmailValidator())
-    emailField.BaseField.Prompter.SetOutput(c.Cmd().OutOrStdout())
+        ValidateEmail()
 
-    passwordField := input.NewPasswordField("Password", input.NewDefaultPrompter()).
-        Validate(input.PasswordStrengthValidator())
-    passwordField.BaseField.Prompter.SetOutput(c.Cmd().OutOrStdout())
-
-    // Collect input
-    email, err := emailField.Prompt(ctx)
+    value, err := emailField.Prompt(ctx)
     if err != nil {
-        return nil, err
+        return "", err
     }
-
-    password, err := passwordField.Prompt(ctx)
-    if err != nil {
-        return nil, err
+    email, ok := value.(string)
+    if !ok {
+        return "", fmt.Errorf("unexpected type returned from email field")
     }
-
-    return &UserRequest{
-        Email:    email.(string),
-        Password: password.(string),
-    }, nil
+    return email, nil
 }
 ```
 
-## Error Handling
-
-The input system automatically handles validation errors by re-prompting the user:
-
-```go
-// This will keep prompting until valid email is entered
-email, err := input.NewStringField("Email", prompter).
-    Required().
-    Validate(input.EmailValidator()).
-    Prompt(ctx)
-```
-
-For non-validation errors (EOF, interrupts), the error is returned immediately.
-
 ## Testing
 
-The package is designed to be easily testable by allowing custom input/output:
+The package is easy to test by injecting a `*Reader` over in-memory buffers:
 
 ```go
 func TestInput(t *testing.T) {
     var output bytes.Buffer
-    inputReader := strings.NewReader("test@example.com\n")
+    reader := input.NewReader(strings.NewReader("test@example.com\n"), &output)
 
-    prompter := input.NewDefaultPrompter()
-    prompter.SetOutput(&output)
-    prompter.SetInput(inputReader)
-
-    field := input.NewStringField("Email", prompter).Required()
+    field := input.NewStringField("Email", reader).Required().ValidateEmail()
     result, err := field.Prompt(context.Background())
 
-    // Assert result and output
+    // assert on result and output
 }
 ```
+
+`SetReader` can also swap a field's reader after construction, which is handy when wiring fields up before the input source is known.

--- a/go/integration/README.md
+++ b/go/integration/README.md
@@ -27,7 +27,7 @@ The thumbnail generation integration test validates the complete thumbnail workf
 4. **API Response**: Validate that signed URLs include thumbnail URLs
 5. **Cleanup**: Ensure thumbnails are deleted when original files are deleted
 
-This test requires the `INTEGRATION_TESTS` environment variable to be set and validates the complete image processing pipeline.
+This test runs unconditionally against in-memory registries (`memory.NewFactorySet`) and a temp-directory blob store (`t.TempDir()` + a `file://` upload location). It needs no PostgreSQL and is not gated on any environment variable, so it always executes and validates the complete image processing pipeline.
 
 ## Test Structure
 
@@ -73,9 +73,12 @@ func TestCLIWorkflowIntegration(t *testing.T)
 # Set the PostgreSQL DSN
 export POSTGRES_TEST_DSN="postgres://user:password@localhost:5432/test_db?sslmode=disable"
 
-# Run the integration test
+# Run the integration tests
 cd go
-go test -tags=integration ./integration_test/cli_workflow_integration_test.go -v
+go test ./integration/... -v
+
+# Or just the CLI workflow test
+go test ./integration/... -run TestCLIWorkflowIntegration -v
 ```
 
 #### Using the Test Scripts
@@ -190,7 +193,7 @@ Error: system info request failed with status: 403
 To enable verbose output and debugging:
 
 ```bash
-go test -tags=integration ./integration_test/cli_workflow_integration_test.go -v -test.v
+go test ./integration/... -run TestCLIWorkflowIntegration -v
 ```
 
 ## Integration with CI/CD

--- a/go/scripts/run-integration-tests.sh
+++ b/go/scripts/run-integration-tests.sh
@@ -21,7 +21,7 @@ echo ""
 
 # Run the integration test
 echo "🧪 Running CLI workflow integration test..."
-go test -tags=integration ./integration_test/cli_workflow_integration_test.go -v -timeout=5m
+go test ./integration/... -run TestCLIWorkflowIntegration -v -timeout=5m
 
 echo ""
 echo "✅ CLI workflow integration test completed successfully!"

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -18,14 +18,29 @@ Both baselines preserve the same startup flow used by `docker-compose.yaml`:
 
 ## Image and tag assumptions
 
-- The manifests currently reference `ghcr.io/denisvmedia/inventario:latest`.
-- `.goreleaser.yaml` publishes the multi-arch image set under:
-  - `ghcr.io/denisvmedia/inventario:<tag>`
-  - `ghcr.io/denisvmedia/inventario:v<major>.<minor>`
-  - `ghcr.io/denisvmedia/inventario:v<major>`
-  - `ghcr.io/denisvmedia/inventario:latest`
-  - `ghcr.io/denisvmedia/inventario:SNAPSHOT-<commit>` for snapshot builds
-- For production rollouts, prefer replacing `:latest` with a specific published release tag before applying.
+- **Production prerequisite (do this first):** the `k8s/prod` manifests ship with
+  `ghcr.io/denisvmedia/inventario:latest`. Before applying them to production,
+  replace every `image:` reference in `k8s/prod/deployment.yaml` and
+  `k8s/prod/job-setup.yaml` with a specific, immutable published image tag (a
+  released `v<major>.<minor>.<patch>` once one exists, or a `sha-<commit>` tag in
+  the meantime). `:latest` is a floating tag and is **not** safe for production.
+  - Note: there are **no released version tags yet** (tracked in #2088), so no
+    `vX.Y.Z` image exists to pin to today. Until the first release is published,
+    pin to an immutable `sha-<commit>` tag of a `master` build instead.
+- **For production, the Helm chart at `helm/inventario/` is the preferred deploy
+  path.** `k8s/prod` is a **hand-maintained reference baseline**: it is **not**
+  exercised by CI (only `k8s/dev` is — see the kind smoke workflow below), so it
+  can silently drift from the Helm chart and the application. Treat it as a
+  starting point to read and adapt, not as a CI-verified production target.
+- Container images are published by `.github/workflows/docker.yml` (a matrix
+  build on native amd64/arm64 runners merged into one multi-arch manifest list).
+  `.goreleaser.yaml` deliberately does **not** build Docker images — it owns the
+  binaries, archives, checksums, and the GitHub Release only. The image tags that
+  workflow publishes are:
+  - On a `v*` git tag: `ghcr.io/denisvmedia/inventario:v<major>.<minor>.<patch>`,
+    `:v<major>.<minor>`, `:v<major>`, and `:latest`.
+  - On a push to `master`: `:edge`, `:master`, and an immutable `:sha-<commit>`.
+  - On a pull request: `:pr-<number>` and an immutable `:sha-<commit>`.
 - The CI smoke workflow at `.github/workflows/kind-smoke-test.yml` does **not** push a registry image. It builds `inventario:kind-ci` locally, loads that image into the ephemeral kind cluster, and rewrites a temporary copy of `k8s/dev/inventario/job-setup.yaml` plus `k8s/dev/inventario/deployment.yaml` to use the loaded tag for that run.
 - The container image is built to run as the non-root `inventario` user (`uid: 1001`, `gid: 1001`) and the manifests match that runtime contract.
 
@@ -81,6 +96,10 @@ Prerequisites:
 - A cluster with dynamic PVC provisioning (or a matching pre-provisioned volume).
 - Reachable external PostgreSQL and Redis endpoints.
 - Edited values in `k8s/prod/secret.yaml` and `k8s/prod/configmap.yaml`.
+- Replaced the floating `:latest` image tag in `k8s/prod/deployment.yaml` and
+  `k8s/prod/job-setup.yaml` with a pinned, immutable tag (see "Image and tag
+  assumptions" above). For a CI-verified production deploy, prefer the Helm chart
+  at `helm/inventario/` instead of this baseline.
 
 Apply the baseline:
 

--- a/k8s/prod/deployment.yaml
+++ b/k8s/prod/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: wait-for-bootstrap
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           command: ["/bin/sh", "-ec"]
           args:
@@ -62,7 +62,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: migrate
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           command: ["/bin/sh", "-ec"]
           args:
@@ -95,7 +95,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: wait-for-init-data
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           command: ["/bin/sh", "-ec"]
           args:
@@ -121,7 +121,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: inventario
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           ports:
             - name: http

--- a/k8s/prod/job-setup.yaml
+++ b/k8s/prod/job-setup.yaml
@@ -31,7 +31,7 @@ spec:
             claimName: inventario-data
       initContainers:
         - name: bootstrap
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           command: ["/bin/sh", "-ec"]
           args:
@@ -78,7 +78,7 @@ spec:
               drop: ["ALL"]
       containers:
         - name: init-data
-          image: ghcr.io/denisvmedia/inventario:latest
+          image: ghcr.io/denisvmedia/inventario:latest # replace :latest with a pinned, immutable release tag before applying to production (see k8s/README.md)
           imagePullPolicy: Always
           command: ["/bin/sh", "-ec"]
           args:


### PR DESCRIPTION
Consolidated **docs-only** cleanup for the "docs-only" cluster of the private-alpha readiness audit (#2087). Produced by a 9-lane parallel fan-out (one disjoint file-set per agent) + an accuracy/completeness/frontend verification pass. Every factual claim was verified against the current source before editing.

## Issues addressed

- **#2037** — refresh `DEPLOYMENT.md` (bare-metal/systemd): `:3333` + `INVENTARIO_RUN_*` env vars, required JWT + file-signing secrets, Redis, back-office bootstrap, email/SMTP, `PUBLIC_URL`, CORS; cross-link the canonical `PRODUCTION.md`.
- **#2036** — `k8s/prod` `:latest` footgun: explicit "pin before apply" first step + prefer-Helm note (no released tag exists yet — see #2088); manifests kept valid (no pinning to a non-existent tag).
- **#2099** — add `SECURITY.md` (private vuln disclosure), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- **#2104** — add `docs/user-guide/` getting-started guide; rewire the in-app **Documentation** + **What's new** Help links off the coming-soon dead-ends.
- **#2105** — README/QUICKSTART/AGENTS CLI drift: drop `./ptah/cmd`, `--role`, unimplemented `users update`/tenant flags; fix `db migrate` subcommands; remove broken `SIGNED_URLS.md` links.
- **#2108** — rewrite `go/backup/*` + `go/cmd/internal/input` READMEs around the signed `.inb` format with correct constructor/method signatures (XML demoted to the legacy build-tag-gated path).
- **#2109** — stale devdocs: `files-backfill.md` marked historical, `infra/dev` master-preview (git-generator on the `argocd/master-pin` orphan branch), integration-test paths, dead `Makefile` path.
- **#2110** — contributor/Copilot docs: `internal/log` → `log/slog`.
- **#2111** — medium/low drift across ~80 md files (root docs, `.github`, devdocs core/security, `devdocs/frontend` numbers and paths).

## Verification
- Accuracy + completeness review passes (facts re-checked against source; the HIGH `argocd/master-pin` orphan-branch correction included).
- Frontend `typecheck` / `lint` / `format:check` all green (the only non-doc change is the #2104 Help-link rewire in `SettingsPage.tsx`).

## Intentionally out of scope (follow-ups)
- The `users update` Go stub (#2105) — docs now describe it as "not yet implemented".
- Pinning `k8s/prod` to a real release tag (#2036 / #2088) — no release tags exist yet.

Part of #2087.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct, contribution guidelines, and a security policy.
  * Expanded and rewrote deployment, configuration, and production runbooks (including systemd and Kubernetes guidance).
  * Added end-user documentation (user-guide getting started) and updated extensive CLI/migration instructions and developer docs.
* **New Features**
  * Updated Settings “Getting started” and “What’s new” links to open external documentation in new tabs.
* **Chores**
  * Updated test execution guidance and tightened Go/Postgres test targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->