### PR TITLE
fix(#2087): close cross-tenant backup-import gap + cover the real restore-ownership gate

### DIFF
--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -28,6 +28,14 @@ var (
 	// unknown `?strategy=` value (#2137). The handler answers 422 directly via
 	// unprocessableEntityError, so it does not need a toJSONAPIError mapping.
 	errInvalidDeleteStrategy = errx.NewSentinel("invalid delete strategy: must be one of cascade, unlink")
+	// errImportSourceForeignTenant rejects a backup-import request whose
+	// SourceFilePath points outside the caller's own tenant namespace
+	// (`t/<callerTenant>/...`). A signed `.inb` archive is verified against a
+	// tenant-AGNOSTIC server key, so without this guard a user could import
+	// another tenant's backup by naming its blob key — cross-tenant data
+	// exfiltration. The handler answers 422 directly via
+	// unprocessableEntityError, so it does not need a toJSONAPIError mapping.
+	errImportSourceForeignTenant = errx.NewSentinel("import source path must be within your tenant namespace")
 	// ErrNotSystemAdmin is returned by RequireSystemAdmin when the caller's
 	// user is not flagged as a system administrator. Surfaces as a 403 with
 	// JSON:API code "admin.forbidden" so the FE can render specific copy

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -16,6 +16,7 @@ import (
 	"github.com/denisvmedia/inventario/apiserver/internal/downloadutils"
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/backup/export"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
@@ -445,15 +446,30 @@ func (api *exportsAPI) importExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create export record with pending status and source file path
-	importedExport := models.NewImportedExport(data.Data.Attributes.Description, data.Data.Attributes.SourceFilePath)
-
 	// Extract user from authenticated request context
 	user := GetUserFromRequest(r)
 	if user == nil {
 		http.Error(w, "User context required", http.StatusInternalServerError)
 		return
 	}
+
+	// The import worker reads the source blob key WITHOUT RLS, and a signed
+	// `.inb` archive is verified against a tenant-AGNOSTIC server key. Reject a
+	// SourceFilePath that points outside the caller's own tenant namespace so a
+	// user cannot import another tenant's backup (cross-tenant exfiltration).
+	// A legitimate restore upload is keyed `t/<callerTenant>/restores/...` (see
+	// blobkeys.BuildRestoreUploadKey), so this passes for real flows. Guard the
+	// empty-tenant case explicitly — TenantPrefix("") is "", which would make
+	// HasPrefix vacuously true and defeat the check.
+	src := data.Data.Attributes.SourceFilePath
+	prefix := blobkeys.TenantPrefix(user.TenantID)
+	if prefix == "" || !strings.HasPrefix(src, prefix) {
+		unprocessableEntityError(w, r, errImportSourceForeignTenant)
+		return
+	}
+
+	// Create export record with pending status and source file path
+	importedExport := models.NewImportedExport(data.Data.Attributes.Description, src)
 
 	if importedExport.TenantID == "" {
 		importedExport.TenantID = user.TenantID

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -573,6 +573,121 @@ func TestExportCreate_NonWhitespaceTooLongDescription_Rejects(t *testing.T) {
 		qt.Commentf("expected 422 for 501-char description, body: %s", w.Body.String()))
 }
 
+// TestImportExport_ForeignTenantSourcePath_Rejected is the cross-tenant
+// security regression for POST /exports/import. A signed `.inb` archive is
+// verified against a tenant-AGNOSTIC server key, so the handler MUST reject a
+// SourceFilePath that lives outside the caller's own tenant namespace — without
+// the guard a user could import another tenant's backup blob
+// (`t/<victim>/exports/backup_….inb`) straight into their own account.
+func TestImportExport_ForeignTenantSourcePath_Rejected(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "caller-tenant-id",
+		},
+		Email:    "test+import-foreign@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	must.Assert(testUser.SetPassword("Password123"))
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		EntityService:  services.NewEntityService(factorySet, "memory://"),
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	requestPayload := jsonapi.ImportExportRequest{
+		Data: &jsonapi.ImportExportRequestData{
+			Type: "exports",
+			Attributes: &jsonapi.ImportExportAttributes{
+				Description: "Import another tenant's backup",
+				// Victim tenant's namespace — must be rejected.
+				SourceFilePath: "t/victim-tenant-id/exports/backup_full_database_20260101.inb",
+			},
+		},
+	}
+	payloadBytes := must.Must(json.Marshal(requestPayload))
+
+	req := httptest.NewRequest("POST", "/exports/import", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusUnprocessableEntity,
+		qt.Commentf("foreign-tenant import source must be rejected; body: %s", w.Body.String()))
+}
+
+// TestImportExport_OwnTenantSourcePath_Accepted is the negative control for the
+// cross-tenant guard above: a legitimate restore upload is keyed
+// `t/<callerTenant>/restores/...` (see blobkeys.BuildRestoreUploadKey), so the
+// prefix check MUST pass and the import record must be created (201). This
+// proves the guard does not break real import flows.
+func TestImportExport_OwnTenantSourcePath_Accepted(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "caller-tenant-id",
+		},
+		Email:    "test+import-own@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	must.Assert(testUser.SetPassword("Password123"))
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		EntityService:  services.NewEntityService(factorySet, "memory://"),
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	requestPayload := jsonapi.ImportExportRequest{
+		Data: &jsonapi.ImportExportRequestData{
+			Type: "exports",
+			Attributes: &jsonapi.ImportExportAttributes{
+				Description: "Import my own uploaded backup",
+				// Caller's own restore-upload namespace — must pass.
+				SourceFilePath: "t/caller-tenant-id/restores/backup.inb",
+			},
+		},
+	}
+	payloadBytes := must.Must(json.Marshal(requestPayload))
+
+	req := httptest.NewRequest("POST", "/exports/import", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusCreated,
+		qt.Commentf("own-tenant import source must be accepted; body: %s", w.Body.String()))
+}
+
 // TestGenerateExportSignedURL covers GET /exports/{id}/signed-url (#1780).
 // The endpoint lets the frontend download a completed export without
 // putting a JWT in the URL: it returns an HMAC-signed URL targeting the

--- a/go/backup/import/service_security_test.go
+++ b/go/backup/import/service_security_test.go
@@ -1,0 +1,50 @@
+package importpkg_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	_ "gocloud.dev/blob/memblob" // register the memory:// blob driver
+
+	importpkg "github.com/denisvmedia/inventario/backup/import"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// TestImportService_ProcessImport_ForeignTenantSourcePath_FailsFast is the
+// defense-in-depth regression for the cross-tenant import gap: the import worker
+// reads the source blob key WITHOUT RLS, and a signed `.inb` archive is verified
+// against a tenant-AGNOSTIC server key. ProcessImport MUST fail fast — via
+// markImportFailed, BEFORE opening the bucket — when sourceFilePath lives outside
+// the export record's own tenant namespace.
+//
+// The export is seeded under "test-tenant"; the sourceFilePath points at another
+// tenant's namespace. With the guard, the export is marked failed with the
+// tenant-namespace message. Were the guard absent, the worker would instead read
+// the bucket and fail with "failed to open uploaded backup file" — a distinct
+// message — so this assertion proves the bucket is never touched.
+func TestImportService_ProcessImport_ForeignTenantSourcePath_FailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet, _, _ := newTestFactorySet()
+	registrySet := factorySet.CreateServiceRegistrySet()
+	service := importpkg.NewImportService(factorySet, "memory://test-bucket", nil)
+	ctx := context.Background()
+
+	createdExport := must.Must(registrySet.ExportRegistry.Create(ctx, models.Export{
+		Type:                     models.ExportTypeImported,
+		Status:                   models.ExportStatusPending,
+		Description:              "Test import",
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "test-tenant"},
+	}))
+
+	// Another tenant's namespace — must be rejected without reading the bucket.
+	err := service.ProcessImport(ctx, createdExport.ID, "t/other-tenant/exports/backup_full_database_20260101.inb")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "import source path is outside the export's tenant namespace")
+
+	updatedExport := must.Must(registrySet.ExportRegistry.Get(ctx, createdExport.ID))
+	c.Assert(updatedExport.Status, qt.Equals, models.ExportStatusFailed)
+	c.Assert(updatedExport.ErrorMessage, qt.Contains, "import source path is outside the export's tenant namespace")
+}

