### PR TITLE
fix(email): sanitize + RFC 2047-encode SMTP headers

### DIFF
--- a/go/email/providers/smtp/sender.go
+++ b/go/email/providers/smtp/sender.go
@@ -167,10 +167,14 @@ func buildMIMEMessage(message sender.Message) []byte {
 	return []byte(b.String())
 }
 
+// headerSanitizer strips CR and LF from header values. A Replacer is
+// concurrency-safe and reusable, so it is built once rather than per call.
+var headerSanitizer = strings.NewReplacer("\r", "", "\n", "")
+
 // sanitizeHeader strips CR and LF from a header value so user-influenced
 // data (e.g. a commodity name interpolated into the Subject) can't inject
 // additional headers or message body. RFC 5322 header field values are
 // single-line. #2139
 func sanitizeHeader(v string) string {
-	return strings.NewReplacer("\r", "", "\n", "").Replace(v)
+	return headerSanitizer.Replace(v)
 }

--- a/go/email/providers/smtp/sender.go
+++ b/go/email/providers/smtp/sender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"mime"
 	"net"
 	stdsmtp "net/smtp"
 	"strconv"
@@ -136,11 +137,15 @@ func buildMIMEMessage(message sender.Message) []byte {
 	boundary := fmt.Sprintf("inventario-%d", time.Now().UnixNano())
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "From: %s\r\n", message.From)
-	fmt.Fprintf(&b, "To: %s\r\n", message.To)
-	fmt.Fprintf(&b, "Subject: %s\r\n", message.Subject)
+	fmt.Fprintf(&b, "From: %s\r\n", sanitizeHeader(message.From))
+	fmt.Fprintf(&b, "To: %s\r\n", sanitizeHeader(message.To))
+	// RFC 2047-encode the Subject so non-ASCII (cs/ru) subjects render
+	// correctly in mail clients. QEncoding returns pure-ASCII subjects
+	// unchanged and an encoded-word can't contain a raw CRLF, so this also
+	// closes the header-injection vector for the Subject. #2139
+	fmt.Fprintf(&b, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", sanitizeHeader(message.Subject)))
 	if strings.TrimSpace(message.ReplyTo) != "" {
-		fmt.Fprintf(&b, "Reply-To: %s\r\n", message.ReplyTo)
+		fmt.Fprintf(&b, "Reply-To: %s\r\n", sanitizeHeader(message.ReplyTo))
 	}
 	b.WriteString("MIME-Version: 1.0\r\n")
 	fmt.Fprintf(&b, "Content-Type: multipart/alternative; boundary=%q\r\n", boundary)
@@ -160,4 +165,12 @@ func buildMIMEMessage(message sender.Message) []byte {
 
 	fmt.Fprintf(&b, "--%s--\r\n", boundary)
 	return []byte(b.String())
+}
+
+// sanitizeHeader strips CR and LF from a header value so user-influenced
+// data (e.g. a commodity name interpolated into the Subject) can't inject
+// additional headers or message body. RFC 5322 header field values are
+// single-line. #2139
+func sanitizeHeader(v string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(v)
 }

--- a/go/email/providers/smtp/sender.go
+++ b/go/email/providers/smtp/sender.go
@@ -140,10 +140,9 @@ func buildMIMEMessage(message sender.Message) []byte {
 	fmt.Fprintf(&b, "From: %s\r\n", sanitizeHeader(message.From))
 	fmt.Fprintf(&b, "To: %s\r\n", sanitizeHeader(message.To))
 	// RFC 2047-encode the Subject so non-ASCII (cs/ru) subjects render
-	// correctly in mail clients. QEncoding returns pure-ASCII subjects
-	// unchanged and an encoded-word can't contain a raw CRLF, so this also
-	// closes the header-injection vector for the Subject. #2139
-	fmt.Fprintf(&b, "Subject: %s\r\n", mime.QEncoding.Encode("utf-8", sanitizeHeader(message.Subject)))
+	// correctly in mail clients; encodeSubject never emits a raw CRLF, so
+	// this also closes the header-injection vector for the Subject. #2139
+	fmt.Fprintf(&b, "Subject: %s\r\n", encodeSubject(sanitizeHeader(message.Subject)))
 	if strings.TrimSpace(message.ReplyTo) != "" {
 		fmt.Fprintf(&b, "Reply-To: %s\r\n", sanitizeHeader(message.ReplyTo))
 	}
@@ -177,4 +176,19 @@ var headerSanitizer = strings.NewReplacer("\r", "", "\n", "")
 // single-line. #2139
 func sanitizeHeader(v string) string {
 	return headerSanitizer.Replace(v)
+}
+
+// encodeSubject RFC 2047-encodes a Subject for the header. Pure-ASCII
+// subjects pass through unchanged (both encoders do this); for non-ASCII it
+// picks the shorter of Q- and B-encoding — Q wins when only a few runes
+// need escaping, B (base64) when most do (e.g. Cyrillic), which roughly
+// halves a Russian subject. The shorter encoded-word also leaves more
+// headroom under the RFC 5322 line-length limit. #2139
+func encodeSubject(s string) string {
+	q := mime.QEncoding.Encode("UTF-8", s)
+	b := mime.BEncoding.Encode("UTF-8", s)
+	if len(b) < len(q) {
+		return b
+	}
+	return q
 }

--- a/go/email/providers/smtp/sender_test.go
+++ b/go/email/providers/smtp/sender_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"mime"
 	"net"
+	"net/mail"
 	"strconv"
 	"strings"
 	"testing"
@@ -215,6 +216,29 @@ func TestEncodeSubject_PicksCompactEncoding(t *testing.T) {
 		c.Assert(len(got) <= len(mime.QEncoding.Encode("UTF-8", s)), qt.IsTrue)
 		c.Assert(len(got) <= len(mime.BEncoding.Encode("UTF-8", s)), qt.IsTrue)
 	}
+}
+
+// #2139: the assembled message must be a well-formed email — net/mail's
+// parser accepts it and the encoded non-ASCII Subject decodes back. This
+// guards the whole MIME structure (header block, boundary), not just one
+// header.
+func TestBuildMIMEMessage_ParsesAsValidEmail(t *testing.T) {
+	c := qt.New(t)
+	raw := buildMIMEMessage(sender.Message{
+		From:    "Inventario <noreply@example.com>",
+		To:      "user@example.com",
+		ReplyTo: "support@example.com",
+		Subject: "Подтвердите свою учётную запись Inventario",
+		Text:    "text",
+		HTML:    "<p>html</p>",
+	})
+	msg, err := mail.ReadMessage(strings.NewReader(string(raw)))
+	c.Assert(err, qt.IsNil)
+	c.Assert(msg.Header.Get("To"), qt.Equals, "user@example.com")
+	c.Assert(msg.Header.Get("Reply-To"), qt.Equals, "support@example.com")
+	decoded, err := new(mime.WordDecoder).DecodeHeader(msg.Header.Get("Subject"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(decoded, qt.Equals, "Подтвердите свою учётную запись Inventario")
 }
 
 // mimeHeaderValue returns the value of the first `key: ` header in the

--- a/go/email/providers/smtp/sender_test.go
+++ b/go/email/providers/smtp/sender_test.go
@@ -3,6 +3,7 @@ package smtp
 import (
 	"bufio"
 	"context"
+	"mime"
 	"net"
 	"strconv"
 	"strings"
@@ -152,4 +153,55 @@ func TestSender_Send(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SMTP DATA payload")
 	}
+}
+
+// #2139: non-ASCII (cs/ru) subjects must be RFC 2047 encoded-words so mail
+// clients render them correctly instead of garbling raw UTF-8.
+func TestBuildMIMEMessage_EncodesNonASCIISubject(t *testing.T) {
+	c := qt.New(t)
+	raw := string(buildMIMEMessage(sender.Message{
+		From:    "Inventario <noreply@example.com>",
+		To:      "user@example.com",
+		Subject: "Подтвердите свою учётную запись Inventario",
+		Text:    "text",
+		HTML:    "<p>html</p>",
+	}))
+	subject := mimeHeaderValue(c, raw, "Subject")
+	// Raw Cyrillic must NOT appear unencoded in the header...
+	c.Assert(strings.Contains(subject, "Подтвердите"), qt.IsFalse)
+	c.Assert(strings.HasPrefix(subject, "=?utf-8?"), qt.IsTrue)
+	// ...and the encoded-word decodes back to the original.
+	decoded, err := new(mime.WordDecoder).DecodeHeader(subject)
+	c.Assert(err, qt.IsNil)
+	c.Assert(decoded, qt.Equals, "Подтвердите свою учётную запись Inventario")
+}
+
+// #2139: a CRLF embedded in a header value (e.g. a commodity name in the
+// Subject) must not be able to inject additional headers.
+func TestBuildMIMEMessage_StripsHeaderInjection(t *testing.T) {
+	c := qt.New(t)
+	raw := string(buildMIMEMessage(sender.Message{
+		From:    "noreply@example.com",
+		To:      "user@example.com",
+		Subject: "Hello\r\nBcc: attacker@example.com",
+		Text:    "text",
+		HTML:    "<p>html</p>",
+	}))
+	// No injected Bcc header line is created.
+	c.Assert(strings.Contains(raw, "\r\nBcc:"), qt.IsFalse)
+	// Everything collapses onto the single Subject line.
+	c.Assert(mimeHeaderValue(c, raw, "Subject"), qt.Equals, "HelloBcc: attacker@example.com")
+}
+
+// mimeHeaderValue returns the value of the first `key: ` header in the
+// header block (everything before the first blank line) of a raw message.
+func mimeHeaderValue(c *qt.C, raw, key string) string {
+	headers, _, ok := strings.Cut(raw, "\r\n\r\n")
+	c.Assert(ok, qt.IsTrue)
+	for line := range strings.SplitSeq(headers, "\r\n") {
+		if v, found := strings.CutPrefix(line, key+": "); found {
+			return v
+		}
+	}
+	return ""
 }

--- a/go/email/providers/smtp/sender_test.go
+++ b/go/email/providers/smtp/sender_test.go
@@ -169,7 +169,7 @@ func TestBuildMIMEMessage_EncodesNonASCIISubject(t *testing.T) {
 	subject := mimeHeaderValue(c, raw, "Subject")
 	// Raw Cyrillic must NOT appear unencoded in the header...
 	c.Assert(subject, qt.Not(qt.Contains), "Подтвердите")
-	c.Assert(strings.HasPrefix(subject, "=?utf-8?"), qt.IsTrue)
+	c.Assert(strings.HasPrefix(subject, "=?UTF-8?"), qt.IsTrue)
 	// ...and the encoded-word decodes back to the original.
 	decoded, err := new(mime.WordDecoder).DecodeHeader(subject)
 	c.Assert(err, qt.IsNil)
@@ -191,6 +191,30 @@ func TestBuildMIMEMessage_StripsHeaderInjection(t *testing.T) {
 	c.Assert(raw, qt.Not(qt.Contains), "\r\nBcc:")
 	// Everything collapses onto the single Subject line.
 	c.Assert(mimeHeaderValue(c, raw, "Subject"), qt.Equals, "HelloBcc: attacker@example.com")
+}
+
+// #2139: encodeSubject leaves pure-ASCII subjects untouched and, for
+// non-ASCII, emits the shorter of Q- and B-encoding (base64 wins for heavy
+// Cyrillic — roughly halving the Russian subject, leaving more headroom
+// under the RFC 5322 line limit, see #2142). The result must round-trip.
+func TestEncodeSubject_PicksCompactEncoding(t *testing.T) {
+	c := qt.New(t)
+	// Pure ASCII passes through untouched (en subjects stay readable).
+	c.Assert(encodeSubject("Welcome to Inventario"), qt.Equals, "Welcome to Inventario")
+
+	for _, s := range []string{
+		"Ověřte svůj účet Inventario",                // Czech
+		"Подтвердите свою учётную запись Inventario", // Russian
+	} {
+		got := encodeSubject(s)
+		c.Assert(strings.HasPrefix(got, "=?UTF-8?"), qt.IsTrue, qt.Commentf("got %q", got))
+		decoded, err := new(mime.WordDecoder).DecodeHeader(got)
+		c.Assert(err, qt.IsNil)
+		c.Assert(decoded, qt.Equals, s)
+		// The shorter of Q-/B-encoding was chosen.
+		c.Assert(len(got) <= len(mime.QEncoding.Encode("UTF-8", s)), qt.IsTrue)
+		c.Assert(len(got) <= len(mime.BEncoding.Encode("UTF-8", s)), qt.IsTrue)
+	}
 }
 
 // mimeHeaderValue returns the value of the first `key: ` header in the

--- a/go/email/providers/smtp/sender_test.go
+++ b/go/email/providers/smtp/sender_test.go
@@ -168,7 +168,7 @@ func TestBuildMIMEMessage_EncodesNonASCIISubject(t *testing.T) {
 	}))
 	subject := mimeHeaderValue(c, raw, "Subject")
 	// Raw Cyrillic must NOT appear unencoded in the header...
-	c.Assert(strings.Contains(subject, "Подтвердите"), qt.IsFalse)
+	c.Assert(subject, qt.Not(qt.Contains), "Подтвердите")
 	c.Assert(strings.HasPrefix(subject, "=?utf-8?"), qt.IsTrue)
 	// ...and the encoded-word decodes back to the original.
 	decoded, err := new(mime.WordDecoder).DecodeHeader(subject)
@@ -188,7 +188,7 @@ func TestBuildMIMEMessage_StripsHeaderInjection(t *testing.T) {
 		HTML:    "<p>html</p>",
 	}))
 	// No injected Bcc header line is created.
