### PR TITLE
fix(security): alpha-readiness hardening — tenant-scope, upload cap, session-wipe, TOTP replay, RLS CI

### DIFF
--- a/.github/workflows/go-test-postgres.yml
+++ b/.github/workflows/go-test-postgres.yml
@@ -202,7 +202,7 @@ jobs:
           POSTGRES_TEST_DSN: "postgres://inventario_test:test_password@localhost:5432/inventario_test?sslmode=disable"
         run: |
           go test -v -race -p 1 \
-            -run 'TestUserIsolation|TestAPIUserIsolation' \
+            -run 'TestUserIsolation|TestAPIUserIsolation|TestAPIAuthentication' \
             -skip 'LoadTesting|PerformanceRegression' \
             ./integration/...
         working-directory: go

--- a/.github/workflows/go-test-postgres.yml
+++ b/.github/workflows/go-test-postgres.yml
@@ -181,6 +181,32 @@ jobs:
         run: go test -v -race -tags integration ./debug/seeddata/...
         working-directory: go
 
+      - name: Run cross-tenant / RLS isolation tests
+        # #2094: these negative user/tenant/group-isolation suites previously
+        # never ran in CI — go-test.yml self-skips with no DSN, and this
+        # workflow only ran ./registry/postgres and two named INB tests. They
+        # exercise the real RLS-enforced path through the user-aware registries
+        # (the registry/postgres suite uses a superuser connection that
+        # bypasses RLS), so a tenant/group isolation regression would otherwise
+        # merge green. Serial (-p 1): the ./integration tests share one
+        # database and are not isolation-safe when run together (see #1953).
+        # The load/perf variants (TestUserIsolation_LoadTesting /
+        # _PerformanceRegression) are excluded — they are not negative-isolation
+        # coverage and would add CI flake/runtime. NOTE: the raw-SQL
+        # ./models -tags integration RLS tests are intentionally NOT wired here
+        # — they assert the pre-groups, tenant-only policy shape (INSERT
+        # locations with no group_id, set_tenant_context) and need their own
+        # modernization; the registry-level ./integration suite supersedes that
+        # coverage.
+        env:
+          POSTGRES_TEST_DSN: "postgres://inventario_test:test_password@localhost:5432/inventario_test?sslmode=disable"
+        run: |
+          go test -v -race -p 1 \
+            -run 'TestUserIsolation|TestAPIUserIsolation' \
+            -skip 'LoadTesting|PerformanceRegression' \
+            ./integration/...
+        working-directory: go
+
       - name: Run backup .inb integration tests
         # #534: the signed .inb round trips on a REAL database — the only
         # Go-level coverage of two postgres-only behaviours the in-memory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ Support for multiple database backends via DSN:
 
 ### File Storage Configuration
 - `--upload-location` - Supports file://, s3://, azblob://, gs://
-- `--max-upload-bytes` - Maximum size of a single uploaded file in bytes (default 1 GiB / `1073741824`); `0` or negative disables the limit
+- `--max-upload-bytes` - Maximum size of a single uploaded file in bytes (default 1 GiB / `1073741824`); a negative value disables the limit
 
 ## Testing Strategy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ Support for multiple database backends via DSN:
 
 ### File Storage Configuration
 - `--upload-location` - Supports file://, s3://, azblob://, gs://
+- `--max-upload-bytes` - Maximum size of a single uploaded file in bytes (default 1 GiB / `1073741824`); `0` or negative disables the limit
 
 ## Testing Strategy
 