--- a/go/backup/import/service_shared.go
+++ b/go/backup/import/service_shared.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/internal/backupsign"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
@@ -65,6 +66,15 @@ func (s *ImportService) ProcessImport(ctx context.Context, exportID, sourceFileP
 	exportRecord.Status = models.ExportStatusInProgress
 	if _, err = expReg.Update(ctx, *exportRecord); err != nil {
 		return s.markImportFailed(ctx, exportID, fmt.Sprintf("failed to update export status: %v", err))
+	}
+
+	// Defense-in-depth (the handler is the primary guard): the worker reads the
+	// source blob key WITHOUT RLS, so refuse a path that lives outside the
+	// export's own tenant namespace before opening it. An empty tenant yields an
+	// empty prefix — guard it explicitly so HasPrefix can't pass vacuously.
+	prefix := blobkeys.TenantPrefix(exportRecord.TenantID)
+	if prefix == "" || !strings.HasPrefix(sourceFilePath, prefix) {
+		return s.markImportFailed(ctx, exportID, "import source path is outside the export's tenant namespace")
 	}
 
 	b, err := blob.OpenBucket(ctx, s.uploadLocation)

--- a/go/backup/import/service_test.go
+++ b/go/backup/import/service_test.go
@@ -32,7 +32,7 @@ func TestImportService_ProcessImport_ExportNotFound(t *testing.T) {
 	service := importpkg.NewImportService(factorySet, uploadLocation, nil)
 	ctx := context.Background()
 
-	err := service.ProcessImport(ctx, "non-existent-id", "test-file.xml")
+	err := service.ProcessImport(ctx, "non-existent-id", "t/test-tenant/restores/test-file.xml")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "not found")
 }