-	c.Assert(strings.Contains(raw, "\r\nBcc:"), qt.IsFalse)
+	c.Assert(raw, qt.Not(qt.Contains), "\r\nBcc:")
 	// Everything collapses onto the single Subject line.
 	c.Assert(mimeHeaderValue(c, raw, "Subject"), qt.Equals, "HelloBcc: attacker@example.com")
 }


### PR DESCRIPTION
## What

Closes #2139. Surfaced by the security review of #2136 (now merged).

`buildMIMEMessage` (`go/email/providers/smtp/sender.go`) wrote header values raw, which caused two problems:

1. **Header injection (security, Low).** A CRLF in a user-influenced value — most directly a commodity name concatenated into the loan-reminder `Subject` — could inject additional headers / body.
2. **Garbled non-ASCII subjects (correctness).** #2136 localized subjects to cs/ru (e.g. `Подтвердите свою учётную запись`, `Ověřte svůj účet`). Raw UTF-8 in a `Subject` header violates RFC 2047 and renders garbled in some clients.

## Fix

- **Strip CR/LF** from `From` / `To` / `Subject` / `Reply-To` (`sanitizeHeader`).
- **RFC 2047-encode the Subject** via `mime.QEncoding.Encode("utf-8", …)`: pure-ASCII subjects pass through unchanged (en stays readable), non-ASCII become encoded-words — which also can't carry a raw CRLF, so the Subject injection vector is closed in the same move.

## Tests

- `TestBuildMIMEMessage_EncodesNonASCIISubject` — a Cyrillic subject becomes a `=?utf-8?…?=` encoded-word and decodes back to the original.
- `TestBuildMIMEMessage_StripsHeaderInjection` — a `Subject` containing `\r\nBcc: …` creates no new header line.

`go build`/`vet`, `go test ./email/...`, golangci-lint (0 issues) all green.