--- a/e2e/tests/mfa.spec.ts
+++ b/e2e/tests/mfa.spec.ts
@@ -171,11 +171,12 @@ test.describe.serial('MFA / TOTP enrollment + login', () => {
 
     const { secret, backupCodes } = await enrollMFA(page);
 
-    // Logout and re-login with a TOTP code. We regenerate the code here
-    // rather than reusing the enrollment-verify code: even though the
-    // server allows ±1 step and accepts in-window replay, deriving the
-    // code at the moment of the call is robust to test slowness and
-    // doesn't depend on the previous code being in the same window.
+    // Logout and re-login with a fresh TOTP code. This consumes the current
+    // 30s time-step: the #2124 replay guard records last_used_step, so any
+    // later TOTP in the same window would now be rejected as a replay. That
+    // is why the recover + disable steps below use backup codes instead of a
+    // second same-window TOTP (the pre-#2124 spec relied on in-window TOTP
+    // replay being accepted, which it no longer is — RFC 6238 §5.2).
     await logout(page);
     const totp1 = generateTOTP(secret);
     await loginWithMFA(page, { totp: totp1 }, true);
@@ -189,11 +190,11 @@ test.describe.serial('MFA / TOTP enrollment + login', () => {
     await logout(page);
     await loginWithMFA(page, { backup: backup0 }, false);
 
-    // Recover by typing a fresh TOTP code so the session can continue.
-    await page.fill('[data-testid="mfa-code-input"]', '');
-    await page.click('[data-testid="mfa-toggle-mode"]');
-    const totp2 = generateTOTP(secret);
-    await page.fill('[data-testid="mfa-code-input"]', totp2);
+    // Recover so the session can continue. The login TOTP above already
+    // consumed this 30s step, so a same-window TOTP would be rejected by the
+    // #2124 replay guard — recover with a fresh, unused backup code. The
+    // challenge is already in backup-code mode from the rejected replay above.
+    await page.fill('[data-testid="mfa-code-input"]', backupCodes[1]);
     await Promise.all([
       page.waitForResponse(
         (r) => r.url().includes('/auth/login/mfa') && r.status() === 200,
@@ -204,9 +205,10 @@ test.describe.serial('MFA / TOTP enrollment + login', () => {
       timeout: 15000,
     });
 
-    // Cleanup so a re-run doesn't trip over leftover state.
-    const totpForDisable = generateTOTP(secret);
-    await disableMFA(page, { totp: totpForDisable });
+    // Cleanup so a re-run doesn't trip over leftover state. Disable with
+    // another fresh backup code (a same-window TOTP would again be rejected
+    // by the replay guard).
+    await disableMFA(page, { backup: backupCodes[2] });
   });
 });
 

--- a/frontend/src/features/sessions/api.ts
+++ b/frontend/src/features/sessions/api.ts
@@ -22,15 +22,17 @@ export async function revokeSession(id: string): Promise<void> {
 }
 
 // revokeAllOtherSessions revokes every session except the one identified
-// as current. We must pass the id of the row the list endpoint flagged
-// `is_current: true` via `?keep_id=` because the refresh cookie is
-// path-scoped to /api/v1/auth — it isn't sent on /users/me/sessions, so
-// the BE can't fall back to hashing the cookie here. Pass `undefined`
-// to deliberately wipe every session (e.g. for "log out everywhere"
-// surfaces yet to be built).
-export async function revokeAllOtherSessions(keepSessionId?: string): Promise<void> {
-  const path = keepSessionId
-    ? `/users/me/sessions?keep_id=${encodeURIComponent(keepSessionId)}`
-    : "/users/me/sessions"
-  await http.del(path, { skipGroupRewrite: true })
+// as current. The id of the row the list endpoint flagged
+// `is_current: true` is REQUIRED and passed via `?keep_id=`: the refresh
+// cookie is path-scoped to /api/v1/auth — it isn't sent on
+// /users/me/sessions, so the BE can't fall back to hashing the cookie
+// here. The parameter is intentionally non-optional so a call site that
+// can't resolve a current session (e.g. an impersonation session, which
+// has no is_current row) is a compile error rather than a silent
+// wipe-all (#2126). The matching BE guard refuses an empty keep_id with
+// 400, but we never send that shape from here.
+export async function revokeAllOtherSessions(keepSessionId: string): Promise<void> {
+  await http.del(`/users/me/sessions?keep_id=${encodeURIComponent(keepSessionId)}`, {
+    skipGroupRewrite: true,
+  })
 }

--- a/frontend/src/features/sessions/hooks.ts
+++ b/frontend/src/features/sessions/hooks.ts
@@ -24,13 +24,15 @@ export function useRevokeSession() {
 }
 
 // useRevokeAllOtherSessions takes the id of the session the caller wants
-// to keep — typically the row the list endpoint marked `is_current: true`.
-// The BE needs an explicit signal here because the refresh cookie is
-// scoped to /api/v1/auth and isn't sent on /users/me/sessions.
+// to keep — the row the list endpoint marked `is_current: true`. The id
+// is REQUIRED because the BE needs an explicit signal (the refresh cookie
+// is scoped to /api/v1/auth and isn't sent on /users/me/sessions) and
+// because firing without one would wipe every session. The caller MUST
+// only mutate when an is_current row exists (#2126).
 export function useRevokeAllOtherSessions() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (keepSessionId: string | undefined) => revokeAllOtherSessions(keepSessionId),
+    mutationFn: (keepSessionId: string) => revokeAllOtherSessions(keepSessionId),
     onSuccess: () => qc.invalidateQueries({ queryKey: sessionsKeys.all }),
   })
 }

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -50,6 +50,13 @@ export function SessionsPage() {
   // is still undefined and the deps trip exhaustive-deps.
   const sessions = useMemo(() => sessionsQuery.data?.sessions ?? [], [sessionsQuery.data?.sessions])
   const otherSessionsCount = useMemo(() => sessions.filter((s) => !s.is_current).length, [sessions])
+  // The "Sign out all other sessions" CTA must keep the current session
+  // alive, so it only makes sense when exactly that row is identifiable.
+  // During impersonation no row is flagged `is_current` (the imp session
+  // has no rti claim and no tenant refresh cookie), and firing the CTA
+  // would resolve a keep-id of undefined and wipe EVERY session for the
+  // impersonated user (#2126). Gate the CTA on a current session existing.
+  const hasCurrentSession = useMemo(() => sessions.some((s) => s.is_current), [sessions])
 
   const confirmRevoke = (session: SessionView) => setPendingRevoke(session)
 
@@ -76,6 +83,14 @@ export function SessionsPage() {
     // isn't sent on this route (issue surfaced via the
     // sessions-and-login-history e2e cleanup branch).
     const currentSessionId = sessions.find((s) => s.is_current)?.id
+    // No current session means we can't keep one alive — firing here
+    // would wipe EVERY session (#2126, the impersonation case). The CTA
+    // is already hidden in this state; this is the belt-and-suspenders
+    // no-op so the mutation is never called with an undefined keep-id.
+    if (!currentSessionId) {
+      setRevokeAllOpen(false)
+      return
+    }
     revokeAllOthersMutation.mutate(currentSessionId, {
       onSuccess: () => {
         toast.success(t("settings:sessions.toasts.allRevoked"))
@@ -106,7 +121,7 @@ export function SessionsPage() {
           }
         />
 
-        {otherSessionsCount > 0 ? (
+        {otherSessionsCount > 0 && hasCurrentSession ? (
           <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
             <div className="flex items-center gap-3">
               <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">

--- a/frontend/src/pages/__tests__/SessionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SessionsPage.test.tsx
@@ -143,4 +143,20 @@ describe("<SessionsPage />", () => {
     await user.click(await screen.findByTestId("sessions-confirm-revoke-all-btn"))
     await waitFor(() => expect(capturedQuery).toBe("?keep_id=rt-current"))
   })
+
+  it("hides the revoke-all CTA when no session is flagged current (impersonation)", async () => {
+    // During impersonation the imp session has no rti claim and no tenant
+    // refresh cookie, so the BE flags no row `is_current`. The CTA would
+    // resolve a keep-id of undefined and wipe EVERY session, so it must be
+    // hidden even though "other" sessions exist (#2126).
+    const noCurrent = baseTokens.map((t) => ({ ...t, is_current: false }))
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/sessions"), () => HttpResponse.json({ sessions: noCurrent }))
+    )
+    renderPage()
+    await screen.findByTestId("sessions-list")
+    expect(screen.queryByTestId("sessions-revoke-all-btn")).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7937,6 +7937,15 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
                     };
                 };
+                /** @description Request Entity Too Large */
+                413: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
                 /** @description Unprocessable Entity */
                 422: {
                     headers: {
@@ -8005,6 +8014,15 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.UploadResponse"];
+                    };
+                };
+                /** @description Request Entity Too Large */
+                413: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Unprocessable Entity */
@@ -9349,7 +9367,8 @@ export type paths = {
          * @description Revoke every refresh token for the authenticated user except the one identified as current.
          *     Resolution order for the "current" session: `?keep_id=<id>` (recommended; the id the FE
          *     rendered with `is_current: true` on GET /users/me/sessions) → access token `rti` claim
-         *     → refresh cookie hash. When none matches, every session is revoked.
+         *     → refresh cookie hash. When none matches, the request is rejected with 400 (the current
+         *     session can't be identified, so revoking everything is refused).
          */
         delete: {
             parameters: {
@@ -9365,6 +9384,15 @@ export type paths = {
             responses: {
                 /** @description No Content */
                 204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Bad Request */
+                400: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -160,9 +160,16 @@ func parsePagination(pageStr, perPageStr string) (page, perPage int) {
 }
 
 type Params struct {
-	FactorySet                 *registry.FactorySet
-	EntityService              *services.EntityService
-	UploadLocation             string
+	FactorySet     *registry.FactorySet
+	EntityService  *services.EntityService
+	UploadLocation string
+	// MaxUploadBytes caps the size of a single uploaded file (issue #2101).
+	// The multipart upload path streams the body straight to the blob store
+	// and bypasses the 1 MiB request-body cap in security_middleware.go, so
+	// without this limit one user can exhaust the shared storage. Threaded
+	// into uploadsAPI and enforced in saveFile via http.MaxBytesReader; a
+	// breach renders 413. <= 0 disables the cap (back-compat / opt-out).
+	MaxUploadBytes             int64
 	DebugInfo                  *debug.Info
 	StartTime                  time.Time
 	JWTSecret                  []byte                             // JWT secret for user authentication

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -1036,8 +1036,12 @@ func (api *AuthAPI) applyDefaultGroupUpdate(w http.ResponseWriter, r *http.Reque
 		return true
 	}
 	// Membership check: the user can only pick a group they actually belong to.
-	// GroupMembershipRegistry is tenant-scoped, so a cross-tenant id is rejected
-	// by the same lookup.
+	// GetByGroupAndUser runs in RLS-bypass (service) mode and filters only by
+	// group_id, so the returned row can in principle belong to another tenant.
+	// We therefore compare tenants explicitly below (mirroring the OAuth-callback
+	// guards elsewhere in this file) instead of trusting the lookup to be
+	// tenant-scoped — never let a client move users.default_group_id onto another
+	// tenant's group via the client-controlled DefaultGroupID (#2112).
 	membership, err := api.groupMembershipRegistry.GetByGroupAndUser(r.Context(), *req.DefaultGroupID, user.ID)
 	switch {
 	case errors.Is(err, registry.ErrNotFound):
@@ -1062,6 +1066,16 @@ func (api *AuthAPI) applyDefaultGroupUpdate(w http.ResponseWriter, r *http.Reque
 		slog.Error("Group membership lookup returned nil membership without an error",
 			"user_id", user.ID, "group_id", *req.DefaultGroupID)
 		http.Error(w, "Failed to verify group membership", http.StatusInternalServerError)
+		return false
+	case membership.TenantID != user.TenantID:
+		// The membership row exists but belongs to a different tenant. Treat it
+		// exactly like "not a member": the user has no legitimate way to know a
+		// foreign tenant's group id, and a leaked/duplicated membership row must
+		// not become a cross-tenant write of default_group_id (#2112).
+		slog.Warn("User tried to set default_group_id for a group in another tenant",
+			"user_id", user.ID, "group_id", *req.DefaultGroupID,
+			"user_tenant_id", user.TenantID, "membership_tenant_id", membership.TenantID)
+		http.Error(w, "default_group_id must reference a group you belong to", http.StatusBadRequest)
 		return false
 	}
 	groupID := *req.DefaultGroupID

--- a/go/apiserver/auth_mfa.go
+++ b/go/apiserver/auth_mfa.go
@@ -306,10 +306,18 @@ func (api *AuthAPI) handleMFAVerify(w http.ResponseWriter, r *http.Request) {
 	// Enrollment intentionally does NOT advance last_used_step. The replay
 	// guard (#2124) covers the endpoints where replaying a sniffed code has
 	// value — login, disable, regenerate — which share the monotonic step
-	// ledger. Enrollment is a one-time, already-authenticated, idempotent
-	// pending→enabled confirmation; bumping it here would only block a
-	// legitimate user who manages MFA within the same 30s step, for no real
-	// gain (an enrollment-code→login replay also needs the victim's password).
+	// ledger via MarkTOTPStepUsedAtomic. Enrollment is a one-time,
+	// already-authenticated, idempotent pending→enabled confirmation, and
+	// bumping it would block a legitimate user who manages MFA within the same
+	// 30s step. Accepted residual: because enrollment leaves last_used_step at
+	// 0, a sniffed enrollment code could, within its ~60s validity, be
+	// replayed at /auth/mfa/regenerate-backup-codes — the one consume path
+	// that needs no password, only the already-authenticated session — to
+	// rotate the user's backup codes. That requires an attacker who has BOTH
+	// hijacked the session AND sniffed the enrollment code in the same window
+	// (an already-compromised account), so we accept it rather than break the
+	// legitimate same-step manage flow. login + disable are unaffected (both
+	// gate on the password / step-1 mfa_token).
 	row.BackupCodesHashed = models.ValuerSlice[string](hashes)
 	if _, err := api.mfaRegistry.Update(r.Context(), *row); err != nil {
 		slog.Error("MFA verify: persist row failed", "user_id", user.ID, "error", err)
@@ -482,13 +490,13 @@ func (api *AuthAPI) handleMFARegenerateBackupCodes(w http.ResponseWriter, r *htt
 		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
 		return
 	}
-	// Carry the step + timestamp the CAS just committed into the in-memory
-	// row so the full-row Update below doesn't revert last_used_step /
-	// last_used_at to their pre-CAS values.
-	row.BackupCodesHashed = models.ValuerSlice[string](hashes)
-	row.LastUsedAt = &now
-	row.LastUsedStep = matchedStep
-	if _, err := api.mfaRegistry.Update(r.Context(), *row); err != nil {
+	// Persist ONLY the new backup codes via a targeted update. last_used_step
+	// and last_used_at were already committed by the CAS above; a full-row
+	// Update here would re-write last_used_step from this handler's loaded
+	// value and could clobber a concurrent login that advanced the step in
+	// the meantime, re-opening the replay window (#2124). Keeping the CAS the
+	// sole writer of last_used_step preserves monotonicity.
+	if err := api.mfaRegistry.UpdateBackupCodes(r.Context(), user.TenantID, user.ID, hashes, now); err != nil {
 		slog.Error("MFA regenerate: persist failed", "user_id", user.ID, "error", err)
 		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
 		return

--- a/go/apiserver/auth_mfa.go
+++ b/go/apiserver/auth_mfa.go
@@ -278,7 +278,7 @@ func (api *AuthAPI) handleMFAVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ok, err := api.mfaService.VerifyTOTP(*row, req.Code)
+	_, ok, err := api.mfaService.VerifyTOTPStep(*row, req.Code)
 	if err != nil {
 		slog.Error("MFA verify: totp check failed", "user_id", user.ID, "error", err)
 		http.Error(w, "Failed to verify MFA", http.StatusInternalServerError)
@@ -303,6 +303,13 @@ func (api *AuthAPI) handleMFAVerify(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 	row.EnabledAt = &now
 	row.LastUsedAt = &now
+	// Enrollment intentionally does NOT advance last_used_step. The replay
+	// guard (#2124) covers the endpoints where replaying a sniffed code has
+	// value — login, disable, regenerate — which share the monotonic step
+	// ledger. Enrollment is a one-time, already-authenticated, idempotent
+	// pending→enabled confirmation; bumping it here would only block a
+	// legitimate user who manages MFA within the same 30s step, for no real
+	// gain (an enrollment-code→login replay also needs the victim's password).
 	row.BackupCodesHashed = models.ValuerSlice[string](hashes)
 	if _, err := api.mfaRegistry.Update(r.Context(), *row); err != nil {
 		slog.Error("MFA verify: persist row failed", "user_id", user.ID, "error", err)
@@ -438,7 +445,7 @@ func (api *AuthAPI) handleMFARegenerateBackupCodes(w http.ResponseWriter, r *htt
 		return
 	}
 
-	ok, err := api.mfaService.VerifyTOTP(*row, req.Code)
+	matchedStep, ok, err := api.mfaService.VerifyTOTPStep(*row, req.Code)
 	if err != nil {
 		slog.Error("MFA regenerate: totp check failed", "user_id", user.ID, "error", err)
 		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
@@ -450,6 +457,24 @@ func (api *AuthAPI) handleMFARegenerateBackupCodes(w http.ResponseWriter, r *htt
 		http.Error(w, "Invalid code", http.StatusUnauthorized)
 		return
 	}
+	// Replay guard (RFC 6238 §5.2, #2124): commit the matched step via the
+	// atomic CAS before regenerating codes. A replayed TOTP (step already
+	// consumed) loses the CAS and is rejected like a wrong code, so a
+	// stolen session can't reuse a single sniffed code to churn the
+	// legitimate user's backup codes.
+	now := time.Now()
+	won, casErr := api.mfaRegistry.MarkTOTPStepUsedAtomic(r.Context(), user.TenantID, user.ID, matchedStep, now)
+	if casErr != nil {
+		slog.Error("MFA regenerate: totp step CAS failed", "user_id", user.ID, "error", casErr)
+		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
+		return
+	}
+	if !won {
+		errMsg := "replayed code during regenerate-backup-codes"
+		api.logAuth(r.Context(), "mfa_regenerate", &user.ID, &user.TenantID, false, r, &errMsg)
+		http.Error(w, "Invalid code", http.StatusUnauthorized)
+		return
+	}
 
 	plain, hashes, err := api.mfaService.GenerateBackupCodes(services.MFABackupCodeCount)
 	if err != nil {
@@ -457,13 +482,12 @@ func (api *AuthAPI) handleMFARegenerateBackupCodes(w http.ResponseWriter, r *htt
 		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
 		return
 	}
-	// Update LastUsedAt alongside the new code set — the user just
-	// proved possession of a valid TOTP, so the row's "last used"
-	// timestamp should reflect that, matching how loginMFA / mfa_disable
-	// touch LastUsedAt on every successful verification (#1645 review).
-	now := time.Now()
+	// Carry the step + timestamp the CAS just committed into the in-memory
+	// row so the full-row Update below doesn't revert last_used_step /
+	// last_used_at to their pre-CAS values.
 	row.BackupCodesHashed = models.ValuerSlice[string](hashes)
 	row.LastUsedAt = &now
+	row.LastUsedStep = matchedStep
 	if _, err := api.mfaRegistry.Update(r.Context(), *row); err != nil {
 		slog.Error("MFA regenerate: persist failed", "user_id", user.ID, "error", err)
 		http.Error(w, "Failed to regenerate codes", http.StatusInternalServerError)
@@ -637,19 +661,17 @@ func (api *AuthAPI) issueMFALoginSession(w http.ResponseWriter, r *http.Request,
 func (api *AuthAPI) consumeAnyMFACode(r *http.Request, user *models.User, row *models.UserMFASecret, totpCode, backupCode, action string) bool {
 	ctx := r.Context()
 	if totpCode != "" {
-		ok, err := api.mfaService.VerifyTOTP(*row, totpCode)
-		if err != nil {
-			slog.Error("MFA verify path: totp check failed", "user_id", user.ID, "error", err)
+		consumed, abort := api.consumeTOTPCode(ctx, user, row, totpCode)
+		if abort {
 			return false
 		}
-		if ok {
-			now := time.Now()
-			row.LastUsedAt = &now
-			if _, err := api.mfaRegistry.Update(ctx, *row); err != nil {
-				slog.Error("MFA verify path: persist last_used_at failed", "user_id", user.ID, "error", err)
-			}
+		if consumed {
 			return true
 		}
+		// A non-consumed TOTP — a wrong code, or a replayed code that lost
+		// the CAS — falls through to the backup-code path and the shared
+		// invalid-code audit/return below, so a replay is logged and
+		// rejected identically to a wrong code.
 	}
 	if backupCode != "" {
 		matcher := api.mfaService.MatchBackupCode(backupCode)
@@ -669,6 +691,32 @@ func (api *AuthAPI) consumeAnyMFACode(r *http.Request, user *models.User, row *m
 	errMsg := "invalid mfa code"
 	api.logAuth(ctx, action, &user.ID, &user.TenantID, false, r, &errMsg)
 	return false
+}
+
+// consumeTOTPCode verifies totpCode against the user's secret and, on a
+// match, commits the matched time-step via the atomic replay-guard CAS
+// (#2124, RFC 6238 §5.2). consumed is true only when the code both
+// verified and WON the CAS — i.e. a fresh, non-replayed code. A replayed
+// code (the same step re-presented within the ±1-step skew window, or a
+// concurrent racer with an identical code) loses the CAS and returns
+// consumed=false. abort is true on an already-logged infrastructure
+// failure, signalling the caller to reject the request. The CAS also
+// stamps last_used_at, so no separate bump is needed.
+func (api *AuthAPI) consumeTOTPCode(ctx context.Context, user *models.User, row *models.UserMFASecret, totpCode string) (consumed, abort bool) {
+	matchedStep, ok, err := api.mfaService.VerifyTOTPStep(*row, totpCode)
+	if err != nil {
+		slog.Error("MFA verify path: totp check failed", "user_id", user.ID, "error", err)
+		return false, true
+	}
+	if !ok {
+		return false, false
+	}
+	won, casErr := api.mfaRegistry.MarkTOTPStepUsedAtomic(ctx, user.TenantID, user.ID, matchedStep, time.Now())
+	if casErr != nil {
+		slog.Error("MFA verify path: totp step CAS failed", "user_id", user.ID, "error", casErr)
+		return false, true
+	}
+	return won, false
 }
 
 // issueMFAToken signs a short-lived JWT that authorizes the step-2

--- a/go/apiserver/auth_mfa.go
+++ b/go/apiserver/auth_mfa.go
@@ -277,6 +277,18 @@ func (api *AuthAPI) handleMFAVerify(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to verify MFA", http.StatusInternalServerError)
 		return
 	}
+	if row.IsEnabled() {
+		// /auth/mfa/verify is strictly the one-time pending→enabled
+		// confirmation. The comment below explains why this path deliberately
+		// does NOT bump last_used_step — which is only safe while the endpoint
+		// can't run on an already-enabled row. Without this guard a still-valid
+		// code could be re-submitted here post-enrollment to re-issue backup
+		// codes AND skip the replay ledger, leaving that code replayable at
+		// login/disable/regenerate. Re-enrollment goes through setup (409);
+		// rotating codes goes through regenerate (which DOES CAS). (#2124)
+		http.Error(w, "MFA already enabled", http.StatusBadRequest)
+		return
+	}
 
 	_, ok, err := api.mfaService.VerifyTOTPStep(*row, req.Code)
 	if err != nil {

--- a/go/apiserver/auth_mfa_test.go
+++ b/go/apiserver/auth_mfa_test.go
@@ -270,8 +270,10 @@ func TestMFA_Login_TOTPReplayRejectedWithinWindow(t *testing.T) {
 	f := newAuthMFAFixture(t)
 	enrollAndEnable(t, f)
 
-	row, _ := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
-	plain, _ := decryptOf(t, f, row.SecretEncrypted)
+	row, err := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
+	c.Assert(err, qt.IsNil)
+	plain, err := decryptOf(t, f, row.SecretEncrypted)
+	c.Assert(err, qt.IsNil)
 	code, err := totp.GenerateCodeCustom(plain, time.Now(), totp.ValidateOpts{
 		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
 	})
@@ -463,8 +465,10 @@ func TestMFA_Regenerate_RejectsReplayedCode(t *testing.T) {
 	f := newAuthMFAFixture(t)
 	enrollAndEnable(t, f)
 
-	row, _ := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
-	plain, _ := decryptOf(t, f, row.SecretEncrypted)
+	row, err := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
+	c.Assert(err, qt.IsNil)
+	plain, err := decryptOf(t, f, row.SecretEncrypted)
+	c.Assert(err, qt.IsNil)
 	code, err := totp.GenerateCodeCustom(plain, time.Now(), totp.ValidateOpts{
 		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
 	})

--- a/go/apiserver/auth_mfa_test.go
+++ b/go/apiserver/auth_mfa_test.go
@@ -453,6 +453,31 @@ func mintMFAToken(t *testing.T, secret []byte, claims jwt.MapClaims) string {
 	return signed
 }
 
+// TestMFA_Regenerate_RejectsReplayedCode locks in the #2124 guard on the
+// regenerate path: a TOTP code accepted once at /auth/mfa/regenerate-backup-
+// codes cannot be replayed within its skew window. The targeted backup-code
+// update (not a full-row Update) keeps MarkTOTPStepUsedAtomic the sole writer
+// of last_used_step, so the second attempt loses the CAS and is rejected.
+func TestMFA_Regenerate_RejectsReplayedCode(t *testing.T) {
+	c := qt.New(t)
+	f := newAuthMFAFixture(t)
+	enrollAndEnable(t, f)
+
+	row, _ := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
+	plain, _ := decryptOf(t, f, row.SecretEncrypted)
+	code, err := totp.GenerateCodeCustom(plain, time.Now(), totp.ValidateOpts{
+		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	first := f.call(t, "POST", "/auth/mfa/regenerate-backup-codes", apiserver.MFAVerifyRequest{Code: code})
+	c.Assert(first.Code, qt.Equals, http.StatusOK)
+
+	// Same code, same time-step → replay rejected like a wrong code.
+	replay := f.call(t, "POST", "/auth/mfa/regenerate-backup-codes", apiserver.MFAVerifyRequest{Code: code})
+	c.Assert(replay.Code, qt.Equals, http.StatusUnauthorized)
+}
+
 func TestMFA_Regenerate_RequiresCurrentCode(t *testing.T) {
 	c := qt.New(t)
 	f := newAuthMFAFixture(t)

--- a/go/apiserver/auth_mfa_test.go
+++ b/go/apiserver/auth_mfa_test.go
@@ -260,6 +260,49 @@ func TestMFA_Login_ChallengeAndComplete(t *testing.T) {
 	c.Assert(loginResp.User.Email, qt.Equals, f.user.Email)
 }
 
+// TestMFA_Login_TOTPReplayRejectedWithinWindow locks in the #2124 guarantee:
+// a TOTP code consumed at /auth/login/mfa cannot be replayed at the same
+// endpoint within its ±1-step validity window, even though the code is still
+// arithmetically valid. Without the last_used_step CAS the second attempt
+// would mint a second session from a single sniffed code.
+func TestMFA_Login_TOTPReplayRejectedWithinWindow(t *testing.T) {
+	c := qt.New(t)
+	f := newAuthMFAFixture(t)
+	enrollAndEnable(t, f)
+
+	row, _ := f.mfaRegistry.GetByUser(context.Background(), f.user.TenantID, f.user.ID)
+	plain, _ := decryptOf(t, f, row.SecretEncrypted)
+	code, err := totp.GenerateCodeCustom(plain, time.Now(), totp.ValidateOpts{
+		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Each step-2 needs a fresh step-1 mfa_token; the TOTP code stays the same.
+	challenge := func() string {
+		step1 := f.call(t, "POST", "/auth/login", map[string]string{
+			"email":    f.user.Email,
+			"password": mfaTestPassword,
+		})
+		c.Assert(step1.Code, qt.Equals, http.StatusOK)
+		var ch apiserver.LoginMFARequiredResponse
+		c.Assert(json.NewDecoder(step1.Body).Decode(&ch), qt.IsNil)
+		return ch.MFAToken
+	}
+
+	first := f.call(t, "POST", "/auth/login/mfa", apiserver.LoginMFARequest{
+		MFAToken: challenge(),
+		TOTPCode: code,
+	})
+	c.Assert(first.Code, qt.Equals, http.StatusOK)
+
+	// Same code, same time-step → the replay is rejected like a wrong code.
+	replay := f.call(t, "POST", "/auth/login/mfa", apiserver.LoginMFARequest{
+		MFAToken: challenge(),
+		TOTPCode: code,
+	})
+	c.Assert(replay.Code, qt.Equals, http.StatusUnauthorized)
+}
+
 func TestMFA_Login_BackupCodeSingleUse(t *testing.T) {
 	c := qt.New(t)
 	f := newAuthMFAFixture(t)

--- a/go/apiserver/backoffice_auth_mfa.go
+++ b/go/apiserver/backoffice_auth_mfa.go
@@ -118,30 +118,24 @@ func (api *BackofficeAuthAPI) loginMFA(w http.ResponseWriter, r *http.Request) {
 }
 
 // consumeBackofficeMFACode tries the TOTP code first, then the backup
-// code. On a successful TOTP match it bumps LastUsedAt (the backup-code
-// path does that internally via ConsumeBackupCodeAtomic). Returns true
-// iff one of the codes verified.
+// code. On a successful TOTP match it commits the matched time-step via
+// MarkTOTPStepUsedAtomic — the replay guard (#2124) — which also stamps
+// LastUsedAt; a replayed code loses that CAS and is treated as invalid.
+// The backup-code path stamps LastUsedAt internally via
+// ConsumeBackupCodeAtomic. Returns true iff one of the codes verified.
 func (api *BackofficeAuthAPI) consumeBackofficeMFACode(r *http.Request, user *models.BackofficeUser, row *models.BackofficeUserMFASecret, totpCode, backupCode string) bool {
 	ctx := r.Context()
 	if totpCode != "" {
-		// Reuse the existing MFAService verifier — the TOTP secret
-		// envelope is identical to the tenant-plane secret, so the
-		// same VerifyTOTP path applies. We construct a thin shim
-		// models.UserMFASecret that carries just the encrypted secret;
-		// the verifier only reads SecretEncrypted.
-		shim := models.UserMFASecret{SecretEncrypted: row.SecretEncrypted}
-		ok, err := api.mfaService.VerifyTOTP(shim, totpCode)
-		if err != nil {
-			slog.Error("Backoffice login_mfa: TOTP verify failed", "user_id", user.ID, "error", err)
+		consumed, abort := api.consumeBackofficeTOTPCode(ctx, user, row, totpCode)
+		if abort {
 			return false
 		}
-		if ok {
-			if bumpErr := api.mfaRegistry.BumpLastUsedAt(ctx, user.ID, time.Now()); bumpErr != nil {
-				// Non-fatal — the user still authenticated.
-				slog.Error("Backoffice login_mfa: failed to bump last_used_at", "user_id", user.ID, "error", bumpErr)
-			}
+		if consumed {
 			return true
 		}
+		// A non-consumed TOTP — a wrong code, or a replayed code that lost
+		// the CAS — falls through to the backup-code path and the caller's
+		// invalid-code handling (audit + 401).
 	}
 	if backupCode != "" {
 		matcher := api.mfaService.MatchBackupCode(backupCode)
@@ -157,6 +151,33 @@ func (api *BackofficeAuthAPI) consumeBackofficeMFACode(r *http.Request, user *mo
 		}
 	}
 	return false
+}
+
+// consumeBackofficeTOTPCode verifies totpCode against the back-office
+// user's secret and, on a match, commits the matched time-step via the
+// atomic replay-guard CAS (#2124). The back-office TOTP secret envelope is
+// identical to the tenant-plane secret, so it reuses MFAService via a thin
+// models.UserMFASecret shim carrying only the encrypted secret (the
+// verifier reads SecretEncrypted only). consumed is true only when the code
+// both verified and WON the CAS; a replayed code loses the CAS and returns
+// consumed=false. abort is true on an already-logged infrastructure
+// failure. The CAS also stamps last_used_at.
+func (api *BackofficeAuthAPI) consumeBackofficeTOTPCode(ctx context.Context, user *models.BackofficeUser, row *models.BackofficeUserMFASecret, totpCode string) (consumed, abort bool) {
+	shim := models.UserMFASecret{SecretEncrypted: row.SecretEncrypted}
+	matchedStep, ok, err := api.mfaService.VerifyTOTPStep(shim, totpCode)
+	if err != nil {
+		slog.Error("Backoffice login_mfa: TOTP verify failed", "user_id", user.ID, "error", err)
+		return false, true
+	}
+	if !ok {
+		return false, false
+	}
+	won, casErr := api.mfaRegistry.MarkTOTPStepUsedAtomic(ctx, user.ID, matchedStep, time.Now())
+	if casErr != nil {
+		slog.Error("Backoffice login_mfa: TOTP step CAS failed", "user_id", user.ID, "error", casErr)
+		return false, true
+	}
+	return won, false
 }
 
 // afterBackofficeMFASuccess clears the step-2 failed-attempt counter

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -233,6 +233,19 @@ func unprocessableEntityError(w http.ResponseWriter, r *http.Request, err error)
 	return render.Render(w, r, jsonapi.NewErrors(NewUnprocessableEntityError(err)))
 }
 
+// requestEntityTooLargeError renders a 413 Payload Too Large with the
+// JSON:API envelope. Used by the upload path (#2101) when a streamed file
+// exceeds the configured per-file size cap.
+func requestEntityTooLargeError(w http.ResponseWriter, r *http.Request, err error) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusRequestEntityTooLarge,
+		StatusText:     "Request Entity Too Large",
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}
+
 // adminBlockGuardError maps the two #1747 admin-block guard sentinels
 // (self-block, admin-on-admin without force) to their 422 + code wire
 // shape. Extracted so the toJSONAPIError switch stays under the

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -79,6 +79,11 @@ type uploadsAPI struct {
 	fileSigningService *services.FileSigningService
 	factorySet         *registry.FactorySet
 	thumbnailConfig    services.ThumbnailGenerationConfig
+	// maxUploadBytes caps a single uploaded file (issue #2101). When > 0 the
+	// streaming save wraps the source in http.MaxBytesReader so the TOTAL
+	// bytes (MIME sniff + body) are bounded; a breach surfaces as 413. <= 0
+	// disables the cap (back-compat / opt-out).
+	maxUploadBytes int64
 }
 
 // @Summary Upload a file
@@ -89,6 +94,7 @@ type uploadsAPI struct {
 // @Param groupSlug path string true "Group slug"
 // @Param file formData file true "File to upload"
 // @Success 201 {object} jsonapi.FileResponse "Created"
+// @Failure 413 {object} jsonapi.Errors "Request Entity Too Large"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
 // @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /g/{groupSlug}/uploads/file [post]
@@ -209,6 +215,7 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 // @Param groupSlug path string true "Group slug"
 // @Param file formData file true "Signed .inb backup file to upload"
 // @Success 200 {object} jsonapi.UploadResponse "OK"
+// @Failure 413 {object} jsonapi.Errors "Request Entity Too Large"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
 // @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /g/{groupSlug}/uploads/restores [post]
@@ -281,11 +288,23 @@ type uploadHTTPError struct {
 func (e *uploadHTTPError) Error() string { return e.err.Error() }
 func (e *uploadHTTPError) Unwrap() error { return e.err }
 
+// isUploadHTTPError reports whether err already carries a chosen HTTP status
+// (an *uploadHTTPError). Used by saveOnePart to pass such errors through
+// untouched rather than rewrapping them into a generic 500.
+func isUploadHTTPError(err error) bool {
+	_, ok := errors.AsType[*uploadHTTPError](err)
+	return ok
+}
+
 func renderUploadError(w http.ResponseWriter, r *http.Request, err error) {
 	if ue, ok := errors.AsType[*uploadHTTPError](err); ok {
 		switch ue.status {
 		case http.StatusUnprocessableEntity:
 			unprocessableEntityError(w, r, ue.err)
+		case http.StatusRequestEntityTooLarge:
+			// #2101: the streamed file exceeded the configured per-file
+			// size cap. Render 413 rather than the generic 500.
+			requestEntityTooLargeError(w, r, ue.err)
 		default:
 			internalServerError(w, r, ue.err)
 		}
@@ -359,6 +378,11 @@ func (api *uploadsAPI) saveOnePart(ctx context.Context, part io.Reader, basename
 			status: http.StatusUnprocessableEntity,
 			err:    errxtrace.Wrap("unsupported content type", err),
 		}
+	case isUploadHTTPError(err):
+		// saveFile already chose the HTTP status (e.g. the #2101 oversize
+		// 413). Pass it through untouched so the dispatch renders that
+		// status instead of rewrapping it into a generic 500.
+		return uploadedFile{}, err
 	case err != nil:
 		return uploadedFile{}, errxtrace.Wrap("unable to save file", err)
 	}
@@ -382,10 +406,29 @@ func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Rea
 		err = errors.Join(err, fw.Close())
 	}()
 
-	wrappedSrc := mimekit.NewMIMEReader(src, allowedContentTypes)
+	// Cap the source before MIME sniffing so the TOTAL bytes read (the
+	// sniff window + the streamed body) are bounded (issue #2101). The
+	// multipart upload path bypasses the 1 MiB request-body cap in
+	// security_middleware.go, so without this an unbounded io.Copy lets one
+	// user fill the shared blob store. A nil ResponseWriter is supported —
+	// MaxBytesReader only uses it to set the "request too large" connection
+	// flag, which is irrelevant here; on overflow Read returns a
+	// *http.MaxBytesError that we map to 413 below.
+	bodySrc := src
+	if api.maxUploadBytes > 0 {
+		bodySrc = http.MaxBytesReader(nil, io.NopCloser(src), api.maxUploadBytes)
+	}
+
+	wrappedSrc := mimekit.NewMIMEReader(bodySrc, allowedContentTypes)
 
 	written, err := io.Copy(fw, wrappedSrc)
 	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			return "", 0, &uploadHTTPError{
+				status: http.StatusRequestEntityTooLarge,
+				err:    errxtrace.Classify(errx.NewDisplayable("uploaded file exceeds the maximum allowed size")),
+			}
+		}
 		return "", 0, errxtrace.Wrap("failed when saving the file", err, errx.Attrs("filename", filename))
 	}
 
@@ -399,6 +442,7 @@ func Uploads(params Params) func(r chi.Router) {
 		fileSigningService: services.NewFileSigningService(params.FileSigningKey, params.FileURLExpiration),
 		factorySet:         params.FactorySet,
 		thumbnailConfig:    params.ThumbnailConfig,
+		maxUploadBytes:     params.MaxUploadBytes,
 	}
 
 	// Create concurrent upload service for upload limiting

--- a/go/apiserver/uploads_test.go
+++ b/go/apiserver/uploads_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
 
 	"github.com/denisvmedia/inventario/apiserver"
 	"github.com/denisvmedia/inventario/internal/backupsign"
@@ -211,4 +212,104 @@ func TestUploads_file_tenantPrefixedKey(t *testing.T) {
 	c.Assert(strings.HasPrefix(resp.Attributes.OriginalPath, "t/"+testUser.TenantID+"/files/"), qt.IsTrue,
 		qt.Commentf("OriginalPath %q must live under the authenticated tenant's namespace", resp.Attributes.OriginalPath))
 	c.Assert(resp.Attributes.Path, qt.Not(qt.Contains), "t/")
+}
+
+// TestUploads_file_tooLarge is the #2101 regression test: a POST
+// /uploads/file whose body exceeds the configured per-file size cap is
+// rejected with 413 and persists no FileEntity row. Without the cap the
+// streaming io.Copy is unbounded and one user can fill the shared blob
+// store; the multipart path also bypasses the 1 MiB request-body cap in
+// security_middleware.go, so the limit must live in the save path itself.
+func TestUploads_file_tooLarge(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	// Tiny cap so a small payload trips it. 0/negative would disable the
+	// cap entirely (the back-compat opt-out), so we set a positive value.
+	params.MaxUploadBytes = 16
+
+	// Count the seeded file rows up-front so the assertion proves the
+	// rejected upload added nothing, regardless of the harness fixtures.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	registrySet := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	before := must.Must(registrySet.FileRegistry.Count(ctx))
+
+	// Build a JPEG larger than the cap so the MIME sniff passes but the
+	// total streamed bytes exceed MaxUploadBytes.
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for x := range 64 {
+		for y := range 64 {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 128, A: 255})
+		}
+	}
+	var imgBuf bytes.Buffer
+	c.Assert(jpeg.Encode(&imgBuf, img, &jpeg.Options{Quality: 90}), qt.IsNil)
+	c.Assert(imgBuf.Len() > 16, qt.IsTrue, qt.Commentf("payload %d bytes must exceed the 16-byte cap", imgBuf.Len()))
+
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	h := CreateFormFileMIME("file", "big-photo.jpg", "image/jpeg")
+	fileWriter, err := bodyWriter.CreatePart(h)
+	c.Assert(err, qt.IsNil)
+	_, err = fileWriter.Write(imgBuf.Bytes())
+	c.Assert(err, qt.IsNil)
+	contentType := bodyWriter.FormDataContentType()
+	bodyWriter.Close()
+
+	req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/file", bodyBuf)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", contentType)
+	addTestUserAuthHeader(req, testUser.ID)
+
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusRequestEntityTooLarge, qt.Commentf("body=%s", rr.Body.String()))
+
+	// No FileEntity row was persisted for the rejected upload.
+	after := must.Must(registrySet.FileRegistry.Count(ctx))
+	c.Assert(after, qt.Equals, before)
+}
+
+// TestUploads_file_capDisabled proves the #2101 opt-out: with
+// MaxUploadBytes <= 0 a large file is accepted (201), so the cap is purely
+// additive and existing deployments that don't set the knob keep working.
+func TestUploads_file_capDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	params.MaxUploadBytes = 0 // disabled
+
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for x := range 64 {
+		for y := range 64 {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 200, A: 255})
+		}
+	}
+	var imgBuf bytes.Buffer
+	c.Assert(jpeg.Encode(&imgBuf, img, &jpeg.Options{Quality: 90}), qt.IsNil)
+
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	h := CreateFormFileMIME("file", "ok-photo.jpg", "image/jpeg")
+	fileWriter, err := bodyWriter.CreatePart(h)
+	c.Assert(err, qt.IsNil)
+	_, err = fileWriter.Write(imgBuf.Bytes())
+	c.Assert(err, qt.IsNil)
+	contentType := bodyWriter.FormDataContentType()
+	bodyWriter.Close()
+
+	req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/file", bodyBuf)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", contentType)
+	addTestUserAuthHeader(req, testUser.ID)
+
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated, qt.Commentf("body=%s", rr.Body.String()))
 }

--- a/go/apiserver/users_me.go
+++ b/go/apiserver/users_me.go
@@ -211,19 +211,24 @@ func (api *usersMeAPI) revokeSession(w http.ResponseWriter, r *http.Request) {
 //  3. The refresh cookie's hash, retained for tokens minted before
 //     "rti" landed or for callers that scope their cookie wider.
 //
-// When none of the three produces a match we still revoke everything —
-// the caller has already proven they hold a valid access token, so
-// wiping all sessions is the correct outcome for that (legitimate but
-// rare) shape.
+// When none of the three produces a match we REFUSE the wipe with 400
+// rather than revoking everything (#2126). The endpoint's contract is
+// "revoke all OTHER sessions" — keep the current one — and an inability
+// to identify the current session means we can't honour that contract.
+// The only caller that lands here is an impersonation session (no rti,
+// no tenant refresh cookie); revoking all would leave the impersonated
+// user with no surviving session.
 // @Summary Revoke all other sessions
 // @Description Revoke every refresh token for the authenticated user except the one identified as current.
 // @Description Resolution order for the "current" session: `?keep_id=<id>` (recommended; the id the FE
 // @Description rendered with `is_current: true` on GET /users/me/sessions) → access token `rti` claim
-// @Description → refresh cookie hash. When none matches, every session is revoked.
+// @Description → refresh cookie hash. When none matches, the request is rejected with 400 (the current
+// @Description session can't be identified, so revoking everything is refused).
 // @Tags users-me
 // @Produce json
 // @Param keep_id query string false "Session id to keep alive (the is_current row from GET /users/me/sessions). Optional — when omitted the BE falls back to the access token's rti claim, then the refresh cookie."
 // @Success 204 {string} string "No Content"
+// @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Router /users/me/sessions [delete]
 func (api *usersMeAPI) revokeAllOtherSessions(w http.ResponseWriter, r *http.Request) {
@@ -263,6 +268,20 @@ func (api *usersMeAPI) revokeAllOtherSessions(w http.ResponseWriter, r *http.Req
 				keepID = rt.ID
 			}
 		}
+	}
+
+	// #2126: refuse the full wipe when the current session can't be
+	// identified. This endpoint's contract is "revoke all OTHER sessions"
+	// (keep the current one); if none of ?keep_id=, the access token's rti
+	// claim, or the refresh cookie resolves a row to keep, revoking
+	// everything is never the intent. The only shape that reaches here with
+	// keepID == "" is an impersonation session (no rti, no tenant refresh
+	// cookie) — a normal logged-in user always resolves a keepID via rti or
+	// cookie. Calling RevokeAllExceptID with "" would nuke every refresh
+	// token for the impersonated user, leaving no survivor.
+	if keepID == "" {
+		http.Error(w, "cannot determine the current session to keep; refusing to revoke all sessions", http.StatusBadRequest)
+		return
 	}
 
 	if err := api.refreshTokenRegistry.RevokeAllExceptID(r.Context(), user.ID, keepID); err != nil {

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -353,6 +353,46 @@ func TestUsersMeAPI(t *testing.T) {
 		c.Assert(wiped.RevokedAt, qt.IsNotNil)
 	})
 
+	// DELETE /sessions — #2126: when the current session can't be
+	// identified (no ?keep_id=, no rti claim, no refresh cookie — exactly
+	// the impersonation shape), the handler MUST refuse the wipe with 400
+	// and leave every session intact rather than revoking all of them.
+	t.Run("revoke_all_other_sessions_refuses_when_no_keep_id", func(t *testing.T) {
+		c := qt.New(t)
+		a, err := rtReg.Create(c.Context(), models.RefreshToken{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+				TenantID: user.TenantID, UserID: user.ID,
+			},
+			TokenHash: "no-keep-a-hash",
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		c.Assert(err, qt.IsNil)
+		b, err := rtReg.Create(c.Context(), models.RefreshToken{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+				TenantID: user.TenantID, UserID: user.ID,
+			},
+			TokenHash: "no-keep-b-hash",
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		c.Assert(err, qt.IsNil)
+
+		// NO ?keep_id=, NO refresh cookie, NO rti claim — the shared `r`
+		// router injects the user but never sets a JWT claim, mirroring an
+		// impersonation session.
+		req := httptest.NewRequest(http.MethodDelete, "/users/me/sessions", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusBadRequest)
+
+		// Both sessions survive — nothing was revoked.
+		storedA, err := rtReg.Get(c.Context(), a.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(storedA.RevokedAt, qt.IsNil)
+		storedB, err := rtReg.Get(c.Context(), b.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(storedB.RevokedAt, qt.IsNil)
+	})
+
 	// GET /login-history — newest first, optional failed-count
 	// hint populated.
 	t.Run("login_history_newest_first", func(t *testing.T) {

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -16,8 +16,15 @@ import (
 // example --workers-only / --workers-exclude) live on the same struct but are
 // only bound to CLI flags on the subcommand that consumes them.
 type Config struct {
-	Addr                             string `yaml:"addr" env:"ADDR" env-default:":3333"`
-	UploadLocation                   string `yaml:"upload_location" env:"UPLOAD_LOCATION" env-default:""`
+	Addr           string `yaml:"addr" env:"ADDR" env-default:":3333"`
+	UploadLocation string `yaml:"upload_location" env:"UPLOAD_LOCATION" env-default:""`
+	// MaxUploadBytes caps the size of a single uploaded file (issue #2101).
+	// The multipart upload path streams the body straight to the blob store
+	// and deliberately bypasses the 1 MiB request-body cap, so without this
+	// limit one user can fill the shared storage with an unbounded upload.
+	// Default 1 GiB (1<<30) is generous enough for normal photo/video/PDF
+	// uploads; 0 (or negative) disables the cap for back-compat / opt-out.
+	MaxUploadBytes                   int64  `yaml:"max_upload_bytes" env:"MAX_UPLOAD_BYTES" env-default:"1073741824"`
 	MaxConcurrentExports             int    `yaml:"max_concurrent_exports" env:"MAX_CONCURRENT_EXPORTS" env-default:"0"`
 	MaxConcurrentImports             int    `yaml:"max_concurrent_imports" env:"MAX_CONCURRENT_IMPORTS" env-default:"0"`
 	MaxConcurrentRestores            int    `yaml:"max_concurrent_restores" env:"MAX_CONCURRENT_RESTORES" env-default:"0"`

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -22,8 +22,10 @@ type Config struct {
 	// The multipart upload path streams the body straight to the blob store
 	// and deliberately bypasses the 1 MiB request-body cap, so without this
 	// limit one user can fill the shared storage with an unbounded upload.
-	// Default 1 GiB (1<<30) is generous enough for normal photo/video/PDF
-	// uploads; 0 (or negative) disables the cap for back-compat / opt-out.
+	// Default 1 GiB (1<<30), backfilled in SetDefaults so it holds even when a
+	// YAML config omits the key (cleanenv applies env-default only on env
+	// reads, not YAML). A NEGATIVE value disables the cap (explicit opt-out);
+	// 0 / omitted falls back to the default.
 	MaxUploadBytes                   int64  `yaml:"max_upload_bytes" env:"MAX_UPLOAD_BYTES" env-default:"1073741824"`
 	MaxConcurrentExports             int    `yaml:"max_concurrent_exports" env:"MAX_CONCURRENT_EXPORTS" env-default:"0"`
 	MaxConcurrentImports             int    `yaml:"max_concurrent_imports" env:"MAX_CONCURRENT_IMPORTS" env-default:"0"`
@@ -266,6 +268,15 @@ func (c *Config) SetDefaults() {
 	}
 	if c.AIVisionProvider == "" {
 		c.AIVisionProvider = "none"
+	}
+	if c.MaxUploadBytes == 0 {
+		// #2101: cleanenv applies the env-default (1 GiB) only when reading
+		// env vars, not when a YAML config omits the key — same reason
+		// ImpersonationTTL / AIVisionTimeout are backfilled above. Leaving it
+		// at 0 would silently DISABLE the upload cap on a YAML-configured
+		// deploy. A negative value (explicit opt-out) is preserved as "no
+		// limit"; only the zero/omitted case defaults.
+		c.MaxUploadBytes = 1 << 30
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/config_test.go
+++ b/go/cmd/inventario/run/bootstrap/config_test.go
@@ -26,6 +26,38 @@ func TestConfigSetDefaults_DefaultsNegativeEmailQueueMaxRetries(t *testing.T) {
 	c.Assert(cfg.EmailQueueMaxRetries, qt.Equals, 5)
 }
 
+func TestConfigSetDefaults_MaxUploadBytesDefaultsAppliedWhenZero(t *testing.T) {
+	c := qt.New(t)
+
+	// #2101: a YAML config that omits max_upload_bytes leaves the field at 0
+	// (cleanenv applies env-default only on env reads), which would silently
+	// disable the upload cap. SetDefaults must backfill the 1 GiB default.
+	cfg := bootstrap.Config{MaxUploadBytes: 0}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.MaxUploadBytes, qt.Equals, int64(1<<30))
+}
+
+func TestConfigSetDefaults_MaxUploadBytesPreservesExplicitPositive(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := bootstrap.Config{MaxUploadBytes: 5 << 20}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.MaxUploadBytes, qt.Equals, int64(5<<20))
+}
+
+func TestConfigSetDefaults_MaxUploadBytesPreservesNegativeAsDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	// A negative value is the explicit opt-out ("no limit") — the enforcement
+	// path treats <= 0 as "no cap", so it must NOT be backfilled.
+	cfg := bootstrap.Config{MaxUploadBytes: -1}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.MaxUploadBytes, qt.Equals, int64(-1))
+}
+
 func TestConfigSetDefaults_GlobalRateLimitDefaultsApplied(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -18,6 +18,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags := cmd.PersistentFlags()
 	flags.StringVar(&cfg.Addr, "addr", cfg.Addr, "Bind address for the server")
 	flags.StringVar(&cfg.UploadLocation, "upload-location", cfg.UploadLocation, "Location for the uploaded files")
+	flags.Int64Var(&cfg.MaxUploadBytes, "max-upload-bytes", cfg.MaxUploadBytes, "Maximum size of a single uploaded file in bytes; 0 or negative disables the limit")
 	shared.RegisterDatabaseFlags(cmd, dbConfig)
 	flags.IntVar(&cfg.MaxConcurrentExports, "max-concurrent-exports", cfg.MaxConcurrentExports, "Maximum number of concurrent export processes")
 	flags.IntVar(&cfg.MaxConcurrentImports, "max-concurrent-imports", cfg.MaxConcurrentImports, "Maximum number of concurrent import processes")

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -18,7 +18,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags := cmd.PersistentFlags()
 	flags.StringVar(&cfg.Addr, "addr", cfg.Addr, "Bind address for the server")
 	flags.StringVar(&cfg.UploadLocation, "upload-location", cfg.UploadLocation, "Location for the uploaded files")
-	flags.Int64Var(&cfg.MaxUploadBytes, "max-upload-bytes", cfg.MaxUploadBytes, "Maximum size of a single uploaded file in bytes; 0 or negative disables the limit")
+	flags.Int64Var(&cfg.MaxUploadBytes, "max-upload-bytes", cfg.MaxUploadBytes, "Maximum size of a single uploaded file in bytes (default 1 GiB); a negative value disables the limit")
 	shared.RegisterDatabaseFlags(cmd, dbConfig)
 	flags.IntVar(&cfg.MaxConcurrentExports, "max-concurrent-exports", cfg.MaxConcurrentExports, "Maximum number of concurrent export processes")
 	flags.IntVar(&cfg.MaxConcurrentImports, "max-concurrent-imports", cfg.MaxConcurrentImports, "Maximum number of concurrent import processes")

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -62,6 +62,7 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 	params := apiserver.Params{
 		FactorySet:     factorySet,
 		UploadLocation: cfg.UploadLocation,
+		MaxUploadBytes: cfg.MaxUploadBytes,
 		StartTime:      time.Now(),
 	}
 	params.EntityService = services.NewEntityService(factorySet, params.UploadLocation)

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6987,6 +6987,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/jsonapi.FileResponse"
                         }
                     },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -7036,6 +7042,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.UploadResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "422": {
@@ -8093,7 +8105,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nResolution order for the \"current\" session: ` + "`" + `?keep_id=\u003cid\u003e` + "`" + ` (recommended; the id the FE\nrendered with ` + "`" + `is_current: true` + "`" + ` on GET /users/me/sessions) → access token ` + "`" + `rti` + "`" + ` claim\n→ refresh cookie hash. When none matches, every session is revoked.",
+                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nResolution order for the \"current\" session: ` + "`" + `?keep_id=\u003cid\u003e` + "`" + ` (recommended; the id the FE\nrendered with ` + "`" + `is_current: true` + "`" + ` on GET /users/me/sessions) → access token ` + "`" + `rti` + "`" + ` claim\n→ refresh cookie hash. When none matches, the request is rejected with 400 (the current\nsession can't be identified, so revoking everything is refused).",
                 "produces": [
                     "application/json"
                 ],
@@ -8112,6 +8124,12 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "string"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6980,6 +6980,12 @@
                             "$ref": "#/definitions/jsonapi.FileResponse"
                         }
                     },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -7029,6 +7035,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.UploadResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "422": {
@@ -8086,7 +8098,7 @@
                 }
             },
             "delete": {
-                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nResolution order for the \"current\" session: `?keep_id=\u003cid\u003e` (recommended; the id the FE\nrendered with `is_current: true` on GET /users/me/sessions) → access token `rti` claim\n→ refresh cookie hash. When none matches, every session is revoked.",
+                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nResolution order for the \"current\" session: `?keep_id=\u003cid\u003e` (recommended; the id the FE\nrendered with `is_current: true` on GET /users/me/sessions) → access token `rti` claim\n→ refresh cookie hash. When none matches, the request is rejected with 400 (the current\nsession can't be identified, so revoking everything is refused).",
                 "produces": [
                     "application/json"
                 ],
@@ -8105,6 +8117,12 @@
                 "responses": {
                     "204": {
                         "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "string"
                         }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -9356,6 +9356,10 @@ paths:
           description: Created
           schema:
             $ref: '#/definitions/jsonapi.FileResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
         "422":
           description: Unprocessable Entity
           schema:
@@ -9390,6 +9394,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/jsonapi.UploadResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
         "422":
           description: Unprocessable Entity
           schema:
@@ -10114,7 +10122,8 @@ paths:
         Revoke every refresh token for the authenticated user except the one identified as current.
         Resolution order for the "current" session: `?keep_id=<id>` (recommended; the id the FE
         rendered with `is_current: true` on GET /users/me/sessions) → access token `rti` claim
-        → refresh cookie hash. When none matches, every session is revoked.
+        → refresh cookie hash. When none matches, the request is rejected with 400 (the current
+        session can't be identified, so revoking everything is refused).
       parameters:
       - description: Session id to keep alive (the is_current row from GET /users/me/sessions).
           Optional — when omitted the BE falls back to the access token's rti claim,
@@ -10127,6 +10136,10 @@ paths:
       responses:
         "204":
           description: No Content
+          schema:
+            type: string
+        "400":
+          description: Bad Request
           schema:
             type: string
         "401":

--- a/go/integration/api_user_isolation_test.go
+++ b/go/integration/api_user_isolation_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/apiserver"
-	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/debug"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
@@ -27,16 +25,24 @@ import (
 	"github.com/denisvmedia/inventario/services"
 )
 
-// setupTestAPIServer creates a test API server with authentication
-func setupTestAPIServer(t *testing.T) (server *httptest.Server, user1 *models.User, user2 *models.User, jwtSecret string, registrySet *registry.Set, cleanup func()) {
-	c := qt.New(t)
-	dsn := os.Getenv("POSTGRES_TEST_DSN")
-	if dsn == "" {
-		t.Skip("POSTGRES_TEST_DSN environment variable not set")
-		return nil, nil, nil, "", nil, nil
-	}
+// apiIsolationFixture bundles one user with their own group (incl. an
+// owner-membership row so GroupSlugResolverMiddleware admits them) and a ready
+// WithUser+WithGroup context for registry-level seeding.
+type apiIsolationFixture struct {
+	user  *models.User
+	group *models.LocationGroup
+	ctx   context.Context
+}
 
-	// Set up fresh database with bootstrap and migrations
+// setupTestAPIServer creates a test API server with authentication, a real
+// tenant, and TWO users — each owning a SEPARATE group. The modern data routes
+// are group-scoped (/api/v1/g/{groupSlug}/...) and gated by group membership, so
+// isolation is exercised by routing each user through their own group's slug.
+func setupTestAPIServer(t *testing.T) (server *httptest.Server, fs *registry.FactorySet, user1, user2 apiIsolationFixture, jwtSecret string, cleanup func()) {
+	t.Helper()
+	c := qt.New(t)
+	dsn := mustTestDSN(t)
+
 	err := setupFreshDatabase(dsn)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to setup fresh database"))
 
@@ -46,52 +52,34 @@ func setupTestAPIServer(t *testing.T) (server *httptest.Server, user1 *models.Us
 
 	jwtSecretBytes := []byte("test-secret-32-bytes-minimum-length")
 
-	// Create test tenant first with unique identifiers
-	testTenant := models.Tenant{
-		Name:   "Test Tenant API " + time.Now().Format("20060102-150405"),
-		Slug:   "test-tenant-api-" + fmt.Sprintf("%d", time.Now().UnixNano()%1000000),
+	// Real tenant.
+	uniq := fmt.Sprintf("%d", time.Now().UnixNano())
+	createdTenant := must.Must(factorySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Test Tenant API " + uniq,
+		Slug:   "test-tenant-api-" + uniq,
 		Status: models.TenantStatusActive,
-	}
-	createdTenant, err := factorySet.TenantRegistry.Create(context.Background(), testTenant)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create test tenant"))
-	testTenantID := createdTenant.ID
+	}))
 
-	// Create test users with unique identifiers
-	timestamp := fmt.Sprintf("%d", time.Now().UnixNano()%1000000)
-	user1Model := models.User{
-		TenantAwareEntityID: models.TenantAwareEntityID{
-			TenantID: testTenantID,
-		},
-		Email:    "user1-" + timestamp + "@api-test.com",
-		Name:     "API Test User 1",
-		IsActive: true,
-	}
-	err = user1Model.SetPassword("TestPassword123")
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password for user1"))
+	// Two users in the same tenant.
+	createdUser1 := mustCreateAPIUser(c, factorySet, createdTenant.ID, "user1-"+uniq+"@api-test.com")
+	createdUser2 := mustCreateAPIUser(c, factorySet, createdTenant.ID, "user2-"+uniq+"@api-test.com")
 
-	user2Model := models.User{
-		TenantAwareEntityID: models.TenantAwareEntityID{
-			TenantID: testTenantID,
-		},
-		Email:    "user2-" + timestamp + "@api-test.com",
-		Name:     "API Test User 2",
-		IsActive: true,
-	}
-	err = user2Model.SetPassword("TestPassword123")
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password for user2"))
+	// GroupService wired exactly like the production apiserver so CreateGroup
+	// both creates the group AND inserts the creator's owner-membership row
+	// (required by GroupSlugResolverMiddleware).
+	groupService := services.NewGroupService(
+		factorySet.LocationGroupRegistry,
+		factorySet.GroupMembershipRegistry,
+		factorySet.GroupInviteRegistry,
+	)
+	groupService.SetUserRegistry(factorySet.UserRegistry)
 
-	createdUser1, err := factorySet.UserRegistry.Create(context.Background(), user1Model)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user1"))
+	group1 := must.Must(groupService.CreateGroup(context.Background(), createdTenant.ID, createdUser1.ID, "User1 Group", "", "", models.Currency("USD")))
+	group2 := must.Must(groupService.CreateGroup(context.Background(), createdTenant.ID, createdUser2.ID, "User2 Group", "", "", models.Currency("USD")))
 
-	createdUser2, err := factorySet.UserRegistry.Create(context.Background(), user2Model)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user2"))
+	user1 = apiIsolationFixture{user: createdUser1, group: group1, ctx: userGroupContext(context.Background(), createdUser1, group1)}
+	user2 = apiIsolationFixture{user: createdUser2, group: group2, ctx: userGroupContext(context.Background(), createdUser2, group2)}
 
-	// Create user-aware registry set for user1 (for testing purposes)
-	ctx := appctx.WithUser(context.Background(), createdUser1)
-	registrySet, err = factorySet.CreateUserRegistrySet(ctx)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user registry set"))
-
-	// Create API server
 	params := apiserver.Params{
 		FactorySet:     factorySet,
 		EntityService:  services.NewEntityService(factorySet, "file://uploads?memfs=1&create_dir=1"),
@@ -111,21 +99,38 @@ func setupTestAPIServer(t *testing.T) (server *httptest.Server, user1 *models.Us
 		}
 	}
 
-	return server, createdUser1, createdUser2, string(jwtSecretBytes), registrySet, cleanup
+	return server, factorySet, user1, user2, string(jwtSecretBytes), cleanup
 }
 
-// generateJWTToken creates a JWT token for the given user
+// mustCreateAPIUser creates an active user with a known password in the tenant.
+func mustCreateAPIUser(c *qt.C, fs *registry.FactorySet, tenantID, email string) *models.User {
+	c.Helper()
+	u := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               email,
+		Name:                "API Test User",
+		IsActive:            true,
+	}
+	c.Assert(u.SetPassword("TestPassword123"), qt.IsNil)
+	return must.Must(fs.UserRegistry.Create(context.Background(), u))
+}
+
+// generateJWTToken creates a JWT access token for the given user. The
+// token_type=access claim is mandatory post-#1778 — the JWT middleware rejects
+// any token without it as "invalid token type".
 func generateJWTToken(user *models.User, jwtSecret string) (string, error) {
-	expiresAt := time.Now().Add(24 * time.Hour)
+	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": user.ID,
-		"exp":     expiresAt.Unix(),
+		"user_id":    user.ID,
+		"token_type": "access",
+		"exp":        now.Add(24 * time.Hour).Unix(),
+		"iat":        now.Unix(),
 	})
 
 	return token.SignedString([]byte(jwtSecret))
 }
 
-// makeAuthenticatedRequest makes an HTTP request with JWT authentication
+// makeAuthenticatedRequest makes an HTTP request with JWT authentication.
 func makeAuthenticatedRequest(method, url string, body []byte, token string) (*http.Response, error) {
 	var req *http.Request
 	var err error
@@ -135,7 +140,6 @@ func makeAuthenticatedRequest(method, url string, body []byte, token string) (*h
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 	}
-
 	if err != nil {
 		return nil, err
 	}
@@ -147,79 +151,65 @@ func makeAuthenticatedRequest(method, url string, body []byte, token string) (*h
 	return client.Do(req)
 }
 
-// TestAPIUserIsolation_Commodities tests commodity API isolation
-func TestAPIUserIsolation_Commodities(t *testing.T) {
-	server, createdUser1, createdUser2, jwtSecret, registrySet, cleanup := setupTestAPIServer(t)
-	defer cleanup()
-
-	// Get the variables we need
-	testTenantID := createdUser1.TenantID // Both users have the same tenant ID
-
-	// Group currency now lives on the location group, which setupTestAPIServer
-	// already stamps with GroupCurrency=USD — so nothing to do here.
-
-	// Create a location and area for the commodity
-	location := models.Location{
+// seedAPILocationArea creates a location + area in the fixture's group via the
+// user-aware registry, returning the area id the HTTP commodity-create needs.
+func seedAPILocationArea(c *qt.C, fs *registry.FactorySet, f apiIsolationFixture) string {
+	c.Helper()
+	locReg := must.Must(fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	loc := must.Must(locReg.Create(f.ctx, models.Location{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			TenantID:        testTenantID,
-			CreatedByUserID: createdUser1.ID,
+			TenantID:        f.user.TenantID,
+			GroupID:         f.group.ID,
+			CreatedByUserID: f.user.ID,
 		},
 		Name:    "Test Location",
 		Address: "123 Test St",
-	}
-
-	// Create location using user1's context
-	ctx := appctx.WithUser(context.Background(), createdUser1)
-	createdLocation, err := registrySet.LocationRegistry.Create(ctx, location)
-	if err != nil {
-		t.Fatalf("Failed to create location: %v", err)
-	}
-
-	area := models.Area{
+	}))
+	areaReg := must.Must(fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	area := must.Must(areaReg.Create(f.ctx, models.Area{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			TenantID:        testTenantID,
-			CreatedByUserID: createdUser1.ID,
+			TenantID:        f.user.TenantID,
+			GroupID:         f.group.ID,
+			CreatedByUserID: f.user.ID,
 		},
 		Name:       "Test Area",
-		LocationID: createdLocation.ID,
-	}
-	createdArea, err := registrySet.AreaRegistry.Create(ctx, area)
-	if err != nil {
-		t.Fatalf("Failed to create area: %v", err)
-	}
+		LocationID: loc.ID,
+	}))
+	return area.ID
+}
 
-	// Generate tokens for both users
-	token1, err := generateJWTToken(createdUser1, jwtSecret)
-	if err != nil {
-		t.Fatalf("Failed to generate token for user1: %v", err)
-	}
+// commoditiesPath builds the group-scoped commodities collection URL.
+func commoditiesPath(serverURL, groupSlug string) string {
+	return serverURL + "/api/v1/g/" + groupSlug + "/commodities"
+}
 
-	token2, err := generateJWTToken(createdUser2, jwtSecret)
-	if err != nil {
-		t.Fatalf("Failed to generate token for user2: %v", err)
-	}
+// TestAPIUserIsolation_Commodities exercises commodity API isolation at the HTTP
+// layer: user1 creates a commodity in their group; user2 (a different group) must
+// not see it; and user2 is denied membership when targeting user1's group slug.
+func TestAPIUserIsolation_Commodities(t *testing.T) {
+	server, fs, user1, user2, jwtSecret, cleanup := setupTestAPIServer(t)
+	defer cleanup()
+	c := qt.New(t)
 
-	// User1 creates a commodity (as draft to avoid price validation)
-	//commodityData := map[string]any{
-	//	"name":        "User1 Commodity",
-	//	"description": "A commodity created by user1",
-	//	"area_id":     area.ID,
-	//	"count":       1,
-	//	"status":      "in_use",
-	//	"draft":       true, // Create as draft to bypass group currency validation
-	//}
+	areaID := seedAPILocationArea(c, fs, user1)
 
+	token1, err := generateJWTToken(user1.user, jwtSecret)
+	c.Assert(err, qt.IsNil)
+	token2, err := generateJWTToken(user2.user, jwtSecret)
+	c.Assert(err, qt.IsNil)
+
+	// User1 creates a commodity (draft → bypasses group-currency price math).
 	obj := &jsonapi.CommodityRequest{
 		Data: &jsonapi.CommodityData{
 			Type: "commodities",
 			Attributes: &models.Commodity{
 				Name:                   "New Commodity in Area 2",
 				ShortName:              "NewCom2",
-				AreaID:                 new(createdArea.ID),
+				AreaID:                 new(areaID),
 				Type:                   models.CommodityTypeElectronics,
 				OriginalPrice:          must.Must(decimal.NewFromString("1000.00")),
 				OriginalPriceCurrency:  models.Currency("USD"),
-				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")), // to pass the validation
+				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")),
 				CurrentPrice:           must.Must(decimal.NewFromString("800.00")),
 				SerialNumber:           "SN123456",
 				ExtraSerialNumbers:     []string{"SN654321"},
@@ -237,114 +227,97 @@ func TestAPIUserIsolation_Commodities(t *testing.T) {
 	}
 
 	jsonData, err := json.Marshal(obj)
-	if err != nil {
-		t.Fatalf("Failed to marshal commodity data: %v", err)
-	}
+	c.Assert(err, qt.IsNil)
 
-	resp, err := makeAuthenticatedRequest("POST", server.URL+"/api/v1/commodities", jsonData, token1)
-	if err != nil {
-		t.Fatalf("Failed to create commodity: %v", err)
-	}
+	resp, err := makeAuthenticatedRequest(http.MethodPost, commoditiesPath(server.URL, user1.group.Slug), jsonData, token1)
+	c.Assert(err, qt.IsNil)
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("Expected status %d, got %d. Response body: %s", http.StatusCreated, resp.StatusCode, string(body))
+		resp.Body.Close()
+		c.Fatalf("Expected status %d, got %d. Response body: %s", http.StatusCreated, resp.StatusCode, string(body))
 	}
 	resp.Body.Close()
 
-	// User2 tries to list commodities - should see empty list
-	resp, err = makeAuthenticatedRequest("GET", server.URL+"/api/v1/commodities", nil, token2)
-	if err != nil {
-		t.Fatalf("Failed to list commodities for user2: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
-	}
+	// User2, on THEIR OWN group, sees an empty list (group-scoped isolation).
+	resp, err = makeAuthenticatedRequest(http.MethodGet, commoditiesPath(server.URL, user2.group.Slug), nil, token2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusOK)
+	c.Assert(decodeDataLen(c, resp), qt.Equals, 0)
+
+	// User2 is forbidden from even addressing user1's group slug (not a member).
+	resp, err = makeAuthenticatedRequest(http.MethodGet, commoditiesPath(server.URL, user1.group.Slug), nil, token2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusForbidden)
+	resp.Body.Close()
+
+	// User1 sees their one commodity.
+	resp, err = makeAuthenticatedRequest(http.MethodGet, commoditiesPath(server.URL, user1.group.Slug), nil, token1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusOK)
 
 	var commodities map[string]any
-	err = json.NewDecoder(resp.Body).Decode(&commodities)
-	if err != nil {
-		t.Fatalf("Failed to decode commodities: %v", err)
-	}
-	if len(commodities["data"].([]any)) != 0 {
-		t.Errorf("Expected 0 commodities for user2, got %d", len(commodities))
-	}
+	c.Assert(json.NewDecoder(resp.Body).Decode(&commodities), qt.IsNil)
 	resp.Body.Close()
-
-	// User1 can see their commodity
-	resp, err = makeAuthenticatedRequest("GET", server.URL+"/api/v1/commodities", nil, token1)
-	if err != nil {
-		t.Fatalf("Failed to list commodities for user1: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-
-	commodities = map[string]any(nil)
-	err = json.NewDecoder(resp.Body).Decode(&commodities)
-	if err != nil {
-		t.Fatalf("Failed to decode commodities for user1: %v", err)
-	}
-	dataArray := commodities["data"].([]any)
-	if len(dataArray) != 1 {
-		t.Errorf("Expected 1 commodity for user1, got %d", len(dataArray))
-	}
-	if len(dataArray) > 0 {
-		name := dataArray[0].(map[string]any)["attributes"].(map[string]any)["name"]
-		if name != obj.Data.Attributes.Name {
-			t.Errorf("Expected '%s', got %v", obj.Data.Attributes.Name, name)
-		}
-	}
-	resp.Body.Close()
+	dataArray, ok := commodities["data"].([]any)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(dataArray, qt.HasLen, 1)
+	name := dataArray[0].(map[string]any)["attributes"].(map[string]any)["name"]
+	c.Assert(name, qt.Equals, obj.Data.Attributes.Name)
 }
 
-// TestAPIAuthentication tests authentication requirements for API endpoints
+// decodeDataLen decodes a JSON:API collection response and returns len(data).
+func decodeDataLen(c *qt.C, resp *http.Response) int {
+	c.Helper()
+	defer resp.Body.Close()
+	var payload map[string]any
+	c.Assert(json.NewDecoder(resp.Body).Decode(&payload), qt.IsNil)
+	data, ok := payload["data"].([]any)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("response has no data array: %v", payload))
+	return len(data)
+}
+
+// TestAPIAuthentication tests authentication requirements for group-scoped API
+// endpoints: every data route must reject an unauthenticated request with 401.
 func TestAPIAuthentication(t *testing.T) {
-	server, _, _, _, _, cleanup := setupTestAPIServer(t)
+	server, _, user1, _, _, cleanup := setupTestAPIServer(t)
 	defer cleanup()
 
+	slug := user1.group.Slug
 	endpoints := []struct {
 		method string
 		path   string
 	}{
-		{"GET", "/api/v1/commodities"},
-		{"POST", "/api/v1/commodities"},
-		{"GET", "/api/v1/locations"},
-		{"POST", "/api/v1/locations"},
-		{"GET", "/api/v1/areas"},
-		{"POST", "/api/v1/areas"},
-		{"GET", "/api/v1/files"},
-		{"GET", "/api/v1/exports"},
-		{"POST", "/api/v1/exports"},
+		{http.MethodGet, "/api/v1/g/" + slug + "/commodities"},
+		{http.MethodPost, "/api/v1/g/" + slug + "/commodities"},
+		{http.MethodGet, "/api/v1/g/" + slug + "/locations"},
+		{http.MethodPost, "/api/v1/g/" + slug + "/locations"},
+		{http.MethodGet, "/api/v1/g/" + slug + "/areas"},
+		{http.MethodPost, "/api/v1/g/" + slug + "/areas"},
+		{http.MethodGet, "/api/v1/g/" + slug + "/files"},
+		{http.MethodGet, "/api/v1/g/" + slug + "/exports"},
+		{http.MethodPost, "/api/v1/g/" + slug + "/exports"},
 	}
 
 	for _, endpoint := range endpoints {
 		t.Run(fmt.Sprintf("%s %s", endpoint.method, endpoint.path), func(t *testing.T) {
-			// Test without authentication - should fail
+			c := qt.New(t)
 			var req *http.Request
 			var err error
 
-			if endpoint.method == "POST" {
-				testData := map[string]any{"name": "Test"}
-				jsonData, _ := json.Marshal(testData)
+			if endpoint.method == http.MethodPost {
+				jsonData := must.Must(json.Marshal(map[string]any{"name": "Test"}))
 				req, err = http.NewRequest(endpoint.method, server.URL+endpoint.path, bytes.NewBuffer(jsonData))
 			} else {
 				req, err = http.NewRequest(endpoint.method, server.URL+endpoint.path, nil)
 			}
-
-			if err != nil {
-				t.Fatalf("Failed to create request: %v", err)
-			}
+			c.Assert(err, qt.IsNil)
 			req.Header.Set("Content-Type", "application/json")
 
 			client := &http.Client{}
 			resp, err := client.Do(req)
-			if err != nil {
-				t.Fatalf("Request failed: %v", err)
-			}
-			if resp.StatusCode != http.StatusUnauthorized {
-				t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, resp.StatusCode)
-			}
-			resp.Body.Close()
+			c.Assert(err, qt.IsNil)
+			defer resp.Body.Close()
+			c.Assert(resp.StatusCode, qt.Equals, http.StatusUnauthorized)
 		})
 	}
 }

--- a/go/integration/api_user_isolation_test.go
+++ b/go/integration/api_user_isolation_test.go
@@ -52,12 +52,25 @@ func setupTestAPIServer(t *testing.T) (server *httptest.Server, fs *registry.Fac
 
 	jwtSecretBytes := []byte("test-secret-32-bytes-minimum-length")
 
-	// Real tenant.
+	// Real tenant, marked as the system default so the host→tenant resolver
+	// (PublicTenantMiddleware → TenantRegistry.GetDefault) resolves every
+	// request to it. Without a default tenant the server 503s
+	// ("No default tenant configured") before auth or routing runs — the CI
+	// failure these tests hit on a truly fresh DB (#2094). setupFreshDatabase
+	// bootstraps + migrates but does NOT truncate, so a prior test's default
+	// tenant may linger: demote it first to satisfy the
+	// tenants_single_default_idx partial unique index (mirrors
+	// createTenantAndGetID in cli_workflow_integration_test.go).
 	uniq := fmt.Sprintf("%d", time.Now().UnixNano())
+	if existing, getErr := factorySet.TenantRegistry.GetDefault(context.Background()); getErr == nil {
+		existing.IsDefault = false
+		must.Must(factorySet.TenantRegistry.Update(context.Background(), *existing))
+	}
 	createdTenant := must.Must(factorySet.TenantRegistry.Create(context.Background(), models.Tenant{
-		Name:   "Test Tenant API " + uniq,
-		Slug:   "test-tenant-api-" + uniq,
-		Status: models.TenantStatusActive,
+		Name:      "Test Tenant API " + uniq,
+		Slug:      "test-tenant-api-" + uniq,
+		Status:    models.TenantStatusActive,
+		IsDefault: true,
 	}))
 
 	// Two users in the same tenant.

--- a/go/integration/user_isolation_comprehensive_test.go
+++ b/go/integration/user_isolation_comprehensive_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -182,7 +183,7 @@ func TestUserIsolation_EdgeCases(t *testing.T) {
 	})
 
 	c.Run("Very Long User ID", func(c *qt.C) {
-		longUserID := string(make([]byte, 10000))
+		longUserID := strings.Repeat("a", 10000)
 		longCtx := userGroupContext(
 			context.Background(),
 			&models.User{
@@ -200,15 +201,16 @@ func TestUserIsolation_EdgeCases(t *testing.T) {
 			},
 		)
 
-		// Should handle gracefully - expect error for extremely long user ID.
+		// Should handle gracefully. Denial at registry-set creation is
+		// acceptable; if it succeeds, isolation must still hold — a
+		// non-existent tenant/group must surface zero rows, never a leak.
 		registrySet, err := fs.CreateUserRegistrySet(longCtx)
 		if err != nil {
-			// If registry creation fails, that's acceptable for extremely long IDs.
-			c.Logf("Registry creation failed for long user ID (expected): %v", err)
 			return
 		}
-		_, err = registrySet.CommodityRegistry.List(longCtx)
-		// Either success or failure is acceptable for edge case testing.
-		c.Logf("List operation result for long user ID: %v", err)
+		commodities, err := registrySet.CommodityRegistry.List(longCtx)
+		if err == nil {
+			c.Assert(commodities, qt.HasLen, 0)
+		}
 	})
 }

--- a/go/integration/user_isolation_comprehensive_test.go
+++ b/go/integration/user_isolation_comprehensive_test.go
@@ -7,377 +7,208 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-extras/go-kit/must"
-	"github.com/shopspring/decimal"
 
-	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
 
-// TestUserIsolation_ComprehensiveScenarios tests complex real-world scenarios
+// TestUserIsolation_ComprehensiveScenarios tests complex real-world scenarios.
+// Isolation is GROUP-scoped, so every party lives in its own group within a
+// shared tenant — that is what makes the cross-party negative assertions
+// meaningful.
 func TestUserIsolation_ComprehensiveScenarios(t *testing.T) {
 	c := qt.New(t)
-	factorySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
 	c.Run("Complex Entity Relationships", func(c *qt.C) {
-		// Create multiple users for complex scenarios
-		user1 := createTestUser(c, factorySet.UserRegistry, "user1t1@comprehensive.com")
-		ctx1 := appctx.WithUser(context.Background(), user1)
-		registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx1))
+		user1, user2 := newIsolationPair(c, fs)
+		registrySet := must.Must(fs.CreateUserRegistrySet(user1.ctx))
+		registrySet2 := must.Must(fs.CreateUserRegistrySet(user2.ctx))
 
-		user2 := createTestUser(c, factorySet.UserRegistry, "user2t1@comprehensive.com")
-		ctx2 := appctx.WithUser(context.Background(), user2)
-		registrySet2 := must.Must(factorySet.CreateUserRegistrySet(ctx2))
+		// User1 creates a location → area → commodity in group1.
+		createdLocation1 := seedLocation(c, fs, user1, "User1 Warehouse")
+		createdArea1 := seedArea(c, fs, user1, createdLocation1.ID, "User1 Storage Area")
+		_ = seedCommodity(c, fs, user1, createdArea1.ID, "User1 Product", "UP1")
 
-		// Create shared location and area for user1 that can be used across tests
-		location1 := models.Location{
-			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-				EntityID:        models.EntityID{ID: "comp-location-1t1"},
-				TenantID:        "test-tenant-id",
-				CreatedByUserID: user1.ID,
-			},
-			Name:    "User1 Warehouse",
-			Address: "123 User1 Street",
-		}
-		userAwareLocationRegistry1 := registrySet.LocationRegistry
-		createdLocation1, err := userAwareLocationRegistry1.Create(ctx1, location1)
-		c.Assert(err, qt.IsNil)
-
-		area1 := models.Area{
-			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-				EntityID:        models.EntityID{ID: "comp-area-1"},
-				TenantID:        "test-tenant-id",
-				CreatedByUserID: user1.ID,
-			},
-			Name:       "User1 Storage Area",
-			LocationID: createdLocation1.ID,
-		}
-		userAwareAreaRegistry1 := registrySet.AreaRegistry
-		createdArea1, err := userAwareAreaRegistry1.Create(ctx1, area1)
-		c.Assert(err, qt.IsNil)
-
-		commodity1 := models.Commodity{
-			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-				EntityID:        models.EntityID{ID: "comp-commodity-1"},
-				TenantID:        "test-tenant-id",
-				CreatedByUserID: user1.ID,
-			},
-			Name:                   "User1 Product",
-			ShortName:              "UP1",
-			Type:                   models.CommodityTypeElectronics,
-			Count:                  1,
-			OriginalPrice:          decimal.NewFromFloat(100.00),
-			OriginalPriceCurrency:  "USD",
-			ConvertedOriginalPrice: decimal.Zero,
-			CurrentPrice:           decimal.NewFromFloat(90.00),
-			Status:                 models.CommodityStatusInUse,
-			PurchaseDate:           models.ToPDate("2023-01-01"),
-			RegisteredDate:         models.ToPDate("2023-01-02"),
-			LastModifiedDate:       models.ToPDate("2023-01-03"),
-			Draft:                  false,
-			AreaID:                 new(createdArea1.ID),
-		}
-		userAwareCommodityRegistry1 := registrySet.CommodityRegistry
-		_, err = userAwareCommodityRegistry1.Create(ctx1, commodity1)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to create commodity: %v", err))
-
-		// User2 tries to access User1's entities through relationships
-		// Should not be able to access location
-		userAwareLocationRegistry2 := registrySet2.LocationRegistry
-		_, err = userAwareLocationRegistry2.Get(ctx2, createdLocation1.ID)
+		// User2 (different group) cannot reach user1's location or area.
+		_, err := registrySet2.LocationRegistry.Get(user2.ctx, createdLocation1.ID)
 		c.Assert(err, qt.IsNotNil, qt.Commentf("Expected error when user2 tries to access user1's location"))
 
-		// Should not be able to access area
-		userAwareAreaRegistry2 := registrySet2.AreaRegistry
-		_, err = userAwareAreaRegistry2.Get(ctx2, createdArea1.ID)
+		_, err = registrySet2.AreaRegistry.Get(user2.ctx, createdArea1.ID)
 		c.Assert(err, qt.IsNotNil, qt.Commentf("Expected error when user2 tries to access user1's area"))
 
-		// User2 creates their own entities with similar names
-		location2 := models.Location{
-			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-				EntityID:        models.EntityID{ID: "comp-location-2t1"},
-				TenantID:        "test-tenant-id",
-				CreatedByUserID: user2.ID,
-			},
-			Name:    "User1 Warehouse", // Same name as User1's location
-			Address: "456 User2 Street",
-		}
-		_, err = userAwareLocationRegistry2.Create(ctx2, location2)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to create location for user2: %v", err))
+		// User2 creates their own location with the SAME name in group2.
+		_ = seedLocation(c, fs, user2, "User1 Warehouse")
 
-		// Verify users can only see their own entities despite same names
-		locations1, err := userAwareLocationRegistry1.List(ctx1)
+		// Each user sees only their own location despite identical names.
+		locations1, err := registrySet.LocationRegistry.List(user1.ctx)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to list locations for user1: %v", err))
-		c.Assert(locations1, qt.HasLen, 1, qt.Commentf("Expected 1 location for user1, got %d", len(locations1)))
-		c.Assert(locations1[0].ID, qt.Equals, createdLocation1.ID, qt.Commentf("Expected location ID %s, got %s", createdLocation1.ID, locations1[0].ID))
+		c.Assert(locations1, qt.HasLen, 1)
+		c.Assert(locations1[0].ID, qt.Equals, createdLocation1.ID)
 
-		locations2, err := userAwareLocationRegistry2.List(ctx2)
+		locations2, err := registrySet2.LocationRegistry.List(user2.ctx)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to list locations for user2: %v", err))
-		c.Assert(locations2, qt.HasLen, 1, qt.Commentf("Expected 1 location for user2, got %d", len(locations2)))
+		c.Assert(locations2, qt.HasLen, 1)
 	})
 
 	c.Run("Cross-User Update Attempts", func(c *qt.C) {
-		// Create multiple users for complex scenarios
-		user1 := createTestUser(c, factorySet.UserRegistry, "user1t2@comprehensive.com")
-		ctx1 := appctx.WithUser(c.Context(), user1)
-		registrySet1 := must.Must(factorySet.CreateUserRegistrySet(ctx1))
+		// Three users, each in their own group; users 2 and 3 must not be able
+		// to mutate user1's commodity.
+		tenant := createIsolationTenant(c, fs)
+		owner := newGroupedUser(c, fs, tenant, "owner@comprehensive.com", "Owner Group")
+		attacker2 := newGroupedUser(c, fs, tenant, "attacker2@comprehensive.com", "Attacker2 Group")
+		attacker3 := newGroupedUser(c, fs, tenant, "attacker3@comprehensive.com", "Attacker3 Group")
 
-		user2 := createTestUser(c, factorySet.UserRegistry, "user2t2@comprehensive.com")
-		ctx2 := appctx.WithUser(c.Context(), user2)
-		registrySet2 := must.Must(factorySet.CreateUserRegistrySet(ctx2))
+		registrySet2 := must.Must(fs.CreateUserRegistrySet(attacker2.ctx))
+		registrySet3 := must.Must(fs.CreateUserRegistrySet(attacker3.ctx))
 
-		user3 := createTestUser(c, factorySet.UserRegistry, "user3t2@comprehensive.com")
-		ctx3 := appctx.WithUser(c.Context(), user3)
-		registrySet3 := must.Must(factorySet.CreateUserRegistrySet(ctx3))
+		createdLocation1 := seedLocation(c, fs, owner, "User1 Warehouse")
+		createdArea1 := seedArea(c, fs, owner, createdLocation1.ID, "User1 Storage Area")
+		created1 := seedCommodity(c, fs, owner, createdArea1.ID, "Original Name", "ON")
 
-		// Create shared location and area for user1 that can be used across tests
-		location1 := models.Location{
-			Name:    "User1 Warehouse",
-			Address: "123 User1 Street",
-			// Note: ID will be generated server-side for security
-		}
-		userAwareLocationRegistry1 := registrySet1.LocationRegistry
-		createdLocation1, err := userAwareLocationRegistry1.Create(ctx1, location1)
-		c.Assert(err, qt.IsNil)
-
-		area1 := models.Area{
-			Name:       "User1 Storage Area",
-			LocationID: createdLocation1.ID,
-			// Note: ID will be generated server-side for security
-		}
-		userAwareAreaRegistry1 := registrySet1.AreaRegistry
-		createdArea1, err := userAwareAreaRegistry1.Create(ctx1, area1)
-		c.Assert(err, qt.IsNil)
-
-		// User1 creates entities
-		commodity1 := models.Commodity{
-			// Note: ID will be generated server-side for security
-			Name:                   "Original Name",
-			ShortName:              "ON",
-			AreaID:                 new(createdArea1.ID),
-			Type:                   models.CommodityTypeElectronics,
-			Count:                  1,
-			OriginalPrice:          decimal.NewFromFloat(100.00),
-			OriginalPriceCurrency:  "USD",
-			ConvertedOriginalPrice: decimal.Zero,
-			CurrentPrice:           decimal.NewFromFloat(90.00),
-			Status:                 models.CommodityStatusInUse,
-			PurchaseDate:           models.ToPDate("2023-01-01"),
-			RegisteredDate:         models.ToPDate("2023-01-02"),
-			LastModifiedDate:       models.ToPDate("2023-01-03"),
-			Draft:                  false,
-		}
-		userAwareCommodityRegistry1 := registrySet1.CommodityRegistry
-		created1, err := userAwareCommodityRegistry1.Create(ctx1, commodity1)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to create commodity: %v", err))
-
-		// User2 tries to update User1's commodity
+		// User2 tries to update user1's commodity.
 		created1.Name = "Hacked Name"
 		created1.ShortName = "HN"
-		userAwareCommodityRegistry2 := registrySet2.CommodityRegistry
-		_, err = userAwareCommodityRegistry2.Update(ctx2, *created1)
+		_, err := registrySet2.CommodityRegistry.Update(attacker2.ctx, *created1)
 		c.Assert(err, qt.IsNotNil, qt.Commentf("Expected error when user2 tries to update user1's commodity"))
 
-		// User3 also tries to update User1's commodity
+		// User3 tries the same.
 		created1.Name = "Another Hack"
-		userAwareCommodityRegistry3 := registrySet3.CommodityRegistry
-		_, err = userAwareCommodityRegistry3.Update(ctx3, *created1)
+		_, err = registrySet3.CommodityRegistry.Update(attacker3.ctx, *created1)
 		c.Assert(err, qt.IsNotNil, qt.Commentf("Expected error when user3 tries to update user1's commodity"))
 
-		// Verify the commodity remains unchanged
-		retrieved, err := userAwareCommodityRegistry1.Get(ctx1, created1.ID)
+		// The commodity is unchanged when read back by its owner.
+		registrySet1 := must.Must(fs.CreateUserRegistrySet(owner.ctx))
+		retrieved, err := registrySet1.CommodityRegistry.Get(owner.ctx, created1.ID)
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to retrieve commodity: %v", err))
-		c.Assert(retrieved, qt.IsNotNil, qt.Commentf("Expected commodity to be retrieved"))
-		c.Assert(retrieved.Name, qt.Equals, "Original Name", qt.Commentf("Expected name to remain unchanged"))
-		c.Assert(retrieved.ShortName, qt.Equals, "ON", qt.Commentf("Expected short name to remain unchanged"))
+		c.Assert(retrieved, qt.IsNotNil)
+		c.Assert(retrieved.Name, qt.Equals, "Original Name")
+		c.Assert(retrieved.ShortName, qt.Equals, "ON")
 	})
 
 	c.Run("Bulk Operations Isolation", func(c *qt.C) {
-		// Create multiple users for complex scenarios
-		user1 := createTestUser(c, factorySet.UserRegistry, "user1t3@comprehensive.com")
-		ctx1 := appctx.WithUser(context.Background(), user1)
-		registrySet1, err := factorySet.CreateUserRegistrySet(ctx1)
-		c.Assert(err, qt.IsNil)
-
-		user2 := createTestUser(c, factorySet.UserRegistry, "user2t3@comprehensive.com")
-		ctx2 := appctx.WithUser(context.Background(), user2)
-		registrySet2, err := factorySet.CreateUserRegistrySet(ctx2)
-		c.Assert(err, qt.IsNil)
-
-		user3 := createTestUser(c, factorySet.UserRegistry, "user3t3@comprehensive.com")
-		ctx3 := appctx.WithUser(context.Background(), user3)
-		registrySet3, err := factorySet.CreateUserRegistrySet(ctx3)
-		c.Assert(err, qt.IsNil)
-
-		// Create shared location and area for user1 that can be used across tests
-		location1 := models.Location{
-			Name:    "User1 Warehouse",
-			Address: "123 User1 Street",
-			// Note: ID will be generated server-side for security
-		}
-		userAwareLocationRegistry1 := registrySet1.LocationRegistry
-		createdLocation1, err := userAwareLocationRegistry1.Create(ctx1, location1)
-		c.Assert(err, qt.IsNil)
-
-		area1 := models.Area{
-			Name:       "User1 Storage Area",
-			LocationID: createdLocation1.ID,
-			// Note: ID will be generated server-side for security
-		}
-		userAwareAreaRegistry1 := registrySet1.AreaRegistry
-		createdArea1, err := userAwareAreaRegistry1.Create(ctx1, area1)
-		c.Assert(err, qt.IsNil)
-
-		// Create areas for each user first (reuse existing area for user1)
-		areas := []*models.Area{createdArea1} // User1 already has an area
-
-		users := []*models.User{user1, user2, user3}
-		ctxs := []context.Context{ctx1, ctx2, ctx3}
-		registrySets := []*registry.Set{registrySet1, registrySet2, registrySet3}
-
-		// Create areas for user2 and user3
-		for userIndex := 1; userIndex < 3; userIndex++ {
-			user := users[userIndex]
-			ctx := ctxs[userIndex]
-			registrySet := registrySets[userIndex]
-
-			// Create location first
-			location := models.Location{
-				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-					EntityID:        models.EntityID{ID: fmt.Sprintf("bulk-location-user%d", userIndex+1)},
-					TenantID:        "test-tenant-id",
-					CreatedByUserID: user.ID,
-				},
-				Name:    fmt.Sprintf("User%d Bulk Location", userIndex+1),
-				Address: fmt.Sprintf("123 User%d Bulk Street", userIndex+1),
-			}
-			userAwareLocationRegistry := registrySet.LocationRegistry
-			createdLocation, err := userAwareLocationRegistry.Create(ctx, location)
-			c.Assert(err, qt.IsNil)
-
-			// Create area
-			area := models.Area{
-				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-					EntityID:        models.EntityID{ID: fmt.Sprintf("bulk-area-user%d", userIndex+1)},
-					TenantID:        "test-tenant-id",
-					CreatedByUserID: user.ID,
-				},
-				Name:       fmt.Sprintf("User%d Bulk Area", userIndex+1),
-				LocationID: createdLocation.ID,
-			}
-			userAwareAreaRegistry := registrySet.AreaRegistry
-			createdArea, err := userAwareAreaRegistry.Create(ctx, area)
-			c.Assert(err, qt.IsNil)
-			areas = append(areas, createdArea)
+		// Three users, each in their own group, each creating 10 commodities.
+		// Every user must see exactly their own 10.
+		tenant := createIsolationTenant(c, fs)
+		fixtures := []isolationFixture{
+			newGroupedUser(c, fs, tenant, "user1t3@comprehensive.com", "Bulk Group 1"),
+			newGroupedUser(c, fs, tenant, "user2t3@comprehensive.com", "Bulk Group 2"),
+			newGroupedUser(c, fs, tenant, "user3t3@comprehensive.com", "Bulk Group 3"),
 		}
 
-		// Each user creates multiple entities
-		for userIndex, registrySet := range registrySets {
+		registrySets := make([]*registry.Set, len(fixtures))
+		for i, f := range fixtures {
+			registrySets[i] = must.Must(fs.CreateUserRegistrySet(f.ctx))
+		}
+
+		// Each user gets a location + area, then 10 commodities under it.
+		for userIndex, f := range fixtures {
+			loc := seedLocation(c, fs, f, fmt.Sprintf("User%d Bulk Location", userIndex+1))
+			area := seedArea(c, fs, f, loc.ID, fmt.Sprintf("User%d Bulk Area", userIndex+1))
 			for i := range 10 {
-				commodity := models.Commodity{
-					TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-						EntityID:        models.EntityID{ID: fmt.Sprintf("bulk-commodity-user%d-%d", userIndex+1, i)},
-						TenantID:        "test-tenant-id",
-						CreatedByUserID: users[userIndex].ID, // #nosec G602 -- false positive
-					},
-					Name:                   fmt.Sprintf("User%d Commodity %d", userIndex+1, i),
-					ShortName:              fmt.Sprintf("U%dC%d", userIndex+1, i),
-					AreaID:                 new(areas[userIndex].ID),
-					Type:                   models.CommodityTypeElectronics,
-					Count:                  1,
-					OriginalPrice:          decimal.NewFromFloat(100.00),
-					OriginalPriceCurrency:  "USD",
-					ConvertedOriginalPrice: decimal.Zero,
-					CurrentPrice:           decimal.NewFromFloat(90.00),
-					Status:                 models.CommodityStatusInUse,
-					PurchaseDate:           models.ToPDate("2023-01-01"),
-					RegisteredDate:         models.ToPDate("2023-01-02"),
-					LastModifiedDate:       models.ToPDate("2023-01-03"),
-					Draft:                  false,
-				}
-				userAwareCommodityRegistry := registrySet.CommodityRegistry
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user-aware registry for user %d: %v", userIndex+1, err))
-				_, err = userAwareCommodityRegistry.Create(ctxs[userIndex], commodity) // #nosec G602 -- false positive
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to create commodity for user %d: %v", userIndex+1, err))
+				_ = seedCommodity(c, fs, f, area.ID,
+					fmt.Sprintf("User%d Commodity %d", userIndex+1, i),
+					fmt.Sprintf("U%dC%d", userIndex+1, i))
 			}
 		}
 
-		// Verify each user can only see their own entities
-		userAwareCommodityRegistry1 := registrySet1.CommodityRegistry
-		commodities1, err := userAwareCommodityRegistry1.List(ctx1)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to list commodities for user1: %v", err))
-		c.Assert(commodities1, qt.HasLen, 10, qt.Commentf("Expected 10 commodities for user1, got %d", len(commodities1)))
-		for _, commodity := range commodities1 {
-			c.Assert(commodity.GetCreatedByUserID(), qt.Equals, user1.ID, qt.Commentf("Expected user ID %s, got %s", user1.ID, commodity.GetCreatedByUserID()))
-		}
-
-		userAwareCommodityRegistry2 := registrySet2.CommodityRegistry
-		commodities2, err := userAwareCommodityRegistry2.List(ctx2)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to list commodities for user2: %v", err))
-		c.Assert(commodities2, qt.HasLen, 10, qt.Commentf("Expected 10 commodities for user2, got %d", len(commodities2)))
-		for _, commodity := range commodities2 {
-			c.Assert(commodity.GetCreatedByUserID(), qt.Equals, user2.ID, qt.Commentf("Expected user ID %s, got %s", user2.ID, commodity.GetCreatedByUserID()))
-		}
-
-		userAwareCommodityRegistry3 := registrySet3.CommodityRegistry
-		commodities3, err := userAwareCommodityRegistry3.List(ctx3)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to list commodities for user3: %v", err))
-		c.Assert(commodities3, qt.HasLen, 10, qt.Commentf("Expected 10 commodities for user3, got %d", len(commodities3)))
-		for _, commodity := range commodities3 {
-			c.Assert(commodity.GetCreatedByUserID(), qt.Equals, user3.ID, qt.Commentf("Expected user ID %s, got %s", user3.ID, commodity.GetCreatedByUserID()))
+		// Verify each user sees exactly their own 10 commodities.
+		for userIndex, f := range fixtures {
+			commodities, err := registrySets[userIndex].CommodityRegistry.List(f.ctx)
+			c.Assert(err, qt.IsNil, qt.Commentf("Failed to list commodities for user %d: %v", userIndex+1, err))
+			c.Assert(commodities, qt.HasLen, 10, qt.Commentf("Expected 10 commodities for user %d, got %d", userIndex+1, len(commodities)))
+			for _, commodity := range commodities {
+				c.Assert(commodity.GetCreatedByUserID(), qt.Equals, f.user.ID)
+			}
 		}
 	})
 }
 
-// TestUserIsolation_EdgeCases tests edge cases and boundary conditions
+// newGroupedUser is a convenience for sub-tests that need more than the two
+// users newIsolationPair provides: one user in their own fresh group within the
+// given tenant, with a ready WithUser+WithGroup context.
+func newGroupedUser(c *qt.C, fs *registry.FactorySet, tenant *models.Tenant, email, groupName string) isolationFixture {
+	c.Helper()
+	user := createTestUser(c, fs.UserRegistry, tenant.ID, email)
+	group := createTestGroup(c, fs, tenant.ID, user.ID, groupName)
+	return isolationFixture{
+		tenant: tenant,
+		user:   user,
+		group:  group,
+		ctx:    userGroupContext(context.Background(), user, group),
+	}
+}
+
+// TestUserIsolation_EdgeCases tests edge cases and boundary conditions around
+// the user-aware registry-set factory.
 func TestUserIsolation_EdgeCases(t *testing.T) {
 	c := qt.New(t)
-	factorySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	c.Cleanup(cleanup)
 
 	c.Run("Empty User Context", func(c *qt.C) {
 		emptyCtx := context.Background()
-		_, err := factorySet.CreateUserRegistrySet(emptyCtx)
+		_, err := fs.CreateUserRegistrySet(emptyCtx)
 		c.Assert(err, qt.IsNotNil, qt.Commentf("Expected error when no user context is provided"))
 		c.Assert(err.Error(), qt.Contains, "user context required")
 	})
 
 	c.Run("Non-existent User ID", func(c *qt.C) {
-		nonExistentCtx := appctx.WithUser(context.Background(), &models.User{
-			TenantAwareEntityID: models.TenantAwareEntityID{
-				EntityID: models.EntityID{ID: "non-existent-id"},
-				TenantID: "test-tenant-id",
+		// A well-formed but unknown user with a group context still resolves a
+		// registry set; it simply sees no rows (RLS denies everything).
+		nonExistentCtx := userGroupContext(
+			context.Background(),
+			&models.User{
+				TenantAwareEntityID: models.TenantAwareEntityID{
+					EntityID: models.EntityID{ID: "non-existent-id"},
+					TenantID: "non-existent-tenant-id",
+				},
 			},
-		})
+			&models.LocationGroup{
+				TenantAwareEntityID: models.TenantAwareEntityID{
+					EntityID: models.EntityID{ID: "non-existent-group-id"},
+					TenantID: "non-existent-tenant-id",
+				},
+				GroupCurrency: models.Currency("USD"),
+			},
+		)
 
-		registrySet, err := factorySet.CreateUserRegistrySet(nonExistentCtx)
+		registrySet, err := fs.CreateUserRegistrySet(nonExistentCtx)
 		c.Assert(err, qt.IsNil)
-		userAwareCommodityRegistry := registrySet.CommodityRegistry
-		commodities, err := userAwareCommodityRegistry.List(nonExistentCtx)
+		commodities, err := registrySet.CommodityRegistry.List(nonExistentCtx)
 		c.Assert(err, qt.IsNil, qt.Commentf("Expected no error for non-existent user"))
 		c.Assert(commodities, qt.HasLen, 0, qt.Commentf("Expected 0 commodities for non-existent user"))
 	})
 
 	c.Run("Very Long User ID", func(c *qt.C) {
 		longUserID := string(make([]byte, 10000))
-		longCtx := appctx.WithUser(context.Background(), &models.User{
-			TenantAwareEntityID: models.TenantAwareEntityID{
-				EntityID: models.EntityID{ID: longUserID},
-				TenantID: "test-tenant-id",
+		longCtx := userGroupContext(
+			context.Background(),
+			&models.User{
+				TenantAwareEntityID: models.TenantAwareEntityID{
+					EntityID: models.EntityID{ID: longUserID},
+					TenantID: "non-existent-tenant-id",
+				},
 			},
-		})
+			&models.LocationGroup{
+				TenantAwareEntityID: models.TenantAwareEntityID{
+					EntityID: models.EntityID{ID: "non-existent-group-id"},
+					TenantID: "non-existent-tenant-id",
+				},
+				GroupCurrency: models.Currency("USD"),
+			},
+		)
 
-		// Should handle gracefully - expect error for extremely long user ID
-		registrySet, err := factorySet.CreateUserRegistrySet(longCtx)
+		// Should handle gracefully - expect error for extremely long user ID.
+		registrySet, err := fs.CreateUserRegistrySet(longCtx)
 		if err != nil {
-			// If registry creation fails, that's acceptable for extremely long IDs
+			// If registry creation fails, that's acceptable for extremely long IDs.
 			c.Logf("Registry creation failed for long user ID (expected): %v", err)
 			return
 		}
-		userAwareCommodityRegistry := registrySet.CommodityRegistry
-		_, err = userAwareCommodityRegistry.List(longCtx)
-		// Either success or failure is acceptable for edge case testing
+		_, err = registrySet.CommodityRegistry.List(longCtx)
+		// Either success or failure is acceptable for edge case testing.
 		c.Logf("List operation result for long user ID: %v", err)
 	})
 }

--- a/go/integration/user_isolation_performance_test.go
+++ b/go/integration/user_isolation_performance_test.go
@@ -9,15 +9,16 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
 	"github.com/shopspring/decimal"
 
-	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/registry/postgres"
 )
 
-// BenchmarkUserIsolation_ConcurrentUsers benchmarks user isolation with concurrent users
+// BenchmarkUserIsolation_ConcurrentUsers benchmarks user isolation with
+// concurrent users, each in their own group.
 func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 	dsn := os.Getenv("POSTGRES_TEST_DSN")
 	if dsn == "" {
@@ -27,30 +28,25 @@ func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 
 	c := qt.New(b)
 
+	c.Assert(setupFreshDatabase(dsn), qt.IsNil, qt.Commentf("failed to set up fresh database"))
+
 	registrySetFunc, cleanup := postgres.NewPostgresRegistrySet()
 	defer cleanup()
 	factorySet, err := registrySetFunc(registry.Config(dsn))
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to create registry set: %v", err))
 
-	// Create test users
-	users := make([]*models.User, 10)
-	for i := range 10 {
-		user := models.User{
-			TenantAwareEntityID: models.TenantAwareEntityID{
-				EntityID: models.EntityID{ID: fmt.Sprintf("bench-user-%d", i)},
-				TenantID: "test-tenant-id",
-			},
-			Email:    fmt.Sprintf("bench-user-%d@example.com", i),
-			Name:     fmt.Sprintf("Benchmark User %d", i),
-			IsActive: true,
-		}
+	tenant := createIsolationTenant(c, factorySet)
 
-		err = user.SetPassword("TestPassword123")
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password: %v", err))
-
-		created, err := factorySet.UserRegistry.Create(context.Background(), user)
-		c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user: %v", err))
-		users[i] = created
+	// Create test users, each with their own group + ready context + area.
+	const numUsers = 10
+	fixtures := make([]isolationFixture, numUsers)
+	areaIDs := make([]string, numUsers)
+	for i := range numUsers {
+		f := newGroupedUser(c, factorySet, tenant, fmt.Sprintf("bench-user-%d@example.com", i), fmt.Sprintf("Bench Group %d", i))
+		loc := seedLocation(c, factorySet, f, fmt.Sprintf("Bench Location %d", i))
+		area := seedArea(c, factorySet, f, loc.ID, fmt.Sprintf("Bench Area %d", i))
+		fixtures[i] = f
+		areaIDs[i] = area.ID
 	}
 
 	b.ResetTimer()
@@ -60,18 +56,20 @@ func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			userIndex := 0
 			for pb.Next() {
-				user := users[userIndex%len(users)]
-				ctx := appctx.WithUser(context.Background(), user)
+				f := fixtures[userIndex%len(fixtures)]
+				areaID := areaIDs[userIndex%len(areaIDs)]
 
-				// Create commodity
-				commodity := models.Commodity{
+				reg := must.Must(factorySet.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+
+				created := must.Must(reg.Create(f.ctx, models.Commodity{
 					TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-						EntityID:        models.EntityID{ID: fmt.Sprintf("bench-commodity-%d-%d", userIndex, time.Now().UnixNano())},
-						TenantID:        "test-tenant-id",
-						CreatedByUserID: user.ID,
+						TenantID:        f.tenant.ID,
+						GroupID:         f.group.ID,
+						CreatedByUserID: f.user.ID,
 					},
-					Name:                   fmt.Sprintf("Benchmark Commodity %d", userIndex),
+					Name:                   fmt.Sprintf("Benchmark Commodity %d-%d", userIndex, time.Now().UnixNano()),
 					ShortName:              fmt.Sprintf("BC%d", userIndex),
+					AreaID:                 new(areaID),
 					Type:                   models.CommodityTypeElectronics,
 					Count:                  1,
 					OriginalPrice:          decimal.NewFromFloat(100.00),
@@ -83,29 +81,16 @@ func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 					RegisteredDate:         models.ToPDate("2023-01-02"),
 					LastModifiedDate:       models.ToPDate("2023-01-03"),
 					Draft:                  false,
-				}
+				}))
 
-				userAwareCommodityRegistry, err := factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user-aware registry: %v", err))
-
-				created, err := userAwareCommodityRegistry.Create(ctx, commodity)
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to create commodity: %v", err))
-
-				// List commodities (should only see own)
-				userAwareCommodityRegistry, err = factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to create user-aware registry: %v", err))
-
-				commodities, err := userAwareCommodityRegistry.List(ctx)
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to list commodities: %v", err))
-
-				// Verify isolation - should only see own commodities
+				// List commodities — should only see own group's commodities.
+				commodities := must.Must(reg.List(f.ctx))
 				for _, commodity := range commodities {
-					c.Assert(commodity.GetCreatedByUserID(), qt.Equals, user.ID, qt.Commentf("Expected user ID %s, got %s", user.ID, commodity.GetCreatedByUserID()))
+					c.Assert(commodity.GetCreatedByUserID(), qt.Equals, f.user.ID)
 				}
 
-				// Clean up
-				err = userAwareCommodityRegistry.Delete(ctx, created.ID)
-				c.Assert(err, qt.IsNil, qt.Commentf("Failed to delete commodity: %v", err))
+				// Clean up.
+				c.Assert(reg.Delete(f.ctx, created.ID), qt.IsNil)
 
 				userIndex++
 			}
@@ -113,99 +98,81 @@ func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 	})
 }
 
-// TestUserIsolation_LoadTesting tests user isolation under load
+// TestUserIsolation_LoadTesting tests user isolation under load. Excluded from
+// CI via `-skip 'LoadTesting'`; kept compiling + correct for local runs.
 func TestUserIsolation_LoadTesting(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Create multiple users
-	numUsers := 50
-	users := make([]*models.User, numUsers)
-	for i := range numUsers {
-		user := models.User{
-			TenantAwareEntityID: models.TenantAwareEntityID{
-				EntityID: models.EntityID{ID: fmt.Sprintf("load-user-%d", i)},
-				TenantID: "test-tenant-id",
-			},
-			Email:    fmt.Sprintf("load-user-%d@example.com", i),
-			Name:     fmt.Sprintf("Load Test User %d", i),
-			IsActive: true,
-		}
-		err := user.SetPassword("TestPassword123")
-		c.Assert(err, qt.IsNil)
+	tenant := createIsolationTenant(c, fs)
 
-		created, err := registrySet.UserRegistry.Create(context.Background(), user)
-		c.Assert(err, qt.IsNil)
-		users[i] = created
+	// Create multiple users, each in their own group.
+	numUsers := 50
+	fixtures := make([]isolationFixture, numUsers)
+	for i := range numUsers {
+		fixtures[i] = newGroupedUser(c, fs, tenant, fmt.Sprintf("load-user-%d@example.com", i), fmt.Sprintf("Load Group %d", i))
 	}
 
-	// Each user creates commodities concurrently
+	// Each user creates commodities concurrently.
 	var wg sync.WaitGroup
-	errors := make(chan error, numUsers*10)
+	errCh := make(chan error, numUsers*10)
 
-	for i, user := range users {
+	for userIndex, f := range fixtures {
 		wg.Add(1)
-		go func(userIndex int, u *models.User) {
+		go func(userIndex int, f isolationFixture) {
 			defer wg.Done()
 
-			ctx := appctx.WithUser(context.Background(), u)
-
-			// Create location and area for this user's commodities
-			location := models.Location{
+			locReg, err := fs.LocationRegistryFactory.CreateUserRegistry(f.ctx)
+			if err != nil {
+				errCh <- fmt.Errorf("user %d failed to create location registry: %w", userIndex, err)
+				return
+			}
+			createdLocation, err := locReg.Create(f.ctx, models.Location{
 				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-					EntityID:        models.EntityID{ID: fmt.Sprintf("load-location-%d", userIndex)},
-					TenantID:        "test-tenant-id",
-					CreatedByUserID: u.ID,
+					TenantID:        f.tenant.ID,
+					GroupID:         f.group.ID,
+					CreatedByUserID: f.user.ID,
 				},
 				Name:    fmt.Sprintf("Load Test Location %d", userIndex),
 				Address: fmt.Sprintf("123 Load Street %d", userIndex),
-			}
-			userAwareLocationRegistry, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx)
+			})
 			if err != nil {
-				errors <- fmt.Errorf("user %d failed to create location registry: %v", userIndex, err)
-				return
-			}
-			createdLocation, err := userAwareLocationRegistry.Create(ctx, location)
-			if err != nil {
-				errors <- fmt.Errorf("user %d failed to create location: %v", userIndex, err)
+				errCh <- fmt.Errorf("user %d failed to create location: %w", userIndex, err)
 				return
 			}
 
-			area := models.Area{
+			areaReg, err := fs.AreaRegistryFactory.CreateUserRegistry(f.ctx)
+			if err != nil {
+				errCh <- fmt.Errorf("user %d failed to create area registry: %w", userIndex, err)
+				return
+			}
+			createdArea, err := areaReg.Create(f.ctx, models.Area{
 				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-					EntityID:        models.EntityID{ID: fmt.Sprintf("load-area-%d", userIndex)},
-					TenantID:        "test-tenant-id",
-					CreatedByUserID: u.ID,
+					TenantID:        f.tenant.ID,
+					GroupID:         f.group.ID,
+					CreatedByUserID: f.user.ID,
 				},
 				Name:       fmt.Sprintf("Load Test Area %d", userIndex),
 				LocationID: createdLocation.ID,
-			}
-			userAwareAreaRegistry, err := registrySet.AreaRegistryFactory.CreateUserRegistry(ctx)
+			})
 			if err != nil {
-				errors <- fmt.Errorf("user %d failed to create area registry: %v", userIndex, err)
-				return
-			}
-			createdArea, err := userAwareAreaRegistry.Create(ctx, area)
-			if err != nil {
-				errors <- fmt.Errorf("user %d failed to create area: %v", userIndex, err)
+				errCh <- fmt.Errorf("user %d failed to create area: %w", userIndex, err)
 				return
 			}
 
-			// Create user-aware registry once for this user
-			userAwareCommodityRegistry, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
+			comReg, err := fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx)
 			if err != nil {
-				errors <- fmt.Errorf("user %d failed to create user-aware registry: %v", userIndex, err)
+				errCh <- fmt.Errorf("user %d failed to create commodity registry: %w", userIndex, err)
 				return
 			}
 
-			// Create multiple commodities per user
 			for j := range 10 {
-				commodity := models.Commodity{
+				_, err = comReg.Create(f.ctx, models.Commodity{
 					TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-						EntityID:        models.EntityID{ID: fmt.Sprintf("load-commodity-%d-%d", userIndex, j)},
-						TenantID:        "test-tenant-id",
-						CreatedByUserID: u.ID,
+						TenantID:        f.tenant.ID,
+						GroupID:         f.group.ID,
+						CreatedByUserID: f.user.ID,
 					},
 					Name:                   fmt.Sprintf("Load Test Commodity %d-%d", userIndex, j),
 					ShortName:              fmt.Sprintf("LTC%d%d", userIndex, j),
@@ -221,114 +188,58 @@ func TestUserIsolation_LoadTesting(t *testing.T) {
 					RegisteredDate:         models.ToPDate("2023-01-02"),
 					LastModifiedDate:       models.ToPDate("2023-01-03"),
 					Draft:                  false,
-				}
-
-				_, err = userAwareCommodityRegistry.Create(ctx, commodity)
+				})
 				if err != nil {
-					errors <- fmt.Errorf("user %d failed to create commodity %d: %v", userIndex, j, err)
+					errCh <- fmt.Errorf("user %d failed to create commodity %d: %w", userIndex, j, err)
 					return
 				}
 			}
 
-			// List commodities and verify isolation
-			commodities, err := userAwareCommodityRegistry.List(ctx)
+			commodities, err := comReg.List(f.ctx)
 			if err != nil {
-				errors <- fmt.Errorf("user %d failed to list commodities: %v", userIndex, err)
+				errCh <- fmt.Errorf("user %d failed to list commodities: %w", userIndex, err)
 				return
 			}
-
-			// Should see exactly 10 commodities (own commodities only)
 			if len(commodities) != 10 {
-				errors <- fmt.Errorf("user %d sees %d commodities, expected 10", userIndex, len(commodities))
+				errCh <- fmt.Errorf("user %d sees %d commodities, expected 10", userIndex, len(commodities))
 				return
 			}
-
-			// Verify all commodities belong to this user
 			for _, commodity := range commodities {
-				if commodity.GetCreatedByUserID() != u.ID {
-					errors <- fmt.Errorf("user %d can see commodity belonging to user %s", userIndex, commodity.GetCreatedByUserID())
+				if commodity.GetCreatedByUserID() != f.user.ID {
+					errCh <- fmt.Errorf("user %d can see commodity belonging to user %s", userIndex, commodity.GetCreatedByUserID())
 					return
 				}
 			}
-		}(i, user)
+		}(userIndex, f)
 	}
 
 	wg.Wait()
-	close(errors)
+	close(errCh)
 
-	// Check for any errors
-	for err := range errors {
+	for err := range errCh {
 		c.Errorf("Load test error: %v", err)
 	}
 }
 
-// TestUserIsolation_SecurityBoundaries tests security edge cases
+// TestUserIsolation_SecurityBoundaries tests security edge cases: a battery of
+// malicious / malformed user identities must never be able to read, list,
+// update, or delete a legitimate user's commodity. This test RUNS in CI.
 func TestUserIsolation_SecurityBoundaries(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Create a legitimate user
-	user := createTestUser(c, registrySet.UserRegistry, "legitimate@example.com")
-	ctx := appctx.WithUser(context.Background(), user)
+	// Create a legitimate user + group and seed a commodity they own.
+	tenant := createIsolationTenant(c, fs)
+	legit := newGroupedUser(c, fs, tenant, "legitimate@example.com", "Legit Group")
 
-	// Create location and area for the commodity
-	location := models.Location{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "security-test-location"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user.ID,
-		},
-		Name:    "Security Test Location",
-		Address: "123 Security Street",
-	}
-	userAwareLocationRegistry, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
-	createdLocation, err := userAwareLocationRegistry.Create(ctx, location)
-	c.Assert(err, qt.IsNil)
+	loc := seedLocation(c, fs, legit, "Security Test Location")
+	area := seedArea(c, fs, legit, loc.ID, "Security Test Area")
+	created := seedCommodity(c, fs, legit, area.ID, "Security Test Commodity", "STC")
 
-	area := models.Area{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "security-test-area"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user.ID,
-		},
-		Name:       "Security Test Area",
-		LocationID: createdLocation.ID,
-	}
-	userAwareAreaRegistry, err := registrySet.AreaRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
-	createdArea, err := userAwareAreaRegistry.Create(ctx, area)
-	c.Assert(err, qt.IsNil)
-
-	// Create a commodity
-	commodity := models.Commodity{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "security-test-commodity"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user.ID,
-		},
-		Name:                   "Security Test Commodity",
-		ShortName:              "STC",
-		AreaID:                 new(createdArea.ID),
-		Type:                   models.CommodityTypeElectronics,
-		Count:                  1,
-		OriginalPrice:          decimal.NewFromFloat(100.00),
-		OriginalPriceCurrency:  "USD",
-		ConvertedOriginalPrice: decimal.Zero,
-		CurrentPrice:           decimal.NewFromFloat(90.00),
-		Status:                 models.CommodityStatusInUse,
-		PurchaseDate:           models.ToPDate("2023-01-01"),
-		RegisteredDate:         models.ToPDate("2023-01-02"),
-		LastModifiedDate:       models.ToPDate("2023-01-03"),
-		Draft:                  false,
-	}
-	userAwareCommodityRegistry, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
-	created, err := userAwareCommodityRegistry.Create(ctx, commodity)
-	c.Assert(err, qt.IsNil)
-
-	// Test various malicious user ID attempts
+	// Various malicious user IDs. Each is paired with a bogus group so the
+	// registry factory always builds successfully and the RLS denial — not a
+	// missing-group setup error — is what we exercise.
 	maliciousUserIDs := []string{
 		"'; DROP TABLE commodities; --",
 		"<script>alert('xss')</script>",
@@ -345,132 +256,94 @@ func TestUserIsolation_SecurityBoundaries(t *testing.T) {
 	}
 
 	for _, maliciousID := range maliciousUserIDs {
-		// Create a sanitized test name to avoid 0x00 pollution in output
 		testName := fmt.Sprintf("Malicious ID: %q", maliciousID)
 		if len(maliciousID) > 100 {
 			testName = fmt.Sprintf("Malicious ID: very_long_string_%d_bytes", len(maliciousID))
 		}
 		t.Run(testName, func(t *testing.T) {
 			c := qt.New(t)
-			maliciousCtx := appctx.WithUser(context.Background(), &models.User{
-				TenantAwareEntityID: models.TenantAwareEntityID{
-					EntityID: models.EntityID{ID: maliciousID},
-					TenantID: "test-tenant-id",
+			maliciousCtx := userGroupContext(
+				context.Background(),
+				&models.User{
+					TenantAwareEntityID: models.TenantAwareEntityID{
+						EntityID: models.EntityID{ID: maliciousID},
+						TenantID: "non-existent-tenant-id",
+					},
 				},
-			})
+				&models.LocationGroup{
+					TenantAwareEntityID: models.TenantAwareEntityID{
+						EntityID: models.EntityID{ID: "non-existent-group-id"},
+						TenantID: "non-existent-tenant-id",
+					},
+					GroupCurrency: models.Currency("USD"),
+				},
+			)
 
-			// Try to access the legitimate user's commodity
-			maliciousUserAwareRegistry, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(maliciousCtx)
+			maliciousReg, err := fs.CommodityRegistryFactory.CreateUserRegistry(maliciousCtx)
 			if err != nil {
-				// If CreateUserRegistry fails, that's expected for malicious contexts
+				// If CreateUserRegistry fails, that's an acceptable outcome for a
+				// malicious context — denial achieved.
 				return
 			}
-			_, err = maliciousUserAwareRegistry.Get(maliciousCtx, created.ID)
-			c.Assert(err, qt.IsNotNil) // Should fail
 
-			// Try to list commodities
-			commodities, err := maliciousUserAwareRegistry.List(maliciousCtx)
+			// Cannot Get the legit commodity.
+			_, err = maliciousReg.Get(maliciousCtx, created.ID)
+			c.Assert(err, qt.IsNotNil)
+
+			// List must not leak the legit commodity.
+			commodities, err := maliciousReg.List(maliciousCtx)
 			if err == nil {
-				// If no error, should return empty list
 				c.Assert(commodities, qt.HasLen, 0)
 			}
 
-			// Try to update the commodity
-			created.Name = "Hacked Name"
-			_, err = maliciousUserAwareRegistry.Update(maliciousCtx, *created)
-			c.Assert(err, qt.IsNotNil) // Should fail
+			// Cannot Update.
+			tampered := *created
+			tampered.Name = "Hacked Name"
+			_, err = maliciousReg.Update(maliciousCtx, tampered)
+			c.Assert(err, qt.IsNotNil)
 
-			// Try to delete the commodity
-			err = maliciousUserAwareRegistry.Delete(maliciousCtx, created.ID)
-			c.Assert(err, qt.IsNotNil) // Should fail
+			// Cannot Delete.
+			err = maliciousReg.Delete(maliciousCtx, created.ID)
+			c.Assert(err, qt.IsNotNil)
 		})
 	}
 
-	// Verify the original commodity is still intact
-	retrieved, err := userAwareCommodityRegistry.Get(ctx, created.ID)
+	// The legit commodity survives the assault intact.
+	legitReg := must.Must(fs.CommodityRegistryFactory.CreateUserRegistry(legit.ctx))
+	retrieved, err := legitReg.Get(legit.ctx, created.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(retrieved.Name, qt.Equals, "Security Test Commodity")
 }
 
-// TestUserIsolation_PerformanceRegression tests for performance regressions
+// TestUserIsolation_PerformanceRegression tests for performance regressions.
+// Excluded from CI via `-skip 'PerformanceRegression'`; kept compiling + correct.
 func TestUserIsolation_PerformanceRegression(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Create a user
-	user := createTestUser(c, registrySet.UserRegistry, "perf@example.com")
-	ctx := appctx.WithUser(context.Background(), user)
+	tenant := createIsolationTenant(c, fs)
+	f := newGroupedUser(c, fs, tenant, "perf@example.com", "Perf Group")
 
-	// Create location and area for commodities
-	location := models.Location{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "perf-location"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user.ID,
-		},
-		Name:    "Performance Test Location",
-		Address: "123 Performance Street",
-	}
-	userAwareLocationRegistry, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
-	createdLocation, err := userAwareLocationRegistry.Create(ctx, location)
-	c.Assert(err, qt.IsNil)
+	loc := seedLocation(c, fs, f, "Performance Test Location")
+	area := seedArea(c, fs, f, loc.ID, "Performance Test Area")
 
-	area := models.Area{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "perf-area"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user.ID,
-		},
-		Name:       "Performance Test Area",
-		LocationID: createdLocation.ID,
-	}
-	userAwareAreaRegistry, err := registrySet.AreaRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
-	createdArea, err := userAwareAreaRegistry.Create(ctx, area)
-	c.Assert(err, qt.IsNil)
-
-	// Create many commodities
 	numCommodities := 1000
-	userAwareCommodityRegistry, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
-	c.Assert(err, qt.IsNil)
+	comReg := must.Must(fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
 
 	for i := range numCommodities {
-		commodity := models.Commodity{
-			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-				EntityID:        models.EntityID{ID: fmt.Sprintf("perf-commodity-%d", i)},
-				TenantID:        "test-tenant-id",
-				CreatedByUserID: user.ID,
-			},
-			Name:                   fmt.Sprintf("Performance Test Commodity %d", i),
-			ShortName:              fmt.Sprintf("PTC%d", i),
-			AreaID:                 new(createdArea.ID),
-			Type:                   models.CommodityTypeElectronics,
-			Count:                  1,
-			OriginalPrice:          decimal.NewFromFloat(100.00),
-			OriginalPriceCurrency:  "USD",
-			ConvertedOriginalPrice: decimal.Zero,
-			CurrentPrice:           decimal.NewFromFloat(90.00),
-			Status:                 models.CommodityStatusInUse,
-			PurchaseDate:           models.ToPDate("2023-01-01"),
-			RegisteredDate:         models.ToPDate("2023-01-02"),
-			LastModifiedDate:       models.ToPDate("2023-01-03"),
-			Draft:                  false,
-		}
-		_, err = userAwareCommodityRegistry.Create(ctx, commodity)
-		c.Assert(err, qt.IsNil)
+		_ = seedCommodity(c, fs, f, area.ID,
+			fmt.Sprintf("Performance Test Commodity %d", i),
+			fmt.Sprintf("PTC%d", i))
 	}
 
-	// Measure list performance
 	start := time.Now()
-	commodities, err := userAwareCommodityRegistry.List(ctx)
+	commodities, err := comReg.List(f.ctx)
 	duration := time.Since(start)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(commodities, qt.HasLen, numCommodities)
 
-	// Performance should be reasonable (less than 1 second for 1000 items)
 	if duration > time.Second {
 		t.Errorf("List operation took too long: %v", duration)
 	}

--- a/go/integration/user_isolation_test.go
+++ b/go/integration/user_isolation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
 	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/appctx"
@@ -16,39 +17,62 @@ import (
 	"github.com/denisvmedia/inventario/registry/postgres"
 )
 
-// setupTestDatabase creates a test database connection and returns cleanup function
+// setupTestDatabase creates a test database connection and returns cleanup function.
 func setupTestDatabase(t *testing.T) (*registry.FactorySet, func()) {
-	dsn := os.Getenv("POSTGRES_TEST_DSN")
-	if dsn == "" {
-		t.Skip("POSTGRES_TEST_DSN environment variable not set")
-		return nil, nil
-	}
+	t.Helper()
+	dsn := mustTestDSN(t)
 
-	// Set up fresh database with bootstrap and migrations
+	// Set up fresh database with bootstrap and migrations.
 	err := setupFreshDatabase(dsn)
 	if err != nil {
 		t.Fatalf("Failed to setup fresh database: %v", err)
 	}
 
 	registrySetFunc, cleanupFunc := postgres.NewPostgresRegistrySet()
-	registrySet, err := registrySetFunc(registry.Config(dsn))
+	factorySet, err := registrySetFunc(registry.Config(dsn))
 	if err != nil {
 		t.Fatalf("Failed to create registry set: %v", err)
 	}
 
-	return registrySet, func() {
+	return factorySet, func() {
 		cleanupFunc()
 	}
 }
 
-// createTestUser creates a test user with the given email and returns the created user
-func createTestUser(c *qt.C, userRegistry registry.UserRegistry, email string) *models.User {
-	// Make email unique by adding timestamp to avoid conflicts between tests
+// mustTestDSN returns the Postgres DSN for the integration suite, skipping the
+// test when it is unset (the CI gate that does set it is issue #2094).
+func mustTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("POSTGRES_TEST_DSN environment variable not set")
+	}
+	return dsn
+}
+
+// createTestTenant creates a real, active tenant row. location_groups and users
+// FK to tenants, so the isolation tests need a genuine tenant id rather than the
+// pre-groups era's hardcoded "test-tenant-id" string.
+func createIsolationTenant(c *qt.C, fs *registry.FactorySet) *models.Tenant {
+	c.Helper()
+	uniq := fmt.Sprintf("%d", time.Now().UnixNano())
+	tenant := must.Must(fs.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Isolation Tenant " + uniq,
+		Slug:   "isolation-tenant-" + uniq,
+		Status: models.TenantStatusActive,
+	}))
+	return tenant
+}
+
+// createTestUser creates a test user in the given tenant. The id is minted
+// server-side; the email is made unique so repeated calls within a suite never
+// collide on the unique-email constraint.
+func createTestUser(c *qt.C, userRegistry registry.UserRegistry, tenantID, email string) *models.User {
+	c.Helper()
 	uniqueEmail := fmt.Sprintf("%s-%d", email, time.Now().UnixNano())
 	user := models.User{
 		TenantAwareEntityID: models.TenantAwareEntityID{
-			EntityID: models.EntityID{ID: "user-" + uniqueEmail},
-			TenantID: "test-tenant-id",
+			TenantID: tenantID,
 		},
 		Email:    uniqueEmail,
 		Name:     "Test User",
@@ -65,66 +89,107 @@ func createTestUser(c *qt.C, userRegistry registry.UserRegistry, email string) *
 	return created
 }
 
-// withUserContext creates a context with the given user ID
-func withUserContext(ctx context.Context, userID string) context.Context {
-	return appctx.WithUser(ctx, &models.User{
-		TenantAwareEntityID: models.TenantAwareEntityID{
-			EntityID: models.EntityID{ID: userID},
-			TenantID: "test-tenant-id",
-		},
-	})
+// createTestGroup creates an active USD location group owned by the given user.
+// RLS for locations/areas/commodities/files/exports is GROUP-scoped
+// (tenant_id AND group_id), so every isolation fixture needs its own group, and
+// the group MUST carry GroupCurrency (commodity validation reads it off the
+// group in context).
+func createTestGroup(c *qt.C, fs *registry.FactorySet, tenantID, userID, name string) *models.LocationGroup {
+	c.Helper()
+	group := must.Must(fs.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Slug:                must.Must(models.GenerateGroupSlug()),
+		Name:                name,
+		Status:              models.LocationGroupStatusActive,
+		GroupCurrency:       models.Currency("USD"),
+		CreatedBy:           userID,
+	}))
+	return group
 }
 
-// TestUserIsolation_Commodities tests that users cannot access each other's commodities
-func TestUserIsolation_Commodities(t *testing.T) {
-	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
-	defer cleanup()
+// userGroupContext builds the request context the user-aware registries expect:
+// it carries BOTH the user (→ get_current_tenant_id / get_current_user_id) AND
+// the group (→ get_current_group_id). Without the group, group-scoped RLS sees
+// an empty get_current_group_id() and every create/read fails closed.
+func userGroupContext(ctx context.Context, user *models.User, group *models.LocationGroup) context.Context {
+	return appctx.WithGroup(appctx.WithUser(ctx, user), group)
+}
 
-	// Setup: Create two users
-	user1 := createTestUser(c, registrySet.UserRegistry, "user1@example.com")
-	user2 := createTestUser(c, registrySet.UserRegistry, "user2@example.com")
+// isolationFixture is a fully-wired single-user tenant/group/context bundle used
+// by the isolation tests. Two fixtures in DIFFERENT groups model the two parties
+// whose data must stay mutually invisible under group-scoped RLS.
+type isolationFixture struct {
+	tenant *models.Tenant
+	user   *models.User
+	group  *models.LocationGroup
+	ctx    context.Context
+}
 
-	// Create location and area for user1's commodity
-	ctx1 := withUserContext(context.Background(), user1.ID)
-	location1 := models.Location{
+// newIsolationPair builds two users in two SEPARATE groups within ONE tenant.
+// Same tenant + different group is exactly what makes the negative assertions
+// meaningful: isolation here is enforced by the group dimension of RLS, not by
+// the tenant dimension (which is held constant) and not by user id.
+func newIsolationPair(c *qt.C, fs *registry.FactorySet) (user1, user2 isolationFixture) {
+	c.Helper()
+	tenant := createIsolationTenant(c, fs)
+
+	u1 := createTestUser(c, fs.UserRegistry, tenant.ID, "user1@example.com")
+	g1 := createTestGroup(c, fs, tenant.ID, u1.ID, "User1 Group")
+
+	u2 := createTestUser(c, fs.UserRegistry, tenant.ID, "user2@example.com")
+	g2 := createTestGroup(c, fs, tenant.ID, u2.ID, "User2 Group")
+
+	user1 = isolationFixture{tenant: tenant, user: u1, group: g1, ctx: userGroupContext(context.Background(), u1, g1)}
+	user2 = isolationFixture{tenant: tenant, user: u2, group: g2, ctx: userGroupContext(context.Background(), u2, g2)}
+	return user1, user2
+}
+
+// seedLocation creates a location owned by the fixture's user/group via the
+// user-aware (RLS-scoped) registry.
+func seedLocation(c *qt.C, fs *registry.FactorySet, f isolationFixture, name string) *models.Location {
+	c.Helper()
+	reg := must.Must(fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	return must.Must(reg.Create(f.ctx, models.Location{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "location-user1"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
+			TenantID:        f.tenant.ID,
+			GroupID:         f.group.ID,
+			CreatedByUserID: f.user.ID,
 		},
-		Name:    "User1 Location",
-		Address: "123 User1 Street",
-	}
-	userAwareLocationRegistry1, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	createdLocation1, err := userAwareLocationRegistry1.Create(ctx1, location1)
-	c.Assert(err, qt.IsNil)
+		Name:    name,
+		Address: "123 " + name + " Street",
+	}))
+}
 
-	area1 := models.Area{
+// seedArea creates an area under the given location, owned by the fixture.
+func seedArea(c *qt.C, fs *registry.FactorySet, f isolationFixture, locationID, name string) *models.Area {
+	c.Helper()
+	reg := must.Must(fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	return must.Must(reg.Create(f.ctx, models.Area{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "area-user1"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
+			TenantID:        f.tenant.ID,
+			GroupID:         f.group.ID,
+			CreatedByUserID: f.user.ID,
 		},
-		Name:       "User1 Area",
-		LocationID: createdLocation1.ID,
-	}
-	userAwareAreaRegistry1, err := registrySet.AreaRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	createdArea1, err := userAwareAreaRegistry1.Create(ctx1, area1)
-	c.Assert(err, qt.IsNil)
+		Name:       name,
+		LocationID: locationID,
+	}))
+}
 
-	// Test: User1 creates a commodity
-	commodity1 := models.Commodity{
+// seedCommodity creates a non-draft commodity in the given area, owned by the
+// fixture. Currency is USD to match the group currency (so ConvertedOriginalPrice
+// stays zero).
+func seedCommodity(c *qt.C, fs *registry.FactorySet, f isolationFixture, areaID, name, shortName string) *models.Commodity {
+	c.Helper()
+	reg := must.Must(fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+	return must.Must(reg.Create(f.ctx, models.Commodity{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "commodity-user1"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
+			TenantID:        f.tenant.ID,
+			GroupID:         f.group.ID,
+			CreatedByUserID: f.user.ID,
 		},
-		Name:                   "User1 Commodity",
-		ShortName:              "UC1",
-		AreaID:                 new(createdArea1.ID),
+		Name:                   name,
+		ShortName:              shortName,
+		AreaID:                 new(areaID),
 		Type:                   models.CommodityTypeElectronics,
 		Count:                  1,
 		OriginalPrice:          decimal.NewFromFloat(100.00),
@@ -136,98 +201,87 @@ func TestUserIsolation_Commodities(t *testing.T) {
 		RegisteredDate:         models.ToPDate("2023-01-02"),
 		LastModifiedDate:       models.ToPDate("2023-01-03"),
 		Draft:                  false,
-	}
+	}))
+}
 
-	userAwareCommodityRegistry1, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	created1, err := userAwareCommodityRegistry1.Create(ctx1, commodity1)
-	c.Assert(err, qt.IsNil)
-	c.Assert(created1, qt.IsNotNil)
-	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.ID)
+// TestUserIsolation_Commodities tests that a user in one group cannot access a
+// commodity created by a user in a different group (group-scoped RLS).
+func TestUserIsolation_Commodities(t *testing.T) {
+	c := qt.New(t)
+	fs, cleanup := setupTestDatabase(t)
+	defer cleanup()
 
-	// Test: User2 cannot access User1's commodity
-	ctx2 := withUserContext(context.Background(), user2.ID)
-	userAwareCommodityRegistry2, err := registrySet.CommodityRegistryFactory.CreateUserRegistry(ctx2)
-	c.Assert(err, qt.IsNil)
-	_, err = userAwareCommodityRegistry2.Get(ctx2, created1.ID)
+	user1, user2 := newIsolationPair(c, fs)
+
+	// User1 creates location → area → commodity in group1.
+	loc1 := seedLocation(c, fs, user1, "User1 Location")
+	area1 := seedArea(c, fs, user1, loc1.ID, "User1 Area")
+	created1 := seedCommodity(c, fs, user1, area1.ID, "User1 Commodity", "UC1")
+	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.user.ID)
+
+	// User2 (different group) cannot Get user1's commodity.
+	reg2 := must.Must(fs.CommodityRegistryFactory.CreateUserRegistry(user2.ctx))
+	_, err := reg2.Get(user2.ctx, created1.ID)
 	c.Assert(err, qt.IsNotNil)
 
-	// Test: User2 cannot see User1's commodity in list
-	commodities2, err := userAwareCommodityRegistry2.List(ctx2)
+	// User2 cannot see user1's commodity in their list.
+	commodities2, err := reg2.List(user2.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(commodities2, qt.HasLen, 0)
 
-	// Test: User1 can see their own commodity
-	commodities1, err := userAwareCommodityRegistry1.List(ctx1)
+	// User1 can see their own commodity.
+	reg1 := must.Must(fs.CommodityRegistryFactory.CreateUserRegistry(user1.ctx))
+	commodities1, err := reg1.List(user1.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(commodities1, qt.HasLen, 1)
 	c.Assert(commodities1[0].ID, qt.Equals, created1.ID)
 }
 
-// TestUserIsolation_Locations tests that users cannot access each other's locations
+// TestUserIsolation_Locations tests that a user in one group cannot access a
+// location created by a user in a different group.
 func TestUserIsolation_Locations(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Setup: Create two users
-	user1 := createTestUser(c, registrySet.UserRegistry, "user1@example.com")
-	user2 := createTestUser(c, registrySet.UserRegistry, "user2@example.com")
+	user1, user2 := newIsolationPair(c, fs)
 
-	// Test: User1 creates a location
-	ctx1 := withUserContext(context.Background(), user1.ID)
-	location1 := models.Location{
-		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
-		},
-		Name:    "User1 Location",
-		Address: "123 User1 Street",
-	}
+	created1 := seedLocation(c, fs, user1, "User1 Location")
+	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.user.ID)
 
-	userAwareLocationRegistry1, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	created1, err := userAwareLocationRegistry1.Create(ctx1, location1)
-	c.Assert(err, qt.IsNil)
-	c.Assert(created1, qt.IsNotNil)
-	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.ID)
-
-	// Test: User2 cannot access User1's location
-	ctx2 := withUserContext(context.Background(), user2.ID)
-	userAwareLocationRegistry2, err := registrySet.LocationRegistryFactory.CreateUserRegistry(ctx2)
-	c.Assert(err, qt.IsNil)
-	_, err = userAwareLocationRegistry2.Get(ctx2, created1.ID)
+	// User2 (different group) cannot Get user1's location.
+	reg2 := must.Must(fs.LocationRegistryFactory.CreateUserRegistry(user2.ctx))
+	_, err := reg2.Get(user2.ctx, created1.ID)
 	c.Assert(err, qt.IsNotNil)
 
-	// Test: User2 cannot see User1's location in list
-	locations2, err := userAwareLocationRegistry2.List(ctx2)
+	// User2 cannot see user1's location in their list.
+	locations2, err := reg2.List(user2.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(locations2, qt.HasLen, 0)
 
-	// Test: User1 can see their own location
-	locations1, err := userAwareLocationRegistry1.List(ctx1)
+	// User1 can see their own location.
+	reg1 := must.Must(fs.LocationRegistryFactory.CreateUserRegistry(user1.ctx))
+	locations1, err := reg1.List(user1.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(locations1, qt.HasLen, 1)
 	c.Assert(locations1[0].ID, qt.Equals, created1.ID)
 }
 
-// TestUserIsolation_Files tests that users cannot access each other's files
+// TestUserIsolation_Files tests that a user in one group cannot access a file
+// created by a user in a different group.
 func TestUserIsolation_Files(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Setup: Create two users
-	user1 := createTestUser(c, registrySet.UserRegistry, "user1@example.com")
-	user2 := createTestUser(c, registrySet.UserRegistry, "user2@example.com")
+	user1, user2 := newIsolationPair(c, fs)
 
-	// Test: User1 creates a file
-	ctx1 := withUserContext(context.Background(), user1.ID)
-	file1 := models.FileEntity{
+	reg1 := must.Must(fs.FileRegistryFactory.CreateUserRegistry(user1.ctx))
+	created1 := must.Must(reg1.Create(user1.ctx, models.FileEntity{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "file-user1"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
+			TenantID:        user1.tenant.ID,
+			GroupID:         user1.group.ID,
+			CreatedByUserID: user1.user.ID,
 		},
 		Title:       "User1 File",
 		Description: "A file created by user1",
@@ -238,78 +292,61 @@ func TestUserIsolation_Files(t *testing.T) {
 			Ext:          ".txt",
 			MIMEType:     "text/plain",
 		},
-	}
+	}))
+	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.user.ID)
 
-	userAwareFileRegistry1, err := registrySet.FileRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	created1, err := userAwareFileRegistry1.Create(ctx1, file1)
-	c.Assert(err, qt.IsNil)
-	c.Assert(created1, qt.IsNotNil)
-	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.ID)
-
-	// Test: User2 cannot access User1's file
-	ctx2 := withUserContext(context.Background(), user2.ID)
-	userAwareFileRegistry2, err := registrySet.FileRegistryFactory.CreateUserRegistry(ctx2)
-	c.Assert(err, qt.IsNil)
-	_, err = userAwareFileRegistry2.Get(ctx2, created1.ID)
+	// User2 (different group) cannot Get user1's file.
+	reg2 := must.Must(fs.FileRegistryFactory.CreateUserRegistry(user2.ctx))
+	_, err := reg2.Get(user2.ctx, created1.ID)
 	c.Assert(err, qt.IsNotNil)
 
-	// Test: User2 cannot see User1's file in list
-	files2, err := userAwareFileRegistry2.List(ctx2)
+	// User2 cannot see user1's file in their list.
+	files2, err := reg2.List(user2.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(files2, qt.HasLen, 0)
 
-	// Test: User1 can see their own file
-	files1, err := userAwareFileRegistry1.List(ctx1)
+	// User1 can see their own file.
+	files1, err := reg1.List(user1.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(files1, qt.HasLen, 1)
 	c.Assert(files1[0].ID, qt.Equals, created1.ID)
 }
 
-// TestUserIsolation_Exports tests that users cannot access each other's exports
+// TestUserIsolation_Exports tests that a user in one group cannot access an
+// export created by a user in a different group. Exports are GROUP-scoped just
+// like the other entities (tenant_id AND group_id in the RLS policy).
 func TestUserIsolation_Exports(t *testing.T) {
 	c := qt.New(t)
-	registrySet, cleanup := setupTestDatabase(t)
+	fs, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
-	// Setup: Create two users
-	user1 := createTestUser(c, registrySet.UserRegistry, "user1@example.com")
-	user2 := createTestUser(c, registrySet.UserRegistry, "user2@example.com")
+	user1, user2 := newIsolationPair(c, fs)
 
-	// Test: User1 creates an export
-	ctx1 := withUserContext(context.Background(), user1.ID)
-	export1 := models.Export{
+	reg1 := must.Must(fs.ExportRegistryFactory.CreateUserRegistry(user1.ctx))
+	created1 := must.Must(reg1.Create(user1.ctx, models.Export{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
-			EntityID:        models.EntityID{ID: "export-user1"},
-			TenantID:        "test-tenant-id",
-			CreatedByUserID: user1.ID,
+			TenantID:        user1.tenant.ID,
+			GroupID:         user1.group.ID,
+			CreatedByUserID: user1.user.ID,
 		},
 		Type:        models.ExportTypeFullDatabase,
 		Description: "An export created by user1",
 		Status:      models.ExportStatusPending,
-	}
+	}))
+	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.user.ID)
 
-	userAwareExportRegistry1, err := registrySet.ExportRegistryFactory.CreateUserRegistry(ctx1)
-	c.Assert(err, qt.IsNil)
-	created1, err := userAwareExportRegistry1.Create(ctx1, export1)
-	c.Assert(err, qt.IsNil)
-	c.Assert(created1, qt.IsNotNil)
-	c.Assert(created1.GetCreatedByUserID(), qt.Equals, user1.ID)
-
-	// Test: User2 cannot access User1's export
-	ctx2 := withUserContext(context.Background(), user2.ID)
-	userAwareExportRegistry2, err := registrySet.ExportRegistryFactory.CreateUserRegistry(ctx2)
-	c.Assert(err, qt.IsNil)
-	_, err = userAwareExportRegistry2.Get(ctx2, created1.ID)
+	// User2 (different group) cannot Get user1's export.
+	reg2 := must.Must(fs.ExportRegistryFactory.CreateUserRegistry(user2.ctx))
+	_, err := reg2.Get(user2.ctx, created1.ID)
 	c.Assert(err, qt.IsNotNil)
 
-	// Test: User2 cannot see User1's export in list
-	exports2, err := userAwareExportRegistry2.List(ctx2)
+	// User2 cannot see user1's export in their list.
+	exports2, err := reg2.List(user2.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(exports2, qt.HasLen, 0)
 
-	// Test: User1 can see their own export
-	exports1, err := userAwareExportRegistry1.List(ctx1)
+	// User1 can see their own export.
+	exports1, err := reg1.List(user1.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(exports1, qt.HasLen, 1)
 	c.Assert(exports1[0].ID, qt.Equals, created1.ID)

--- a/go/models/backoffice_user_mfa_secret.go
+++ b/go/models/backoffice_user_mfa_secret.go
@@ -59,6 +59,12 @@ type BackofficeUserMFASecret struct {
 	// CLI surfaces it as "Last used" on the disable confirmation prompt.
 	//migrator:schema:field name="last_used_at" type="TIMESTAMP"
 	LastUsedAt *time.Time `json:"last_used_at,omitempty" db:"last_used_at" userinput:"false"`
+	// LastUsedStep is the TOTP time-step counter (unix/30) of the most
+	// recently accepted TOTP code. A presented code whose computed step is
+	// <= this value is a replay within the ±1-step skew window and is
+	// rejected (RFC 6238 §5.2). Bumped atomically on each accepted TOTP.
+	//migrator:schema:field name="last_used_step" type="BIGINT" not_null="true" default="0"
+	LastUsedStep int64 `json:"-" db:"last_used_step" userinput:"false"`
 	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"

--- a/go/models/user_mfa_secret.go
+++ b/go/models/user_mfa_secret.go
@@ -57,6 +57,12 @@ type UserMFASecret struct {
 	// surfaces it as "Last used" on the disable confirmation card.
 	//migrator:schema:field name="last_used_at" type="TIMESTAMP"
 	LastUsedAt *time.Time `json:"last_used_at,omitempty" db:"last_used_at" userinput:"false"`
+	// LastUsedStep is the TOTP time-step counter (unix/30) of the most
+	// recently accepted TOTP code. A presented code whose computed step is
+	// <= this value is a replay within the ±1-step skew window and is
+	// rejected (RFC 6238 §5.2). Bumped atomically on each accepted TOTP.
+	//migrator:schema:field name="last_used_step" type="BIGINT" not_null="true" default="0"
+	LastUsedStep int64 `json:"-" db:"last_used_step" userinput:"false"`
 	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"

--- a/go/registry/memory/backoffice_user_mfa_secrets.go
+++ b/go/registry/memory/backoffice_user_mfa_secrets.go
@@ -207,5 +207,9 @@ func (r *BackofficeUserMFASecretRegistry) MarkTOTPStepUsedAtomic(_ context.Conte
 		row.UpdatedAt = now
 		return true, nil
 	}
-	return false, errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
+	// No row → the step could not be claimed. Mirror the postgres CAS, which
+	// reports zero affected rows as (false, nil): a lost CAS (rejected like a
+	// wrong code), not an infrastructure error — keeps memory and production
+	// on one control flow (#2124).
+	return false, nil
 }

--- a/go/registry/memory/backoffice_user_mfa_secrets.go
+++ b/go/registry/memory/backoffice_user_mfa_secrets.go
@@ -181,26 +181,6 @@ func (r *BackofficeUserMFASecretRegistry) ConsumeBackupCodeAtomic(
 	return false, errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
 }
 
-// BumpLastUsedAt sets LastUsedAt to `now` and bumps UpdatedAt. Used by
-// the login MFA handler after a successful TOTP verification.
-func (r *BackofficeUserMFASecretRegistry) BumpLastUsedAt(_ context.Context, backofficeUserID string, now time.Time) error {
-	if backofficeUserID == "" {
-		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "BackofficeUserID"))
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
-		row := pair.Value
-		if row.BackofficeUserID == backofficeUserID {
-			stamped := now
-			row.LastUsedAt = &stamped
-			row.UpdatedAt = time.Now().UTC()
-			return nil
-		}
-	}
-	return errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
-}
-
 // MarkTOTPStepUsedAtomic replicates the postgres CAS under the registry
 // write lock: it bumps last_used_step to `step` only when the stored
 // value is strictly less, returning whether this call won. The lock held

--- a/go/registry/memory/backoffice_user_mfa_secrets.go
+++ b/go/registry/memory/backoffice_user_mfa_secrets.go
@@ -200,3 +200,32 @@ func (r *BackofficeUserMFASecretRegistry) BumpLastUsedAt(_ context.Context, back
 	}
 	return errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
 }
+
+// MarkTOTPStepUsedAtomic replicates the postgres CAS under the registry
+// write lock: it bumps last_used_step to `step` only when the stored
+// value is strictly less, returning whether this call won. The lock held
+// for the read-compare-write serialises two concurrent callers presenting
+// the same code (same step) — only the first wins (#2124).
+func (r *BackofficeUserMFASecretRegistry) MarkTOTPStepUsedAtomic(_ context.Context, backofficeUserID string, step int64, now time.Time) (bool, error) {
+	if backofficeUserID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "BackofficeUserID"))
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		row := pair.Value
+		if row.BackofficeUserID != backofficeUserID {
+			continue
+		}
+		if row.LastUsedStep >= step {
+			// Replay (or stale) — the step was already consumed.
+			return false, nil
+		}
+		row.LastUsedStep = step
+		stamped := now
+		row.LastUsedAt = &stamped
+		row.UpdatedAt = now
+		return true, nil
+	}
+	return false, errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
+}

--- a/go/registry/memory/user_mfa_secrets.go
+++ b/go/registry/memory/user_mfa_secrets.go
@@ -157,7 +157,11 @@ func (r *UserMFASecretRegistry) MarkTOTPStepUsedAtomic(_ context.Context, tenant
 		mfa.UpdatedAt = now
 		return true, nil
 	}
-	return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
+	// No row → the step could not be claimed. Mirror the postgres CAS, which
+	// reports zero affected rows as (false, nil): the handler treats that as a
+	// lost CAS (rejected like a wrong code), not an infrastructure error, so
+	// the two backends share one control flow (#2124).
+	return false, nil
 }
 
 // UpdateBackupCodes replaces BackupCodesHashed for the regenerate flow,

--- a/go/registry/memory/user_mfa_secrets.go
+++ b/go/registry/memory/user_mfa_secrets.go
@@ -127,6 +127,39 @@ func (r *UserMFASecretRegistry) ConsumeBackupCodeAtomic(
 	return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
 }
 
+// MarkTOTPStepUsedAtomic replicates the postgres CAS under the registry
+// write lock: it bumps last_used_step to `step` only when the stored
+// value is strictly less, returning whether this call won. The lock held
+// for the read-compare-write makes two concurrent callers presenting the
+// same code (same step) serialise — only the first wins, the second sees
+// the already-advanced step and loses (#2124).
+func (r *UserMFASecretRegistry) MarkTOTPStepUsedAtomic(_ context.Context, tenantID, userID string, step int64, now time.Time) (bool, error) {
+	if tenantID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if userID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		mfa := pair.Value
+		if mfa.TenantID != tenantID || mfa.UserID != userID {
+			continue
+		}
+		if mfa.LastUsedStep >= step {
+			// Replay (or stale) — the step was already consumed.
+			return false, nil
+		}
+		mfa.LastUsedStep = step
+		mfa.LastUsedAt = &now
+		mfa.UpdatedAt = now
+		return true, nil
+	}
+	return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
+}
+
 func (r *UserMFASecretRegistry) DeleteByUser(_ context.Context, tenantID, userID string) error {
 	if tenantID == "" {
 		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))

--- a/go/registry/memory/user_mfa_secrets.go
+++ b/go/registry/memory/user_mfa_secrets.go
@@ -160,6 +160,31 @@ func (r *UserMFASecretRegistry) MarkTOTPStepUsedAtomic(_ context.Context, tenant
 	return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
 }
 
+// UpdateBackupCodes replaces BackupCodesHashed for the regenerate flow,
+// leaving LastUsedStep / LastUsedAt untouched (owned by
+// MarkTOTPStepUsedAtomic) so a concurrent step advance can't be reverted
+// (#2124).
+func (r *UserMFASecretRegistry) UpdateBackupCodes(_ context.Context, tenantID, userID string, hashes []string, now time.Time) error {
+	if tenantID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if userID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		mfa := pair.Value
+		if mfa.TenantID != tenantID || mfa.UserID != userID {
+			continue
+		}
+		mfa.BackupCodesHashed = hashes
+		mfa.UpdatedAt = now
+		return nil
+	}
+	return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
+}
+
 func (r *UserMFASecretRegistry) DeleteByUser(_ context.Context, tenantID, userID string) error {
 	if tenantID == "" {
 		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))

--- a/go/registry/postgres/backoffice_user_mfa_secrets.go
+++ b/go/registry/postgres/backoffice_user_mfa_secrets.go
@@ -239,34 +239,6 @@ func (r *BackofficeUserMFASecretRegistry) ConsumeBackupCodeAtomic(
 	return consumed, nil
 }
 
-// BumpLastUsedAt sets LastUsedAt to `now` after a successful TOTP
-// verification (the backup-code path bumps it inside
-// ConsumeBackupCodeAtomic instead).
-func (r *BackofficeUserMFASecretRegistry) BumpLastUsedAt(ctx context.Context, backofficeUserID string, now time.Time) error {
-	if backofficeUserID == "" {
-		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "BackofficeUserID"))
-	}
-	reg := r.newSQLRegistry()
-	return reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		query := fmt.Sprintf(
-			`UPDATE %s SET last_used_at = $1, updated_at = now() WHERE backoffice_user_id = $2`,
-			r.tableNames.BackofficeUserMFASecrets(),
-		)
-		res, err := tx.ExecContext(ctx, query, now, backofficeUserID)
-		if err != nil {
-			return errxtrace.Wrap("failed to bump backoffice MFA last_used_at", err)
-		}
-		affected, raErr := res.RowsAffected()
-		if raErr != nil {
-			return errxtrace.Wrap("failed to read rows affected for backoffice MFA bump", raErr)
-		}
-		if affected == 0 {
-			return errxtrace.Classify(registry.ErrBackofficeMFASecretNotFound, errx.Attrs("backoffice_user_id", backofficeUserID))
-		}
-		return nil
-	})
-}
-
 // MarkTOTPStepUsedAtomic compare-and-swaps last_used_step to `step` in a
 // single UPDATE guarded by `last_used_step < $step` — the back-office
 // mirror of UserMFASecretRegistry.MarkTOTPStepUsedAtomic. See there for

--- a/go/registry/postgres/backoffice_user_mfa_secrets.go
+++ b/go/registry/postgres/backoffice_user_mfa_secrets.go
@@ -266,3 +266,38 @@ func (r *BackofficeUserMFASecretRegistry) BumpLastUsedAt(ctx context.Context, ba
 		return nil
 	})
 }
+
+// MarkTOTPStepUsedAtomic compare-and-swaps last_used_step to `step` in a
+// single UPDATE guarded by `last_used_step < $step` — the back-office
+// mirror of UserMFASecretRegistry.MarkTOTPStepUsedAtomic. See there for
+// the full replay-guard rationale (#2124). Returns rowsAffected > 0; a
+// lost CAS (zero rows) is reported as (false, nil), the replay signal.
+// last_used_at / updated_at are bumped in the same statement.
+func (r *BackofficeUserMFASecretRegistry) MarkTOTPStepUsedAtomic(ctx context.Context, backofficeUserID string, step int64, now time.Time) (bool, error) {
+	if backofficeUserID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "BackofficeUserID"))
+	}
+
+	won := false
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`UPDATE %s SET last_used_step = $1, last_used_at = $2, updated_at = $3 WHERE backoffice_user_id = $4 AND last_used_step < $1`,
+			r.tableNames.BackofficeUserMFASecrets(),
+		)
+		res, err := tx.ExecContext(ctx, query, step, now, now, backofficeUserID)
+		if err != nil {
+			return errxtrace.Wrap("failed to mark backoffice TOTP step used", err)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backoffice TOTP step CAS", raErr)
+		}
+		won = affected > 0
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return won, nil
+}

--- a/go/registry/postgres/user_mfa_secrets.go
+++ b/go/registry/postgres/user_mfa_secrets.go
@@ -232,6 +232,50 @@ func (r *UserMFASecretRegistry) ConsumeBackupCodeAtomic(
 	return consumed, nil
 }
 
+// MarkTOTPStepUsedAtomic compare-and-swaps last_used_step to `step` in a
+// single UPDATE guarded by `last_used_step < $step`. The CAS is what
+// makes the TOTP replay guard atomic (#2124): two concurrent step-2
+// requests presenting the SAME code compute the SAME step S, but only
+// the first UPDATE finds last_used_step < S and affects a row — the
+// second affects zero rows and loses. Returns rowsAffected > 0.
+//
+// A single statement (no SELECT … FOR UPDATE) is sufficient because the
+// row-level write lock Postgres takes for the UPDATE serialises the two
+// racers and the WHERE predicate is evaluated against the locked row's
+// committed value. last_used_at / updated_at are bumped in the same
+// statement so the TOTP success path needs no separate BumpLastUsedAt.
+func (r *UserMFASecretRegistry) MarkTOTPStepUsedAtomic(ctx context.Context, tenantID, userID string, step int64, now time.Time) (bool, error) {
+	if tenantID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if userID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+
+	won := false
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`UPDATE %s SET last_used_step = $1, last_used_at = $2, updated_at = $3 WHERE tenant_id = $4 AND user_id = $5 AND last_used_step < $1`,
+			r.tableNames.UserMFASecrets(),
+		)
+		res, err := tx.ExecContext(ctx, query, step, now, now, tenantID, userID)
+		if err != nil {
+			return errxtrace.Wrap("failed to mark user TOTP step used", err)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for user TOTP step CAS", raErr)
+		}
+		won = affected > 0
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return won, nil
+}
+
 // DeleteByUser removes the user's MFA row idempotently — a missing row
 // is not an error, since the disable flow is a no-op for non-enrolled users.
 func (r *UserMFASecretRegistry) DeleteByUser(ctx context.Context, tenantID, userID string) error {

--- a/go/registry/postgres/user_mfa_secrets.go
+++ b/go/registry/postgres/user_mfa_secrets.go
@@ -276,6 +276,39 @@ func (r *UserMFASecretRegistry) MarkTOTPStepUsedAtomic(ctx context.Context, tena
 	return won, nil
 }
 
+// UpdateBackupCodes replaces backup_codes_hashed for the regenerate flow,
+// writing ONLY that column and updated_at. last_used_step / last_used_at are
+// left to MarkTOTPStepUsedAtomic: regenerate CAS-commits the consumed TOTP
+// step first, and a full-row Update here would revert a concurrent step
+// advance, re-opening the replay window (#2124).
+func (r *UserMFASecretRegistry) UpdateBackupCodes(ctx context.Context, tenantID, userID string, hashes []string, now time.Time) error {
+	if tenantID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if userID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+	reg := r.newSQLRegistry()
+	return reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`UPDATE %s SET backup_codes_hashed = $1, updated_at = $2 WHERE tenant_id = $3 AND user_id = $4`,
+			r.tableNames.UserMFASecrets(),
+		)
+		res, err := tx.ExecContext(ctx, query, models.ValuerSlice[string](hashes), now, tenantID, userID)
+		if err != nil {
+			return errxtrace.Wrap("failed to update user MFA backup codes", err)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backup-code update", raErr)
+		}
+		if affected == 0 {
+			return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "UserMFASecret"))
+		}
+		return nil
+	})
+}
+
 // DeleteByUser removes the user's MFA row idempotently — a missing row
 // is not an error, since the disable flow is a no-op for non-enrolled users.
 func (r *UserMFASecretRegistry) DeleteByUser(ctx context.Context, tenantID, userID string) error {

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -2063,6 +2063,21 @@ type UserMFASecretRegistry interface {
 	// classified error on infrastructure failure. Updates LastUsedAt
 	// to `now` on a successful consumption alongside the slice rewrite.
 	ConsumeBackupCodeAtomic(ctx context.Context, tenantID, userID string, now time.Time, matchHash func(hash string) bool) (bool, error)
+
+	// MarkTOTPStepUsedAtomic compare-and-swaps the row's last_used_step
+	// to `step`, succeeding only when the stored last_used_step is
+	// strictly less than `step`. This is the TOTP replay guard
+	// (RFC 6238 §5.2, #2124): a code's time-step is monotonic, so once a
+	// step has been accepted, re-presenting the same code (which computes
+	// the same step) loses the CAS and is rejected. Two concurrent step-2
+	// requests with the same code compute the same step S; only the first
+	// UPDATE (last_used_step < S) affects a row — the second affects zero
+	// rows and the caller treats it as a replay. Returns (true, nil) when
+	// this call won the swap, (false, nil) when it lost (replay), and a
+	// classified error on infrastructure failure. Also stamps LastUsedAt
+	// and UpdatedAt to `now` on a win, so the TOTP success path needs no
+	// separate last-used bump.
+	MarkTOTPStepUsedAtomic(ctx context.Context, tenantID, userID string, step int64, now time.Time) (bool, error)
 }
 
 // BackofficeUserMFASecretRegistry stores per-back-office-user TOTP
@@ -2114,6 +2129,17 @@ type BackofficeUserMFASecretRegistry interface {
 	// successful TOTP verification (the backup-code path bumps it
 	// inside ConsumeBackupCodeAtomic). Used by the login MFA handler.
 	BumpLastUsedAt(ctx context.Context, backofficeUserID string, now time.Time) error
+
+	// MarkTOTPStepUsedAtomic compare-and-swaps the row's last_used_step
+	// to `step`, succeeding only when the stored last_used_step is
+	// strictly less than `step`. The back-office mirror of
+	// UserMFASecretRegistry.MarkTOTPStepUsedAtomic — see there for the
+	// full replay-guard rationale (RFC 6238 §5.2, #2124). Returns
+	// (true, nil) when this call won the swap, (false, nil) when it lost
+	// (replay), and a classified error on infrastructure failure. Also
+	// stamps LastUsedAt and UpdatedAt to `now` on a win, so the TOTP
+	// success path needs no separate BumpLastUsedAt call.
+	MarkTOTPStepUsedAtomic(ctx context.Context, backofficeUserID string, step int64, now time.Time) (bool, error)
 }
 
 // GroupPurger hard-deletes every row whose group_id references the given

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -2078,6 +2078,13 @@ type UserMFASecretRegistry interface {
 	// and UpdatedAt to `now` on a win, so the TOTP success path needs no
 	// separate last-used bump.
 	MarkTOTPStepUsedAtomic(ctx context.Context, tenantID, userID string, step int64, now time.Time) (bool, error)
+
+	// UpdateBackupCodes replaces backup_codes_hashed (the regenerate flow),
+	// writing ONLY that column + updated_at. last_used_step / last_used_at are
+	// owned exclusively by MarkTOTPStepUsedAtomic; a full-row Update here would
+	// clobber a concurrent step advance and re-open the replay window (#2124).
+	// Returns ErrNotFound if the row is gone.
+	UpdateBackupCodes(ctx context.Context, tenantID, userID string, hashes []string, now time.Time) error
 }
 
 // BackofficeUserMFASecretRegistry stores per-back-office-user TOTP
@@ -2124,11 +2131,6 @@ type BackofficeUserMFASecretRegistry interface {
 	// when none matched, and a classified error on infrastructure
 	// failure. Updates LastUsedAt to `now` on a successful consumption.
 	ConsumeBackupCodeAtomic(ctx context.Context, backofficeUserID string, now time.Time, matchHash func(hash string) bool) (bool, error)
-
-	// BumpLastUsedAt sets the last_used_at column to `now` after a
-	// successful TOTP verification (the backup-code path bumps it
-	// inside ConsumeBackupCodeAtomic). Used by the login MFA handler.
-	BumpLastUsedAt(ctx context.Context, backofficeUserID string, now time.Time) error
 
 	// MarkTOTPStepUsedAtomic compare-and-swaps the row's last_used_step
 	// to `step`, succeeding only when the stored last_used_step is

--- a/go/schema/migrations/_sqldata/1782048731_add_mfa_last_used_step.down.sql
+++ b/go/schema/migrations/_sqldata/1782048731_add_mfa_last_used_step.down.sql
@@ -1,0 +1,12 @@
+-- Migration rollback
+-- Generated on: 2026-06-21T13:32:11Z
+-- Direction: DOWN
+
+-- Remove columns from table: backoffice_user_mfa_secrets --
+-- ALTER statements: --
+ALTER TABLE backoffice_user_mfa_secrets DROP COLUMN last_used_step CASCADE;
+-- WARNING: Dropping column backoffice_user_mfa_secrets.last_used_step with CASCADE - This will delete data and dependent objects! --
+-- Remove columns from table: user_mfa_secrets --
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets DROP COLUMN last_used_step CASCADE;
+-- WARNING: Dropping column user_mfa_secrets.last_used_step with CASCADE - This will delete data and dependent objects! --;

--- a/go/schema/migrations/_sqldata/1782048731_add_mfa_last_used_step.up.sql
+++ b/go/schema/migrations/_sqldata/1782048731_add_mfa_last_used_step.up.sql
@@ -1,0 +1,10 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-06-21T13:32:11Z
+-- Direction: UP
+
+-- Add/modify columns for table: backoffice_user_mfa_secrets --
+-- ALTER statements: --
+ALTER TABLE backoffice_user_mfa_secrets ADD COLUMN last_used_step BIGINT NOT NULL DEFAULT '0';
+-- Add/modify columns for table: user_mfa_secrets --
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets ADD COLUMN last_used_step BIGINT NOT NULL DEFAULT '0';

--- a/go/services/mfa_service.go
+++ b/go/services/mfa_service.go
@@ -11,6 +11,7 @@ package services
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base32"
 	"errors"
 	"fmt"
@@ -230,33 +231,77 @@ func (s *MFAService) DecryptSecret(ciphertext string) (string, error) {
 // VerifyTOTP returns true when `code` is the current 6-digit TOTP for
 // the user's stored secret, allowing ±1 step of clock skew.
 // Whitespace and hyphens in code are tolerated (paste-friendly).
+//
+// Implemented as a thin wrapper over VerifyTOTPStep so the boolean
+// "is this code valid?" answer and the "which step matched?" answer
+// can never diverge. Callers that need to defend against replay within
+// the skew window (RFC 6238 §5.2) should use VerifyTOTPStep and feed the
+// matched step into MarkTOTPStepUsedAtomic.
 func (s *MFAService) VerifyTOTP(stored models.UserMFASecret, code string) (bool, error) {
+	_, ok, err := s.VerifyTOTPStep(stored, code)
+	return ok, err
+}
+
+// VerifyTOTPStep verifies `code` against the user's stored secret and,
+// on a match, returns the TOTP time-step counter (unix/totpPeriodSeconds)
+// of the matched candidate. The ±totpSkew window is searched in step
+// order; the first matching candidate wins.
+//
+// The matched step is what the handler hands to MarkTOTPStepUsedAtomic:
+// a code whose step is <= the row's last_used_step is a replay within
+// the skew window and must be rejected even though it is otherwise a
+// cryptographically valid code (RFC 6238 §5.2).
+//
+// Whitespace and hyphens in code are tolerated (paste-friendly). A
+// non-6-digit code returns (0, false, nil) rather than an error so
+// brute-force probing with short strings can't smoke out which paths
+// log errors — same lenient shape as the old VerifyTOTP.
+func (s *MFAService) VerifyTOTPStep(stored models.UserMFASecret, code string) (matchedStep int64, ok bool, err error) {
 	if stored.SecretEncrypted == "" {
-		return false, ErrMFANotEnrolled
+		return 0, false, ErrMFANotEnrolled
 	}
 	plain, err := s.DecryptSecret(stored.SecretEncrypted)
 	if err != nil {
-		return false, err
+		return 0, false, err
 	}
 	cleaned := normalizeCode(code)
-	// A non-6-digit code is invalid by length alone — the pquerna
-	// library returns a non-nil error in that case, but the auth
-	// flow only cares about boolean validity. Treat shape failures
-	// as "wrong code" instead of a 500 so brute-force probing with
-	// short strings can't smoke out which paths log errors.
 	if len(cleaned) != totpDigits.Length() {
-		return false, nil
+		return 0, false, nil
 	}
-	ok, err := totp.ValidateCustom(cleaned, plain, s.now(), totp.ValidateOpts{
-		Period:    totpPeriodSeconds,
-		Skew:      totpSkew,
-		Digits:    totpDigits,
-		Algorithm: otp.AlgorithmSHA1,
-	})
-	if err != nil {
-		return false, fmt.Errorf("mfa: validate totp: %w", err)
+	step, matched := matchTOTPStep(plain, cleaned, s.now().Unix())
+	return step, matched, nil
+}
+
+// matchTOTPStep walks the ±totpSkew window around the current time-step
+// (nowUnix/totpPeriodSeconds) and returns the first candidate step whose
+// generated code constant-time-equals `cleaned`. The second return is
+// false when no candidate in the window matches.
+//
+// Factored out (and taking a plaintext secret rather than a stored row)
+// so both the tenant-plane verify and the back-office verify — which
+// hands in a decrypted secret via a thin shim — can obtain the matched
+// step without re-implementing the window walk. A GenerateCodeCustom
+// error for one candidate is treated as a no-match for that candidate
+// only (lenient, matching the old totp.ValidateCustom behaviour) rather
+// than aborting the whole window.
+func matchTOTPStep(plainSecret, cleaned string, nowUnix int64) (int64, bool) {
+	base := nowUnix / totpPeriodSeconds
+	cleanedBytes := []byte(cleaned)
+	for delta := -totpSkew; delta <= totpSkew; delta++ {
+		step := base + int64(delta)
+		candidate, genErr := totp.GenerateCodeCustom(plainSecret, time.Unix(step*totpPeriodSeconds, 0), totp.ValidateOpts{
+			Period:    totpPeriodSeconds,
+			Digits:    totpDigits,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+		if genErr != nil {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(candidate), cleanedBytes) == 1 {
+			return step, true
+		}
 	}
-	return ok, nil
+	return 0, false
 }
 
 // GenerateBackupCodes returns N freshly-generated plaintext backup

--- a/go/services/mfa_service_test.go
+++ b/go/services/mfa_service_test.go
@@ -143,6 +143,99 @@ func TestVerifyTOTP_ErrorsWhenNotEnrolled(t *testing.T) {
 	c.Assert(err, qt.Equals, services.ErrMFANotEnrolled)
 }
 
+func TestVerifyTOTPStep_ReturnsCurrentStepAndIsStableOnReplay(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestService(t)
+	enr, err := svc.GenerateEnrollment("alex@example.com")
+	c.Assert(err, qt.IsNil)
+	enc, err := svc.EncryptSecret(enr.Secret)
+	c.Assert(err, qt.IsNil)
+	stored := models.UserMFASecret{SecretEncrypted: enc}
+
+	now := time.Unix(1700000000, 0)
+	svc.SetClock(func() time.Time { return now })
+
+	code, err := totp.GenerateCodeCustom(enr.Secret, now, totp.ValidateOpts{
+		Period:    30,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	step, ok, err := svc.VerifyTOTPStep(stored, code)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	// The matched step is unix/30 for the current code — this is the value
+	// the handler CAS-commits to block replay (#2124).
+	c.Assert(step, qt.Equals, now.Unix()/30)
+
+	// Re-presenting the SAME code computes the SAME step, so the handler's
+	// compare-and-swap (last_used_step < step) will reject the replay.
+	stepReplay, okReplay, err := svc.VerifyTOTPStep(stored, code)
+	c.Assert(err, qt.IsNil)
+	c.Assert(okReplay, qt.IsTrue)
+	c.Assert(stepReplay, qt.Equals, step)
+}
+
+func TestVerifyTOTPStep_AdjacentStepsResolveDistinctSteps(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestService(t)
+	enr, err := svc.GenerateEnrollment("alex@example.com")
+	c.Assert(err, qt.IsNil)
+	enc, err := svc.EncryptSecret(enr.Secret)
+	c.Assert(err, qt.IsNil)
+	stored := models.UserMFASecret{SecretEncrypted: enc}
+
+	now := time.Unix(1700000000, 0)
+	svc.SetClock(func() time.Time { return now })
+
+	prevCode, err := totp.GenerateCodeCustom(enr.Secret, now.Add(-30*time.Second), totp.ValidateOpts{
+		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+	})
+	c.Assert(err, qt.IsNil)
+	nextCode, err := totp.GenerateCodeCustom(enr.Secret, now.Add(30*time.Second), totp.ValidateOpts{
+		Period: 30, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// The prior-step code resolves to the lower step, the next-step code to
+	// the higher one — the handler advancing last_used_step monotonically
+	// is what blocks a later replay of the lower step.
+	prevStep, okPrev, err := svc.VerifyTOTPStep(stored, prevCode)
+	c.Assert(err, qt.IsNil)
+	c.Assert(okPrev, qt.IsTrue)
+	c.Assert(prevStep, qt.Equals, now.Unix()/30-1)
+
+	nextStep, okNext, err := svc.VerifyTOTPStep(stored, nextCode)
+	c.Assert(err, qt.IsNil)
+	c.Assert(okNext, qt.IsTrue)
+	c.Assert(nextStep, qt.Equals, now.Unix()/30+1)
+}
+
+func TestVerifyTOTPStep_RejectsGarbageWithoutStep(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestService(t)
+	enr, err := svc.GenerateEnrollment("alex@example.com")
+	c.Assert(err, qt.IsNil)
+	enc, err := svc.EncryptSecret(enr.Secret)
+	c.Assert(err, qt.IsNil)
+	stored := models.UserMFASecret{SecretEncrypted: enc}
+
+	for _, code := range []string{"", "abc", "000000", "12345"} {
+		step, ok, err := svc.VerifyTOTPStep(stored, code)
+		c.Assert(err, qt.IsNil)
+		c.Assert(ok, qt.IsFalse, qt.Commentf("code=%q", code))
+		c.Assert(step, qt.Equals, int64(0), qt.Commentf("code=%q", code))
+	}
+}
+
+func TestVerifyTOTPStep_ErrorsWhenNotEnrolled(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestService(t)
+	_, _, err := svc.VerifyTOTPStep(models.UserMFASecret{}, "123456")
+	c.Assert(err, qt.Equals, services.ErrMFANotEnrolled)
+}
+
 func TestGenerateBackupCodes_HumanFriendlyAndHashed(t *testing.T) {
 	c := qt.New(t)
 	svc := newTestService(t)


### PR DESCRIPTION
## What

Five audit-driven security/correctness fixes from the private-alpha critical path (part of #2087), batched because they touch **disjoint** code paths and don't conflict with the in-flight #2138 / #2141 work.

**Closes #2112 · Closes #2101 · Closes #2126 · Closes #2124 · Closes #2094**

### #2112 — explicit tenant-scope on `PUT /auth/me` default-group update
`applyDefaultGroupUpdate` trusted a (false) comment instead of an actual check. `GetByGroupAndUser` runs in RLS-bypass / service mode and filters only by `group_id`, so the returned membership could belong to another tenant. Added an explicit `membership.TenantID != user.TenantID` rejection (same 400 path as not-a-member) and fixed the misleading comment. Chose the call-site guard over widening `GetByGroupAndUser`'s signature (12 call sites) to keep the blast radius minimal.

### #2101 — enforce a per-file upload size limit
The multipart upload used an unbounded `io.Copy` and bypassed the 1 MiB body cap, so one user could exhaust shared storage. New `--max-upload-size` flag / `INVENTARIO_RUN_MAX_UPLOAD_BYTES` env (default **1 GiB**, `0` disables); the upload source is wrapped in `http.MaxBytesReader` (caps MIME-sniff + body) and overflow maps to **413** via a new `requestEntityTooLargeError` helper. Tests cover both the 413 and the cap-disabled paths. _(The issue's "make the storage quota enforcing" is a larger, separate change — not in scope here.)_

### #2126 — impersonation "sign out all other sessions" must not wipe everything
An impersonation session has no `rti` / refresh-cookie, so no session row is `is_current`; the CTA then resolved keep-id `""` and revoked **all** of the impersonated user's sessions. Belt-and-suspenders:
- **BE (root cause):** `revokeAllOtherSessions` now refuses the wipe (**400**) when the keep-id resolves to empty — a normal user always resolves one via the `rti` claim / refresh cookie, so this only triggers in the broken impersonation case.
- **FE:** the CTA is hidden unless some session is `is_current`, and the mutation can no longer be called with an undefined id (tightened type).

### #2124 — block TOTP replay within the ±1-step skew window
TOTP verification (`Skew=1` / `Period=30s`) accepted a code across ~90s and never recorded the consumed step, so a sniffed code was replayable (RFC 6238 §5.2).
- New `last_used_step BIGINT` on both MFA-secret models (generated migration `1782048731`).
- `MFAService.VerifyTOTPStep` returns the matched step; new `MarkTOTPStepUsedAtomic` registry method commits it via a single compare-and-swap `UPDATE … WHERE last_used_step < $step` — atomic against two concurrent requests with the same code.
- Wired into login-MFA, disable, and regenerate (tenant **and** back-office planes). A code consumed at any of these can't be reused at any of them within the window.
- **Enrollment-verify intentionally does *not* bump the step:** it's a one-time, already-authenticated, idempotent pending→enabled confirmation, and bumping it would block a legitimate "enroll then manage MFA within the same 30 s" flow for a marginal vector (an enroll-code→login replay also requires the victim's password). Added a handler-level test asserting a consumed login code can't be replayed.

### #2094 — actually run the cross-tenant / RLS isolation tests in CI
The negative user/tenant/group-isolation suites existed but never ran (no DSN was wired). A sanity run against a real Postgres revealed they were **bit-rotted** — they predate the location-groups model (created entities without a `GroupID`, built contexts without `WithGroup`), so they failed at setup, not merely "didn't run".
- **Modernized** `go/integration/*isolation*` to the **group-scoped** RLS model (the policy is `tenant_id = get_current_tenant_id() AND group_id = get_current_group_id()`): real tenant → per-user `LocationGroup` → user+group context via `appctx.WithGroup`, with the two users in **different groups** so the negative assertions are enforced by the group dimension of RLS (not coincidence). The HTTP test is routed through group-scoped `/g/{slug}/...` paths with real memberships. All negative (`Get` errors, `List` len 0) and positive (own data visible) assertions are preserved.
- **CI:** new step in `go-test-postgres.yml` runs them serially (`-p 1`; they share one DB — see #1953), excluding the load/perf variants.
- **Scope note:** the raw-SQL `./models -tags integration` RLS test is intentionally **not** wired here — it asserts the pre-groups, tenant-only policy shape (`INSERT locations` with no `group_id`, `set_tenant_context`) and needs its own modernization; the registry-level `./integration` suite supersedes that coverage.

## How it was built
Scout + recon → a fleet of focused agents implemented the disjoint fixes in one worktree (no shared files) → central verification: build/lint/migration-generation/tests all run by the orchestrator (sub-agent claims were independently re-verified — e.g. a stale "missing method" / "redeclared" diagnostic and a sanity-run that exposed the #2094 bit-rot were both caught and resolved before pushing).

## Verification
- **Go:** `go build ./...`, `go vet`, `golangci-lint run`, `go tool qtlint`, `go tool nolintguard` — all clean; full unit suite green; the modernized isolation suite green against a throwaway Postgres (`ok …/integration`, 8 isolation tests run, 0 skipped).
- **Migration** generated via `./scripts/generate-migration.sh` (not hand-written/renamed) and applies + rolls back cleanly.
- **Swagger** regenerated (`@Failure 413` / `400`); **FE** codegen / typecheck / lint / `format:check` / `i18n:check` green; **vitest 1374/1374**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-file upload size cap (default 1 GiB) via `--max-upload-bytes` (negative disables) with `413` responses.
  * Added step-aware MFA TOTP replay protection (prevents code reuse within the validity window).
* **Bug Fixes**
  * “Sign out all other sessions” now rejects with `400` when the current session can’t be identified, preventing accidental session revocation.
  * Sessions UI hides the revoke-all action during impersonation/no-current-session scenarios.
* **Documentation**
  * Updated API/Swagger contracts and file-upload configuration documentation for new 413/400 behaviors and the upload-size flag.
* **Tests**
  * Added regression tests for upload size limiting, MFA replay rejection, and session revoke behavior; expanded isolation coverage and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->