@@ -48,14 +48,15 @@ func TestImportService_ProcessImport_BlobBucketError(t *testing.T) {
 
 	// Create a test export
 	export := models.Export{
-		Type:        models.ExportTypeImported,
-		Status:      models.ExportStatusPending,
-		Description: "Test import",
+		Type:                     models.ExportTypeImported,
+		Status:                   models.ExportStatusPending,
+		Description:              "Test import",
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "test-tenant"},
 	}
 	createdExport, err := registrySet.ExportRegistry.Create(ctx, export)
 	c.Assert(err, qt.IsNil)
 
-	err = service.ProcessImport(ctx, createdExport.ID, "test-file.xml")
+	err = service.ProcessImport(ctx, createdExport.ID, "t/test-tenant/restores/test-file.xml")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "failed to open blob bucket")
 
@@ -76,14 +77,15 @@ func TestImportService_ProcessImport_FileNotFound(t *testing.T) {
 
 	// Create a test export
 	export := models.Export{
-		Type:        models.ExportTypeImported,
-		Status:      models.ExportStatusPending,
-		Description: "Test import",
+		Type:                     models.ExportTypeImported,
+		Status:                   models.ExportStatusPending,
+		Description:              "Test import",
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "test-tenant"},
 	}
 	createdExport, err := registrySet.ExportRegistry.Create(ctx, export)
 	c.Assert(err, qt.IsNil)
 
-	err = service.ProcessImport(ctx, createdExport.ID, "non-existent-file.xml")
+	err = service.ProcessImport(ctx, createdExport.ID, "t/test-tenant/restores/non-existent-file.xml")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "failed to open uploaded backup file")
 
@@ -111,16 +113,17 @@ func TestImportService_ProcessImport_InvalidXML(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	invalidXML := "not valid xml at all <unclosed tag"
-	filePath := "invalid.xml"
+	filePath := "t/test-tenant/restores/invalid.xml"
 	err = b.WriteAll(ctx, filePath, []byte(invalidXML), nil)
 	c.Assert(err, qt.IsNil)
 	b.Close()
 
 	// Create a test export
 	export := models.Export{
-		Type:        models.ExportTypeImported,
-		Status:      models.ExportStatusPending,
-		Description: "Test import",
+		Type:                     models.ExportTypeImported,
+		Status:                   models.ExportStatusPending,
+		Description:              "Test import",
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "test-tenant"},
 	}
 	createdExport, err := registrySet.ExportRegistry.Create(ctx, export)
 	c.Assert(err, qt.IsNil)
@@ -163,7 +166,7 @@ func TestImportService_ProcessImport_Success(t *testing.T) {
 		</commodity>
 	</commodities>
 </inventory>`
-	filePath := "valid.xml"
+	filePath := "t/test-tenant/restores/valid.xml"
 	err = b.WriteAll(ctx, filePath, []byte(validXML), nil)
 	c.Assert(err, qt.IsNil)
 	b.Close()
@@ -242,7 +245,7 @@ func TestImportService_ProcessImport_SuccessWithFileData(t *testing.T) {
 		</commodity>
 	</commodities>
 </inventory>`
-	filePath := "with-files.xml"
+	filePath := "t/test-tenant/restores/with-files.xml"
 	err = b.WriteAll(ctx, filePath, []byte(xmlWithFiles), nil)
 	c.Assert(err, qt.IsNil)
 	b.Close()

--- a/go/backup/restore/processor/ownership_test.go
+++ b/go/backup/restore/processor/ownership_test.go
@@ -1,0 +1,187 @@
+package processor
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/backup/restore/security"
+	"github.com/denisvmedia/inventario/backup/restore/types"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// ownershipFixture bundles everything the validateCommodityOwnershipInDB tests
+// need: the factory set the processor reads through, the owner / attacker users,
+// the owner's group context, and the UUID of a commodity owned by the owner.
+type ownershipFixture struct {
+	factorySet *registry.FactorySet
+	owner      *models.User
+	attacker   *models.User
+	ownerCtx   context.Context
+	// commodityUUID is the immutable UUID of the owner's commodity. The restore
+	// path keys ownership lookups on this UUID (originalXMLID), so it is set
+	// explicitly before Create and preserved by the memory registry.
+	commodityUUID string
+}
+
+// newOwnershipFixture wires up two users (owner + attacker) in the same tenant,
+// a location group owned by the owner, and one location / area / commodity
+// created through the owner's user-aware registry set so CreatedByUserID is
+// stamped to the owner. The commodity carries a known immutable UUID so the
+// in-DB ownership lookup can find it by that UUID.
+func newOwnershipFixture(t *testing.T) *ownershipFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	factorySet := memory.NewFactorySet()
+
+	owner := must.Must(factorySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email: "owner@example.com",
+		Name:  "Owner User",
+	}))
+
+	attacker := must.Must(factorySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email: "attacker@example.com",
+		Name:  "Attacker User",
+	}))
+
+	slug := must.Must(models.GenerateGroupSlug())
+	group := must.Must(factorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: owner.TenantID},
+		Name:                "Test Group",
+		Slug:                slug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           owner.ID,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+
+	ownerCtx := appctx.WithGroup(appctx.WithUser(ctx, owner), group)
+	ownerRegistrySet := must.Must(factorySet.CreateUserRegistrySet(ownerCtx))
+
+	location := must.Must(ownerRegistrySet.LocationRegistry.Create(ownerCtx, models.Location{
+		Name:    "Owner Location",
+		Address: "123 Owner St",
+	}))
+
+	area := must.Must(ownerRegistrySet.AreaRegistry.Create(ownerCtx, models.Area{
+		Name:       "Owner Area",
+		LocationID: location.ID,
+	}))
+
+	// Set the immutable UUID explicitly. The memory registry overwrites the ID
+	// with a fresh server-side value but preserves a caller-provided UUID, which
+	// is exactly what the restore path relies on (commodity.UUID = originalID).
+	commodityUUID := must.Must(models.GenerateGroupSlug())
+	commodity := must.Must(ownerRegistrySet.CommodityRegistry.Create(ownerCtx, models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{UUID: commodityUUID},
+		},
+		AreaID:                 new(area.ID),
+		Name:                   "Owner Commodity",
+		ShortName:              "OC",
+		Type:                   models.CommodityTypeElectronics,
+		Status:                 models.CommodityStatusInUse,
+		Count:                  1,
+		OriginalPrice:          decimal.RequireFromString("100.00"),
+		CurrentPrice:           decimal.RequireFromString("90.00"),
+		OriginalPriceCurrency:  models.Currency("USD"),
+		ConvertedOriginalPrice: decimal.Zero,
+		PurchaseDate:           models.ToPDate("2023-01-01"),
+	}))
+
+	// Guard the fixture's central assumption: the memory registry must keep the
+	// UUID we supplied so the ownership lookup keys line up with originalXMLID.
+	qt.Assert(t, commodity.UUID, qt.Equals, commodityUUID)
+
+	return &ownershipFixture{
+		factorySet:    factorySet,
+		owner:         owner,
+		attacker:      attacker,
+		ownerCtx:      ownerCtx,
+		commodityUUID: commodityUUID,
+	}
+}
+
+func newOwnershipProcessor(fx *ownershipFixture) *RestoreOperationProcessor {
+	entityService := services.NewEntityService(fx.factorySet, "/tmp/restore-test")
+	return NewRestoreOperationProcessor("test-op", fx.factorySet, entityService, "/tmp/restore-test", nil)
+}
+
+// emptyExisting returns an ExistingEntities snapshot with no pre-loaded
+// commodities so the lookup falls through to the in-DB UUID map.
+func emptyExisting() *types.ExistingEntities {
+	return &types.ExistingEntities{Commodities: map[string]*models.Commodity{}}
+}
+
+// Case 1: the commodity is already present in the existing-entities snapshot, so
+// the function short-circuits to nil without touching the DB.
+func TestValidateCommodityOwnershipInDB_ExistingShortCircuit(t *testing.T) {
+	c := qt.New(t)
+	fx := newOwnershipFixture(t)
+	proc := newOwnershipProcessor(fx)
+
+	existing := &types.ExistingEntities{
+		Commodities: map[string]*models.Commodity{
+			fx.commodityUUID: {Name: "already known"},
+		},
+	}
+	stats := &types.RestoreStats{}
+
+	err := proc.validateCommodityOwnershipInDB(fx.ownerCtx, fx.commodityUUID, fx.owner, existing, stats)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0)
+}
+
+// Case 2: the original ID matches a DB commodity owned by the current user → nil.
+func TestValidateCommodityOwnershipInDB_OwnedByCurrentUser(t *testing.T) {
+	c := qt.New(t)
+	fx := newOwnershipFixture(t)
+	proc := newOwnershipProcessor(fx)
+
+	stats := &types.RestoreStats{}
+
+	err := proc.validateCommodityOwnershipInDB(fx.ownerCtx, fx.commodityUUID, fx.owner, emptyExisting(), stats)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0)
+}
+
+// Case 3: the original ID matches a DB commodity owned by a DIFFERENT user →
+// ErrOwnershipViolation, with the error recorded on stats.
+func TestValidateCommodityOwnershipInDB_OwnedByDifferentUser(t *testing.T) {
+	c := qt.New(t)
+	fx := newOwnershipFixture(t)
+	proc := newOwnershipProcessor(fx)
+
+	stats := &types.RestoreStats{}
+
+	err := proc.validateCommodityOwnershipInDB(fx.ownerCtx, fx.commodityUUID, fx.attacker, emptyExisting(), stats)
+	c.Assert(err, qt.ErrorIs, security.ErrOwnershipViolation)
+	c.Assert(stats.ErrorCount, qt.Equals, 1)
+	c.Assert(stats.Errors, qt.HasLen, 1)
+}
+
+// Case 4: the original ID matches no DB commodity → nil (treated as new).
+func TestValidateCommodityOwnershipInDB_NoMatchingCommodity(t *testing.T) {
+	c := qt.New(t)
+	fx := newOwnershipFixture(t)
+	proc := newOwnershipProcessor(fx)
+
+	stats := &types.RestoreStats{}
+
+	err := proc.validateCommodityOwnershipInDB(fx.ownerCtx, "no-such-uuid", fx.owner, emptyExisting(), stats)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0)
+}

--- a/go/backup/restore/processor/processor_shared.go
+++ b/go/backup/restore/processor/processor_shared.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/go-extras/errx"
@@ -15,6 +16,7 @@ import (
 	"github.com/denisvmedia/inventario/backup/restore/security"
 	"github.com/denisvmedia/inventario/backup/restore/types"
 	"github.com/denisvmedia/inventario/internal/backupsign"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/validationctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -103,6 +105,19 @@ func (l *RestoreOperationProcessor) Process(ctx context.Context) error {
 	}
 
 	l.createRestoreStep(ctx, "Initializing restore", models.RestoreStepResultInProgress, "")
+
+	// Defense-in-depth: the restore worker reads the export's blob key WITHOUT
+	// RLS, and an `.inb` archive is signed against a tenant-AGNOSTIC server key.
+	// Refuse a FilePath that lives outside the export's own tenant namespace
+	// before opening it, so a row whose FilePath was somehow set to another
+	// tenant's key cannot exfiltrate that tenant's data. An empty tenant yields
+	// an empty prefix — guard it explicitly so HasPrefix can't pass vacuously.
+	prefix := blobkeys.TenantPrefix(export.TenantID)
+	if prefix == "" || !strings.HasPrefix(export.FilePath, prefix) {
+		return l.markRestoreFailed(ctx,
+			errx.NewSentinel("export file path is outside the export's tenant namespace"),
+			"failed to open export file")
+	}
 
 	b, err := blob.OpenBucket(ctx, l.uploadLocation)
 	if err != nil {

--- a/go/backup/restore/processor/processor_shared.go
+++ b/go/backup/restore/processor/processor_shared.go
@@ -55,7 +55,7 @@ func NewRestoreOperationProcessor(restoreOperationID string, factorySet *registr
 		tagService:            services.NewTagService(factorySet),
 		uploadLocation:        uploadLocation,
 		signer:                signer,
-		securityValidator:     security.NewRestoreSecurityValidator(factorySet, logger),
+		securityValidator:     security.NewRestoreSecurityValidator(logger),
 		importSessionEntities: make(map[string]bool),
 	}
 }

--- a/go/backup/restore/security/validator.go
+++ b/go/backup/restore/security/validator.go
@@ -3,13 +3,8 @@ package security
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"slices"
 	"time"
-
-	"github.com/denisvmedia/inventario/appctx"
-	"github.com/denisvmedia/inventario/registry"
 )
 
 // Package-level errors
@@ -20,9 +15,6 @@ var (
 
 // SecurityValidator defines the interface for security validation during restore operations
 type SecurityValidator interface {
-	ValidateEntityOwnership(ctx context.Context, entityID string, userID string) error
-	ValidateRelationshipIntegrity(ctx context.Context, fileType string, parentEntityType string) error
-	ValidateImportScope(ctx context.Context, entityID string, importSession string, sessionEntities map[string]bool) error
 	LogUnauthorizedAttempt(ctx context.Context, attempt UnauthorizedAttempt)
 }
 
@@ -39,128 +31,18 @@ type UnauthorizedAttempt struct {
 
 // RestoreSecurityValidator implements SecurityValidator for restore operations
 type RestoreSecurityValidator struct {
-	factorySet *registry.FactorySet
-	logger     *slog.Logger
+	logger *slog.Logger
 }
 
 // NewRestoreSecurityValidator creates a new RestoreSecurityValidator
-func NewRestoreSecurityValidator(factorySet *registry.FactorySet, logger *slog.Logger) *RestoreSecurityValidator {
+func NewRestoreSecurityValidator(logger *slog.Logger) *RestoreSecurityValidator {
 	return &RestoreSecurityValidator{
-		factorySet: factorySet,
-		logger:     logger,
+		logger: logger,
 	}
-}
-
-// ValidateEntityOwnership validates that the current user owns the specified entity
-func (v *RestoreSecurityValidator) ValidateEntityOwnership(ctx context.Context, entityID string, userID string) error {
-	// Use service account registries to bypass user filtering and see all entities
-	commodityRegistry := v.factorySet.CommodityRegistryFactory.CreateServiceRegistry()
-	areaRegistry := v.factorySet.AreaRegistryFactory.CreateServiceRegistry()
-	locationRegistry := v.factorySet.LocationRegistryFactory.CreateServiceRegistry()
-
-	// Check commodity ownership
-	if commodity, err := commodityRegistry.Get(ctx, entityID); err == nil {
-		if commodity.CreatedByUserID != userID {
-			v.LogUnauthorizedAttempt(ctx, UnauthorizedAttempt{
-				UserID:         userID,
-				TargetEntityID: entityID,
-				EntityType:     "commodity",
-				Operation:      "restore_link_files",
-				AttemptType:    "cross_user_access",
-				Timestamp:      time.Now(),
-			})
-			return errors.New("unauthorized: cannot link to entity owned by different user")
-		}
-		return nil
-	}
-
-	// Check area ownership
-	if area, err := areaRegistry.Get(ctx, entityID); err == nil {
-		if area.CreatedByUserID != userID {
-			v.LogUnauthorizedAttempt(ctx, UnauthorizedAttempt{
-				UserID:         userID,
-				TargetEntityID: entityID,
-				EntityType:     "area",
-				Operation:      "restore_link_files",
-				AttemptType:    "cross_user_access",
-				Timestamp:      time.Now(),
-			})
-			return errors.New("unauthorized: cannot link to entity owned by different user")
-		}
-		return nil
-	}
-
-	// Check location ownership
-	if location, err := locationRegistry.Get(ctx, entityID); err == nil {
-		if location.CreatedByUserID != userID {
-			v.LogUnauthorizedAttempt(ctx, UnauthorizedAttempt{
-				UserID:         userID,
-				TargetEntityID: entityID,
-				EntityType:     "location",
-				Operation:      "restore_link_files",
-				AttemptType:    "cross_user_access",
-				Timestamp:      time.Now(),
-			})
-			return errors.New("unauthorized: cannot link to entity owned by different user")
-		}
-		return nil
-	}
-
-	// Entity not found - log the attempt but allow file upload (will be orphaned)
-	v.LogUnauthorizedAttempt(ctx, UnauthorizedAttempt{
-		UserID:         userID,
-		TargetEntityID: entityID,
-		EntityType:     "unknown",
-		Operation:      "restore_link_files",
-		AttemptType:    "non_existent_entity_access",
-		Timestamp:      time.Now(),
-	})
-	return errors.New("entity not found: file will be uploaded as orphaned")
-}
-
-// ValidateRelationshipIntegrity validates that file types can be linked to appropriate entity types
-func (v *RestoreSecurityValidator) ValidateRelationshipIntegrity(ctx context.Context, fileType string, parentEntityType string) error {
-	allowedRelationships := map[string][]string{
-		"invoice": {"commodity"},
-		"image":   {"commodity"},
-		"manual":  {"commodity"},
-	}
-
-	allowedParents, exists := allowedRelationships[fileType]
-	if !exists {
-		return fmt.Errorf("unknown file type: %s", fileType)
-	}
-
-	if slices.Contains(allowedParents, parentEntityType) {
-		return nil // Valid relationship
-	}
-
-	return fmt.Errorf("invalid relationship: %s files cannot be linked to %s entities", fileType, parentEntityType)
-}
-
-// ValidateImportScope validates that entities being linked are within the import scope
-func (v *RestoreSecurityValidator) ValidateImportScope(ctx context.Context, entityID string, importSession string, sessionEntities map[string]bool) error {
-	// Check if entity was created in this import session
-	if sessionEntities[entityID] {
-		return nil // OK - entity created in this import
-	}
-
-	// Check if user already owns this entity
-	currentUser := appctx.UserFromContext(ctx)
-	if currentUser == nil {
-		return ErrNoUserContext
-	}
-
-	err := v.ValidateEntityOwnership(ctx, entityID, currentUser.ID)
-	if err != nil {
-		return fmt.Errorf("unauthorized: cannot link to entity outside import scope: %w", err)
-	}
-
-	return nil // OK - user owns existing entity
 }
 
 // LogUnauthorizedAttempt logs details about unauthorized access attempts
-func (v *RestoreSecurityValidator) LogUnauthorizedAttempt(ctx context.Context, attempt UnauthorizedAttempt) {
+func (v *RestoreSecurityValidator) LogUnauthorizedAttempt(_ context.Context, attempt UnauthorizedAttempt) {
 	v.logger.Warn("Unauthorized entity access attempt",
 		"user_id", attempt.UserID,
 		"target_entity_id", attempt.TargetEntityID,

--- a/go/backup/restore/security/validator.go
+++ b/go/backup/restore/security/validator.go
@@ -13,7 +13,10 @@ var (
 	ErrOwnershipViolation = errors.New("commodity belongs to a different user")
 )
 
-// SecurityValidator defines the interface for security validation during restore operations
+// SecurityValidator is the audit-logging surface for restore operations: it
+// records unauthorized entity-access attempts. Ownership and import scope are
+// enforced by the RLS layer and the restore processor
+// (validateCommodityOwnershipInDB), not here — this interface only logs.
 type SecurityValidator interface {
 	LogUnauthorizedAttempt(ctx context.Context, attempt UnauthorizedAttempt)
 }
@@ -29,7 +32,8 @@ type UnauthorizedAttempt struct {
 	RequestDetails map[string]any
 }
 
-// RestoreSecurityValidator implements SecurityValidator for restore operations
+// RestoreSecurityValidator is the slog-backed SecurityValidator the restore
+// processor uses to record unauthorized-access attempts.
 type RestoreSecurityValidator struct {
 	logger *slog.Logger
 }

--- a/go/backup/restore/security/validator_test.go
+++ b/go/backup/restore/security/validator_test.go
@@ -1,0 +1,63 @@
+package security_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/backup/restore/security"
+)
+
+// newValidator builds a RestoreSecurityValidator around a JSON slog handler
+// writing into the returned buffer so log assertions can inspect emitted
+// records.
+func newValidator() (*security.RestoreSecurityValidator, *bytes.Buffer) {
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return security.NewRestoreSecurityValidator(logger), logBuf
+}
+
+// logRecords parses the captured JSON log buffer into a slice of decoded
+// records so tests can assert on individual emitted attributes.
+func logRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		must.Assert(json.Unmarshal([]byte(line), &rec))
+		out = append(out, rec)
+	}
+	return out
+}
+
+func TestLogUnauthorizedAttempt_EmitsWarnRecord(t *testing.T) {
+	c := qt.New(t)
+	validator, logBuf := newValidator()
+
+	validator.LogUnauthorizedAttempt(context.Background(), security.UnauthorizedAttempt{
+		UserID:         "attacker-id",
+		TargetEntityID: "target-123",
+		EntityType:     "commodity",
+		Operation:      "restore_link_files",
+		AttemptType:    "cross_user_access",
+	})
+
+	recs := logRecords(t, logBuf)
+	c.Assert(recs, qt.HasLen, 1)
+	c.Assert(recs[0]["level"], qt.Equals, "WARN")
+	c.Assert(recs[0]["msg"], qt.Equals, "Unauthorized entity access attempt")
+	c.Assert(recs[0]["user_id"], qt.Equals, "attacker-id")
+	c.Assert(recs[0]["target_entity_id"], qt.Equals, "target-123")
+	c.Assert(recs[0]["entity_type"], qt.Equals, "commodity")
+	c.Assert(recs[0]["attempt_type"], qt.Equals, "cross_user_access")
+	c.Assert(recs[0]["operation"], qt.Equals, "restore_link_files")
+}


### PR DESCRIPTION
## What

Restore/import security hardening from the #2087 alpha-readiness audit, in two parts:

1. **Security fix — cross-tenant backup import.** `importExport` accepted any user-supplied `SourceFilePath` (validated only `Required`+`Length`) and the import worker read that raw blob key **without RLS**. A `.inb` is signed with a **tenant-agnostic server key**, so an authenticated user could import *another tenant's* backup by naming its key (`t/<victim>/exports/backup_….inb`) and restore it into their own account → cross-tenant data exfiltration.
   - `importExport` now rejects with **422** any `SourceFilePath` outside the caller's tenant prefix (`blobkeys.TenantPrefix(user.TenantID)`); the empty-tenant case is guarded so the prefix check can't pass vacuously.
   - **Defense-in-depth:** `ProcessImport` and the restore processor's `Process` fail before reading a blob key outside the *export's* own tenant namespace.
   - Legit restore uploads are keyed `t/<callerTenant>/restores/…` (`blobkeys.BuildRestoreUploadKey`), so the check passes for all real flows — covered by a negative-control test (own-tenant key → 201).

2. **Test the real ownership gate + remove dead code.** The `backup/restore/security` validator's three decision methods (`ValidateEntityOwnership` / `RelationshipIntegrity` / `ImportScope`) were **dead code** (zero non-test callers); the flow's actual commodity-ownership gate is `RestoreOperationProcessor.validateCommodityOwnershipInDB`, which was uncovered in normal CI.
   - Deleted the dead methods (+ unused `factorySet` field/param); the validator keeps only `LogUnauthorizedAttempt`. `ErrNoUserContext`/`ErrOwnershipViolation` kept (the processor uses them).
   - **New internal test** for `validateCommodityOwnershipInDB`: existing-short-circuit, owner-OK, cross-user → `errors.Is(ErrOwnershipViolation)` + stats, no-match. Gate coverage **0% → 79.2%**.

## Why I'm confident the deletion was safe

A focused security review of the whole import/restore flow confirmed the removed validator's *described* protections (area/location ownership, relationship integrity, import scope) are **already enforced structurally** by the RLS layer + user-aware registries (tenant/group/owner are overwritten from request context on every create/update; `merge_update` only matches the caller's own rows; `full_replace` deletes only the caller's data; restored blobs are re-keyed under the caller's tenant). The deletion removed dead code, not a needed check — and the same review is what surfaced the import-path gap above.

## Verification (independently re-run)

`go build ./...` · `go test ./apiserver/... ./backup/import/... ./backup/restore/...` (all `ok`) · `go vet` · `golangci-lint` (0 issues) · `go tool nolintguard` · `go tool qtlint` — all clean; also green under `-tags legacy_xml_backup`.