### PR TITLE
fix(deletes): unbreak tenant + user hard-delete via FK-safe purgers

### DIFF
--- a/go/cmd/inventario/tenants/deletecmd/config.go
+++ b/go/cmd/inventario/tenants/deletecmd/config.go
@@ -5,4 +5,11 @@ type Config struct {
 	// Command options
 	Force  bool `yaml:"force" env:"FORCE" env-default:"false"`
 	DryRun bool `yaml:"dry_run" env:"DRY_RUN" env-default:"false"`
+
+	// UploadLocation points at the same object store the server uses, so the
+	// tenant hard-delete can remove the tenant's physical blobs before purging
+	// its DB rows. When empty it falls back to the configured default; if that
+	// does not match the running deployment the blobs are orphaned (the DB
+	// purge still proceeds with a warning).
+	UploadLocation string `yaml:"upload_location" env:"UPLOAD_LOCATION" env-default:""`
 }

--- a/go/cmd/inventario/tenants/deletecmd/deletecmd.go
+++ b/go/cmd/inventario/tenants/deletecmd/deletecmd.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/denisvmedia/inventario/cmd/internal/command"
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/internal/defaults"
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services"
 	"github.com/denisvmedia/inventario/services/admin"
 )
 
@@ -74,6 +76,8 @@ func (c *Command) registerFlags() {
 
 	// Delete options
 	c.Cmd().Flags().BoolVar(&c.config.Force, "force", c.config.Force, "Skip confirmation prompts")
+	c.Cmd().Flags().StringVar(&c.config.UploadLocation, "upload-location", c.config.UploadLocation,
+		"Object-store location of the tenant's uploaded files; required to remove physical blobs (defaults to the configured upload location)")
 }
 
 // deleteTenant handles the tenant deletion process
@@ -113,6 +117,15 @@ func (c *Command) deleteTenant(cfg *Config, dbConfig *shared.DatabaseConfig, idO
 			fmt.Printf("Warning: failed to close admin service: %v\n", closeErr)
 		}
 	}()
+
+	// Wire a FileService bound to the same backend so the hard-delete also
+	// removes the tenant's physical blobs (#2115). Falls back to the configured
+	// default upload location when --upload-location is not given.
+	uploadLocation := strings.TrimSpace(cfg.UploadLocation)
+	if uploadLocation == "" {
+		uploadLocation = defaults.GetUploadLocation()
+	}
+	adminService.SetFileService(services.NewFileService(adminService.FactorySet(), uploadLocation))
 
 	// Find the tenant to delete
 	tenant, err := adminService.GetTenant(context.Background(), idOrSlug)

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -194,6 +194,8 @@ type FactorySet struct {
 	GroupInviteAuditRegistry              GroupInviteAuditRegistry      // GroupInviteAuditRegistry is tenant-scoped, not user-aware
 	GroupNotificationPrefRegistry         GroupNotificationPrefRegistry // Per-group notification opt-outs (#1648); tenant-scoped, user-filtered in application logic
 	GroupPurger                           GroupPurger                   // GroupPurger hard-deletes group-scoped data during purge ticks
+	TenantPurger                          TenantPurger                  // TenantPurger hard-deletes every tenant-scoped dependent row during admin tenant hard-delete (#2115)
+	UserPurger                            UserPurger                    // UserPurger hard-deletes a user's auth/identity rows during admin user hard-delete (#2116)
 	WarrantyReminderRegistry              WarrantyReminderRegistry      // WarrantyReminderRegistry is the worker idempotency store; service-mode only
 	StorageQuotaReminderRegistry          StorageQuotaReminderRegistry  // StorageQuotaReminderRegistry is the storage quota warning worker idempotency store; service-mode only (#1585)
 	MaintenanceReminderRegistry           MaintenanceReminderRegistry   // MaintenanceReminderRegistry is the maintenance reminder worker idempotency store; service-mode only (#1368)

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -135,6 +135,19 @@ func NewFactorySet() *registry.FactorySet {
 		fs.GroupNotificationPrefRegistry,
 		fs.GroupMembershipRegistry,
 	)
+	// UserPurger (#2116): clears a single user's auth/identity rows during the
+	// admin user hard-delete. Takes the plain singleton registries that own the
+	// shared in-memory maps; all eight are set above, so it can be wired here.
+	fs.UserPurger = NewUserPurger(
+		fs.RefreshTokenRegistry,
+		fs.UserMFASecretRegistry,
+		fs.OAuthIdentityRegistry,
+		fs.PasswordResetRegistry,
+		fs.EmailVerificationRegistry,
+		fs.MagicLinkTokenRegistry,
+		fs.GroupMembershipRegistry,
+		fs.SystemAdminGrantRegistry,
+	)
 	// SystemStats (#843): the memory backend is dev/test only and its
 	// data registries are tenant/group-scoped behind the per-request
 	// context, with no cheap installation-wide roll-up. Rather than range
@@ -148,6 +161,10 @@ func NewFactorySet() *registry.FactorySet {
 		return registry.SystemStats{}, nil
 	}
 	fs.PingFn = func(context.Context) error { return nil }
+
+	// TenantPurger (#2115) reads almost every registry off the FactorySet, so
+	// it MUST be wired LAST — after every other fs.* field is populated above.
+	fs.TenantPurger = NewTenantPurger(fs)
 
 	return fs
 }

--- a/go/registry/memory/tenant_purger.go
+++ b/go/registry/memory/tenant_purger.go
@@ -1,0 +1,326 @@
+package memory
+
+import (
+	"context"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.TenantPurger = (*TenantPurger)(nil)
+
+// TenantPurger is the in-memory counterpart to postgres.TenantPurger. It
+// deletes every tenant-scoped row whose TenantID matches the request via each
+// registry's service-mode view, in FK-safe order.
+//
+// Unlike GroupPurger (which took the individual factories it needed) the
+// tenant purge touches almost every registry on the FactorySet — group-scoped
+// data AND the tenant-only auth/identity tables that GroupPurger never sees —
+// so it accepts the whole FactorySet. The orchestration layer wires it last,
+// after every fs.* field is populated.
+//
+// It does NOT delete the tenants row itself — the orchestration layer drops it
+// after the dependents are gone, exactly as postgres.TenantPurger leaves the
+// tenants DELETE to its caller.
+//
+// Three tenant-scoped tables are intentionally NOT purged here: settings,
+// commodity_scan_audits and storage_quota_reminders. Their registry interfaces
+// expose no enumerable per-row List+Delete (SettingsRegistry is Get/Save/Patch;
+// CommodityScanAudit is Record/Count/DeleteOlderThan; StorageQuotaReminder is
+// HasSent/CreateOnce/DeleteByGroupThreshold), so there is no interface-level
+// handle to remove their rows wholesale. The memory GroupPurger omits
+// storage_quota_reminders for the same reason. The postgres purger clears all
+// three via raw SQL and is the authoritative production path; the memory
+// backend is dev/test only, where these tables are negligible. See the
+// postgres purger for the full set.
+type TenantPurger struct {
+	fs *registry.FactorySet
+}
+
+// NewTenantPurger wires a TenantPurger to the populated FactorySet. It must be
+// called after every fs.* registry field is set.
+func NewTenantPurger(fs *registry.FactorySet) *TenantPurger {
+	return &TenantPurger{fs: fs}
+}
+
+// PurgeTenantDependents walks each tenant-scoped registry in FK-safe order and
+// deletes every row whose TenantID matches. Unlike the postgres variant these
+// deletes are not in a single transaction — memory mode is only used for tests
+// where partial failure is acceptable.
+//
+// Ordering mirrors postgres.tenantPurgeOrder: the export/restore + thumbnail
+// chains and the commodity subtree drop before their parents, currency
+// migrations + their audit rows before location_groups, the auth/identity
+// tables before users, and finally location_groups then users (every
+// tenant-scoped table FKs user_id/created_by -> users NO ACTION, and the group
+// data FKs group_id -> location_groups NO ACTION).
+func (r *TenantPurger) PurgeTenantDependents(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return errxtrace.Wrap("tenantID required", registry.ErrFieldRequired)
+	}
+
+	fs := r.fs
+
+	// Resolve the tenant's location groups once. Two registries
+	// (currency-migration audit rows and group_notification_prefs) only expose
+	// a per-(tenant, group) delete — no per-tenant handle — so the purge fans
+	// those out across this group set. ListGroupIDsForTenant returns every
+	// group id (any status) belonging to the tenant.
+	groupIDs, err := r.listGroupIDsForTenant(ctx, tenantID)
+	if err != nil {
+		return errxtrace.Wrap("failed to list tenant groups for purge", err)
+	}
+
+	type step struct {
+		name string
+		run  func() error
+	}
+	steps := []step{
+		// Restore pipeline (deepest children first).
+		{"restore_steps", func() error {
+			reg := fs.RestoreStepRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.RestoreStep])
+		}},
+		{"restore_operations", func() error {
+			reg := fs.RestoreOperationRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.RestoreOperation])
+		}},
+		{"exports", func() error {
+			reg := fs.ExportRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.Export])
+		}},
+		// Thumbnail chain (#2117): slots -> jobs -> files. Both job and slot
+		// rows carry a tenant_id, so the generic per-tenant path applies (no
+		// per-file subquery scoping like the group purger needs).
+		{"user_concurrency_slots", func() error {
+			reg := fs.UserConcurrencySlotRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.UserConcurrencySlot])
+		}},
+		{"thumbnail_generation_jobs", func() error {
+			reg := fs.ThumbnailGenerationJobRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.ThumbnailGenerationJob])
+		}},
+		{"files", func() error {
+			reg := fs.FileRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.FileEntity])
+		}},
+		{"commodity_events", func() error {
+			reg := fs.CommodityEventRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.CommodityEvent])
+		}},
+		// Currency-migration audit rows before the migrations. The only delete
+		// handle is DeleteAuditRowsByGroup(tenant, group), so fan out across the
+		// tenant's groups (mirrors the postgres explicit per-tenant DELETE).
+		{"currency_migration_audit_rows", func() error {
+			reg := fs.CurrencyMigrationRegistryFactory.CreateServiceRegistry()
+			for _, groupID := range groupIDs {
+				if _, derr := reg.DeleteAuditRowsByGroup(ctx, tenantID, groupID); derr != nil {
+					return derr
+				}
+			}
+			return nil
+		}},
+		// Maintenance reminders before their schedules; the reminder registry
+		// is service-mode only, keyed by schedule, so fan out per matching
+		// schedule (mirrors the group purger's DeleteBySchedule path).
+		{"maintenance_reminders", func() error {
+			scheduleReg := fs.MaintenanceScheduleRegistryFactory.CreateServiceRegistry()
+			schedules, listErr := scheduleReg.List(ctx)
+			if listErr != nil {
+				return listErr
+			}
+			for _, s := range schedules {
+				if s == nil || s.GetTenantID() != tenantID {
+					continue
+				}
+				if _, derr := fs.MaintenanceReminderRegistry.DeleteBySchedule(ctx, s.ID); derr != nil {
+					return derr
+				}
+			}
+			return nil
+		}},
+		{"maintenance_schedules", func() error {
+			reg := fs.MaintenanceScheduleRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.MaintenanceSchedule])
+		}},
+		// Commodity sub-resources before commodities.
+		{"commodity_supply_links", func() error {
+			reg := fs.SupplyLinkRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.SupplyLink])
+		}},
+		{"commodity_services", func() error {
+			reg := fs.CommodityServiceRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.CommodityService])
+		}},
+		{"commodity_loans", func() error {
+			reg := fs.CommodityLoanRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.CommodityLoan])
+		}},
+		{"currency_migrations", func() error {
+			reg := fs.CurrencyMigrationRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.CurrencyMigration])
+		}},
+		{"commodities", func() error {
+			reg := fs.CommodityRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.Commodity])
+		}},
+		{"areas", func() error {
+			reg := fs.AreaRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.Area])
+		}},
+		{"locations", func() error {
+			reg := fs.LocationRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.Location])
+		}},
+		{"tags", func() error {
+			reg := fs.TagRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.Tag])
+		}},
+		// Per-user/per-group notification overrides. The only delete handle is
+		// DeleteByGroup(tenant, group), so fan out across the tenant's groups
+		// (mirrors the postgres per-tenant DELETE).
+		{"group_notification_prefs", func() error {
+			for _, groupID := range groupIDs {
+				if _, derr := fs.GroupNotificationPrefRegistry.DeleteByGroup(ctx, tenantID, groupID); derr != nil {
+					return derr
+				}
+			}
+			return nil
+		}},
+		// Audit logs (nullable tenant_id, no FK to tenants); a plain registry.
+		// TenantID is *string, so read it through a nil-safe extractor.
+		{"audit_logs", func() error {
+			return purgeByTenant(ctx, tenantID, fs.AuditLogRegistry.List, fs.AuditLogRegistry.Delete, func(a *models.AuditLog) string {
+				if a.TenantID == nil {
+					return ""
+				}
+				return *a.TenantID
+			})
+		}},
+		// Auth/session/identity tables — all FK user_id -> users NO ACTION, so
+		// they drop before users. Each embeds Registry[T] (generic List/Delete);
+		// the token tables expose a public TenantID field rather than the
+		// TenantAware interface, so read it directly.
+		{"login_events", func() error {
+			return purgeByTenant(ctx, tenantID, fs.LoginEventRegistry.List, fs.LoginEventRegistry.Delete, tenantAware[models.LoginEvent])
+		}},
+		{"refresh_tokens", func() error {
+			return purgeByTenant(ctx, tenantID, fs.RefreshTokenRegistry.List, fs.RefreshTokenRegistry.Delete, tenantAware[models.RefreshToken])
+		}},
+		{"email_verifications", func() error {
+			return purgeByTenant(ctx, tenantID, fs.EmailVerificationRegistry.List, fs.EmailVerificationRegistry.Delete, func(e *models.EmailVerification) string {
+				return e.TenantID
+			})
+		}},
+		{"password_resets", func() error {
+			return purgeByTenant(ctx, tenantID, fs.PasswordResetRegistry.List, fs.PasswordResetRegistry.Delete, func(p *models.PasswordReset) string {
+				return p.TenantID
+			})
+		}},
+		{"magic_link_tokens", func() error {
+			return purgeByTenant(ctx, tenantID, fs.MagicLinkTokenRegistry.List, fs.MagicLinkTokenRegistry.Delete, func(m *models.MagicLinkToken) string {
+				return m.TenantID
+			})
+		}},
+		{"user_mfa_secrets", func() error {
+			return purgeByTenant(ctx, tenantID, fs.UserMFASecretRegistry.List, fs.UserMFASecretRegistry.Delete, tenantAware[models.UserMFASecret])
+		}},
+		{"user_oauth_identities", func() error {
+			return purgeByTenant(ctx, tenantID, fs.OAuthIdentityRegistry.List, fs.OAuthIdentityRegistry.Delete, tenantAware[models.OAuthIdentity])
+		}},
+		{"operation_slots", func() error {
+			reg := fs.OperationSlotRegistryFactory.CreateServiceRegistry()
+			return purgeByTenant(ctx, tenantID, reg.List, reg.Delete, tenantAware[models.OperationSlot])
+		}},
+		// Membership + invite rows: FK both users and location_groups NO ACTION,
+		// so they drop before both. GroupMembership embeds Registry[T], so the
+		// generic per-tenant path applies.
+		{"group_memberships", func() error {
+			return purgeByTenant(ctx, tenantID, fs.GroupMembershipRegistry.List, fs.GroupMembershipRegistry.Delete, tenantAware[models.GroupMembership])
+		}},
+		{"group_invites", func() error {
+			return purgeByTenant(ctx, tenantID, fs.GroupInviteRegistry.List, fs.GroupInviteRegistry.Delete, tenantAware[models.GroupInvite])
+		}},
+		{"group_invites_audit", func() error {
+			return purgeByTenant(ctx, tenantID, fs.GroupInviteAuditRegistry.List, fs.GroupInviteAuditRegistry.Delete, tenantAware[models.GroupInviteAudit])
+		}},
+		// location_groups before users (location_groups.created_by -> users
+		// NO ACTION); after every group-scoped row + currency_migrations.
+		{"location_groups", func() error {
+			return purgeByTenant(ctx, tenantID, fs.LocationGroupRegistry.List, fs.LocationGroupRegistry.Delete, tenantAware[models.LocationGroup])
+		}},
+		// users last.
+		{"users", func() error {
+			return purgeByTenant(ctx, tenantID, fs.UserRegistry.List, fs.UserRegistry.Delete, tenantAware[models.User])
+		}},
+	}
+
+	for _, s := range steps {
+		if err := s.run(); err != nil {
+			return errxtrace.Wrap("failed to purge "+s.name, err)
+		}
+	}
+	return nil
+}
+
+// tenantAware reads the tenant id off any model whose pointer satisfies
+// models.TenantAware. It is the default extractor for purgeByTenant; the few
+// token models that expose a public TenantID field but no GetTenantID method
+// pass a field-reading closure instead.
+func tenantAware[T any](item *T) string {
+	if ta, ok := any(item).(models.TenantAware); ok {
+		return ta.GetTenantID()
+	}
+	return ""
+}
+
+// purgeByTenant lists everything from a service-mode registry view, keeps only
+// rows whose extracted tenant id matches, and deletes each. The service-mode
+// List returns all rows (user/group/tenant filtering disabled), so filtering
+// happens here. tenantOf yields the row's tenant id.
+func purgeByTenant[T any](
+	ctx context.Context,
+	tenantID string,
+	list func(context.Context) ([]*T, error),
+	del func(context.Context, string) error,
+	tenantOf func(*T) string,
+) error {
+	items, err := list(ctx)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if item == nil || tenantOf(item) != tenantID {
+			continue
+		}
+		idable, ok := any(item).(models.IDable)
+		if !ok {
+			continue
+		}
+		if err := del(ctx, idable.GetID()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// listGroupIDsForTenant returns the ids of every location group belonging to
+// the tenant (any status). Used to fan out the two per-(tenant, group)-only
+// deletes (currency-migration audit rows, group_notification_prefs) across the
+// tenant's groups, since neither registry exposes a per-tenant delete.
+func (r *TenantPurger) listGroupIDsForTenant(ctx context.Context, tenantID string) ([]string, error) {
+	groups, err := r.fs.LocationGroupRegistry.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if g == nil || g.GetTenantID() != tenantID {
+			continue
+		}
+		ids = append(ids, g.ID)
+	}
+	return ids, nil
+}

--- a/go/registry/memory/user_purger.go
+++ b/go/registry/memory/user_purger.go
@@ -1,0 +1,189 @@
+package memory
+
+import (
+	"context"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.UserPurger = (*UserPurger)(nil)
+
+// UserPurger is the in-memory counterpart to postgres.UserPurger (#2116). It
+// hard-deletes a single user's auth / identity rows via the existing
+// service-mode registries, mirroring the postgres DELETE-by-user_id sequence.
+//
+// Unlike the postgres variant these deletes are NOT one transaction — memory
+// mode is only used in tests where partial failure is acceptable.
+//
+// PARITY GAPS (memory backend only): several auth tables have no user-scoped
+// delete method on their in-memory registry, so they are skipped here. They are
+// fully handled by postgres.UserPurger. If a memory test ever needs to assert
+// these are gone, the orchestration layer must add the corresponding
+// DeleteByUser-style method to the registry (a shared file, hence not touched
+// from this purger). The skipped tables are:
+//   - login_events           (only DeleteOlderThan exists)
+//   - operation_slots        (only CleanupExpiredSlots / per-slot release)
+//   - commodity_scan_audits  (only DeleteOlderThan exists)
+//   - settings               (no per-user Delete; Get/Save/Patch only)
+//   - group_notification_prefs (only DeleteByGroup / ListByUserGroup; no
+//     list-by-user across all groups)
+//   - thumbnail_generation_jobs + user_concurrency_slots (purged by group in
+//     GroupPurger via the file chain; no user-scoped path)
+//
+// It does NOT touch the users row itself — the orchestration layer issues the
+// final user delete after this returns.
+type UserPurger struct {
+	refreshTokens registry.RefreshTokenRegistry
+	mfaSecrets    registry.UserMFASecretRegistry
+	oauth         registry.OAuthIdentityRegistry
+	passwordReset registry.PasswordResetRegistry
+	emailVerif    registry.EmailVerificationRegistry
+	magicLink     registry.MagicLinkTokenRegistry
+	memberships   registry.GroupMembershipRegistry
+	adminGrants   registry.SystemAdminGrantRegistry
+}
+
+// NewUserPurger wires a UserPurger to the registries that own the shared
+// in-memory data maps. All parameters are required.
+func NewUserPurger(
+	refreshTokens registry.RefreshTokenRegistry,
+	mfaSecrets registry.UserMFASecretRegistry,
+	oauth registry.OAuthIdentityRegistry,
+	passwordReset registry.PasswordResetRegistry,
+	emailVerif registry.EmailVerificationRegistry,
+	magicLink registry.MagicLinkTokenRegistry,
+	memberships registry.GroupMembershipRegistry,
+	adminGrants registry.SystemAdminGrantRegistry,
+) *UserPurger {
+	return &UserPurger{
+		refreshTokens: refreshTokens,
+		mfaSecrets:    mfaSecrets,
+		oauth:         oauth,
+		passwordReset: passwordReset,
+		emailVerif:    emailVerif,
+		magicLink:     magicLink,
+		memberships:   memberships,
+		adminGrants:   adminGrants,
+	}
+}
+
+// PurgeUserDependents hard-deletes the user's auth/identity rows. Idempotent:
+// a second call after a clean purge is a no-op (every step matches zero rows).
+//
+// PRECONDITION (matching postgres): the user must no longer OWN shared content
+// — those rows carry NOT NULL user_id + NOT NULL created_by columns that
+// cannot be orphaned, so this purger deliberately does not touch them.
+func (r *UserPurger) PurgeUserDependents(ctx context.Context, tenantID, userID string) error {
+	if tenantID == "" {
+		return errxtrace.Wrap("tenantID required", registry.ErrFieldRequired)
+	}
+	if userID == "" {
+		return errxtrace.Wrap("userID required", registry.ErrFieldRequired)
+	}
+
+	type step struct {
+		name string
+		run  func() error
+	}
+	steps := []step{
+		{"refresh_tokens", func() error { return r.purgeRefreshTokens(ctx, userID) }},
+		{"email_verifications", func() error { return r.purgeEmailVerifications(ctx, userID) }},
+		{"password_resets", func() error { return r.passwordReset.DeleteByUserID(ctx, userID) }},
+		{"magic_link_tokens", func() error { return r.magicLink.DeleteByUserID(ctx, userID) }},
+		{"user_mfa_secrets", func() error { return r.mfaSecrets.DeleteByUser(ctx, tenantID, userID) }},
+		{"user_oauth_identities", func() error { return r.purgeOAuthIdentities(ctx, tenantID, userID) }},
+		{"group_memberships", func() error { return r.purgeMemberships(ctx, tenantID, userID) }},
+		// System-admin grant the user HOLDS. RevokeAtomic(allowZero=true)
+		// removes it idempotently. The granted_by back-ref is nulled only on
+		// the postgres side; the memory grant registry has no granted_by index
+		// and stores it as an unread value field, so no memory action is needed
+		// for the SET NULL case.
+		{"system_admin_grants", func() error {
+			_, err := r.adminGrants.RevokeAtomic(ctx, userID, true)
+			return err
+		}},
+	}
+	for _, s := range steps {
+		if err := s.run(); err != nil {
+			return errxtrace.Wrap("failed to purge "+s.name, err)
+		}
+	}
+	return nil
+}
+
+// purgeRefreshTokens hard-deletes every refresh token the user owns. The
+// service interface only exposes RevokeByUserID (a soft revoke), so we list +
+// Delete(id) for a true purge mirroring the postgres DELETE FROM refresh_tokens.
+func (r *UserPurger) purgeRefreshTokens(ctx context.Context, userID string) error {
+	tokens, err := r.refreshTokens.GetByUserID(ctx, userID)
+	if err != nil {
+		return err
+	}
+	for _, t := range tokens {
+		if t == nil {
+			continue
+		}
+		if err := r.refreshTokens.Delete(ctx, t.GetID()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// purgeEmailVerifications lists the user's email-verification rows and deletes
+// each by id (no dedicated DeleteByUserID on the memory registry).
+func (r *UserPurger) purgeEmailVerifications(ctx context.Context, userID string) error {
+	rows, err := r.emailVerif.GetByUserID(ctx, userID)
+	if err != nil {
+		return err
+	}
+	for _, ev := range rows {
+		if ev == nil {
+			continue
+		}
+		if err := r.emailVerif.Delete(ctx, ev.GetID()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// purgeOAuthIdentities deletes each provider link the user holds.
+func (r *UserPurger) purgeOAuthIdentities(ctx context.Context, tenantID, userID string) error {
+	ids, err := r.oauth.ListByUser(ctx, tenantID, userID)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if id == nil {
+			continue
+		}
+		if err := r.oauth.DeleteByUserAndProvider(ctx, tenantID, userID, id.Provider); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// purgeMemberships deletes every membership where the user is the MEMBER.
+// ListByUser filters by member_user_id; Delete(id) bypasses the last-owner
+// invariant on purpose — a hard user purge isn't subject to the interactive
+// "can't remove last owner" guard; the orchestration layer transfers ownership
+// first.
+func (r *UserPurger) purgeMemberships(ctx context.Context, tenantID, userID string) error {
+	memberships, err := r.memberships.ListByUser(ctx, tenantID, userID)
+	if err != nil {
+		return err
+	}
+	for _, m := range memberships {
+		if m == nil {
+			continue
+		}
+		if err := r.memberships.Delete(ctx, m.GetID()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -71,6 +71,8 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry(dbx)
 	fs.GroupNotificationPrefRegistry = NewGroupNotificationPrefRegistry(dbx)
 	fs.GroupPurger = NewGroupPurger(dbx)
+	fs.TenantPurger = NewTenantPurger(dbx)
+	fs.UserPurger = NewUserPurger(dbx)
 	fs.WarrantyReminderRegistry = NewWarrantyReminderRegistry(dbx)
 	fs.StorageQuotaReminderRegistry = NewStorageQuotaReminderRegistry(dbx)
 	fs.MaintenanceReminderRegistry = NewMaintenanceReminderRegistry(dbx)

--- a/go/registry/postgres/tenant_purger.go
+++ b/go/registry/postgres/tenant_purger.go
@@ -1,0 +1,242 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.TenantPurger = (*TenantPurger)(nil)
+
+// TenantPurger bulk-deletes every tenant-scoped dependent row belonging to a
+// single Tenant in one background-worker transaction, honoring FK order so the
+// DELETEs succeed without needing ON DELETE CASCADE on every child table.
+//
+// It is the tenant-level analogue of GroupPurger (#2095/#2117). Where
+// GroupPurger clears one group's subtree, TenantPurger clears the union of
+// every group's data PLUS the tenant-only rows that GroupPurger never touches
+// (users, settings, refresh_tokens, login_events, the auth-token tables,
+// location_groups themselves, …).
+//
+// It does NOT delete the tenants row itself — the orchestration layer
+// (services.admin tenant hard-delete) drops it after the dependents are gone,
+// exactly as GroupPurger leaves location_groups to its service. Issue #2115:
+// before this, DeleteTenant was a bare `DELETE FROM tenants` that every one of
+// the ~35 NO ACTION child FKs rejected.
+type TenantPurger struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+// NewTenantPurger returns a TenantPurger bound to the default table names.
+func NewTenantPurger(dbx *sqlx.DB) *TenantPurger {
+	return NewTenantPurgerWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewTenantPurgerWithTableNames returns a TenantPurger using a custom
+// TableNames (used by tests that want to sandbox against renamed tables).
+func NewTenantPurgerWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *TenantPurger {
+	return &TenantPurger{dbx: dbx, tableNames: tableNames}
+}
+
+// tenantPurgeOrder is the FK-safe DELETE sequence for tenant-scoped tables that
+// carry a tenant_id column. Each entry resolves to the fully-qualified table
+// name; PurgeTenantDependents issues `DELETE FROM <table> WHERE tenant_id = $1`
+// against each one inside a single background-worker transaction.
+//
+// Ordering rules (every cross-table FK in the schema is NO ACTION unless noted,
+// so the child must be deleted before its parent):
+//
+//   - restore_steps -> restore_operations -> exports -> files (the export /
+//     restore pipeline; each FK is NO ACTION).
+//   - user_concurrency_slots -> thumbnail_generation_jobs -> files (the
+//     thumbnail chain; both FK to files/jobs are NO ACTION). Unlike GroupPurger
+//     these tables carry a tenant_id, so they ride the same WHERE template and
+//     no subquery scoping is needed.
+//   - commodity sub-resources (events/loans/services/supply_links, the two
+//     maintenance tables, warranty_reminders, currency_migration_audit_rows)
+//     before their parents. Their FK to commodities/schedules/migrations is
+//     ON DELETE CASCADE, but the explicit DELETE keeps tenant scoping local to
+//     this transaction rather than relying on a cascade.
+//   - commodities -> areas -> locations (inventory hierarchy, NO ACTION).
+//   - currency_migration_audit_rows -> currency_migrations (NO ACTION on the
+//     audit row's group_id; CASCADE on migration_id).
+//   - everything group-scoped before location_groups, which is appended at the
+//     very end of PurgeTenantDependents (group_id -> location_groups is NO
+//     ACTION everywhere). location_groups.currency_migration_id ->
+//     currency_migrations is SET NULL, so currency_migrations may precede it.
+//   - users is NOT in this slice; it is deleted LAST (see PurgeTenantDependents)
+//     because virtually every tenant-scoped table FKs user_id/created_by ->
+//     users NO ACTION, and location_groups.created_by -> users NO ACTION too.
+//
+// The settings and commodity_scan_audits tables have no FK to the rows below
+// and no children, so their position within the data block is unconstrained.
+var tenantPurgeOrder = []func(t store.TableNames) string{
+	// Restore pipeline (deepest children first): steps -> operations ->
+	// exports. exports.file_id -> files is NO ACTION, so exports drop before
+	// files (which is later in this slice).
+	func(t store.TableNames) string { return string(t.RestoreSteps()) },
+	func(t store.TableNames) string { return string(t.RestoreOperations()) },
+	func(t store.TableNames) string { return string(t.Exports()) },
+
+	// Thumbnail chain (#2117). Both tables carry a tenant_id (unlike the
+	// group-scoped purge, which had to subquery through files), so the plain
+	// WHERE tenant_id = $1 template works. slots -> jobs -> files.
+	func(t store.TableNames) string { return string(t.UserConcurrencySlots()) },
+	func(t store.TableNames) string { return string(t.ThumbnailGenerationJobs()) },
+
+	// Generic polymorphic files (linked by entity_type/id, no FK chain). Must
+	// drop after exports + the thumbnail chain (both FK to files NO ACTION) and
+	// after commodities.cover_file_id (SET NULL — harmless either way).
+	func(t store.TableNames) string { return string(t.Files()) },
+
+	// Commodity audit timelines (#1450). FK to commodities is CASCADE; explicit
+	// DELETE keeps tenant scoping local.
+	func(t store.TableNames) string { return string(t.CommodityEvents()) },
+
+	// Warranty reminder idempotency rows (#1367). commodity_id -> commodities
+	// CASCADE; dropped before commodities anyway to keep scoping local.
+	func(t store.TableNames) string { return string(t.WarrantyReminders()) },
+
+	// Storage quota reminder idempotency rows (#1585). No commodity FK;
+	// group_id -> location_groups NO ACTION and created_by_user_id -> users
+	// NO ACTION, so they must drop before location_groups and users (both
+	// appended at the end of PurgeTenantDependents).
+	func(t store.TableNames) string { return string(t.StorageQuotaReminders()) },
+
+	// Maintenance reminder idempotency rows (#1368). schedule_id ->
+	// maintenance_schedules CASCADE; dropped before the schedules.
+	func(t store.TableNames) string { return string(t.MaintenanceReminders()) },
+
+	// Maintenance schedules (#1368). commodity_id -> commodities CASCADE;
+	// dropped before commodities.
+	func(t store.TableNames) string { return string(t.MaintenanceSchedules()) },
+
+	// Currency-migration audit rows (#2095). migration_id ->
+	// currency_migrations CASCADE, commodity_id -> commodities SET NULL.
+	// Dropped before both currency_migrations and commodities.
+	func(t store.TableNames) string { return string(t.CurrencyMigrationAudit()) },
+
+	// Commodity sub-resources (#2095). All FK commodities ON DELETE CASCADE;
+	// explicit DELETE before commodities keeps tenant scoping local.
+	func(t store.TableNames) string { return string(t.CommoditySupplyLinks()) },
+	func(t store.TableNames) string { return string(t.CommodityServices()) },
+	func(t store.TableNames) string { return string(t.CommodityLoans()) },
+
+	// Currency migrations (#2095). group_id -> location_groups NO ACTION, so
+	// they must drop before location_groups (appended at the end). The
+	// location_groups.currency_migration_id back-ref is SET NULL.
+	func(t store.TableNames) string { return string(t.CurrencyMigrations()) },
+
+	// AI photo-scan audit rows (#1720). tenant_id + user_id only (no group_id);
+	// no children, so unconstrained — drop before users (appended at the end).
+	func(t store.TableNames) string { return string(t.CommodityScanAudits()) },
+
+	// Inventory hierarchy: commodities -> areas -> locations (NO ACTION).
+	func(t store.TableNames) string { return string(t.Commodities()) },
+	func(t store.TableNames) string { return string(t.Areas()) },
+	func(t store.TableNames) string { return string(t.Locations()) },
+
+	// Tags (#2095). tenant_id + group_id, no incoming FK left now that the
+	// inventory rows that referenced them are gone.
+	func(t store.TableNames) string { return string(t.Tags()) },
+
+	// Per-user/per-group notification overrides (#2095). group_id ->
+	// location_groups NO ACTION; cleared before location_groups.
+	func(t store.TableNames) string { return string(t.GroupNotificationPrefs()) },
+
+	// Installation settings rows. One per (tenant, key); no children, no
+	// incoming FK — unconstrained.
+	func(t store.TableNames) string { return string(t.Settings()) },
+
+	// Audit logs (nullable tenant_id, no FK to tenants). Tenant-scoped data
+	// that should not outlive the tenant. No children.
+	func(t store.TableNames) string { return string(t.AuditLogs()) },
+
+	// Auth/session tables (all FK user_id -> users NO ACTION, so they must
+	// drop before users; none FK each other). login_events, refresh_tokens,
+	// the token tables, MFA + OAuth identities, operation slots.
+	func(t store.TableNames) string { return string(t.LoginEvents()) },
+	func(t store.TableNames) string { return string(t.RefreshTokens()) },
+	func(t store.TableNames) string { return string(t.EmailVerifications()) },
+	func(t store.TableNames) string { return string(t.PasswordResets()) },
+	func(t store.TableNames) string { return string(t.MagicLinkTokens()) },
+	func(t store.TableNames) string { return string(t.UserMFASecrets()) },
+	func(t store.TableNames) string { return string(t.UserOAuthIdentities()) },
+	func(t store.TableNames) string { return string(t.OperationSlots()) },
+
+	// Membership + invite rows. group_id -> location_groups NO ACTION and
+	// created_by/used_by/member_user_id -> users NO ACTION, so they drop before
+	// both location_groups and users.
+	func(t store.TableNames) string { return string(t.GroupMemberships()) },
+	func(t store.TableNames) string { return string(t.GroupInvites()) },
+	func(t store.TableNames) string { return string(t.GroupInvitesAudit()) },
+}
+
+// PurgeTenantDependents issues a DELETE ... WHERE tenant_id = $1 against each
+// dependent table in FK-safe order, inside a single background-worker
+// transaction. All deletes succeed or none do — partial progress would leave
+// orphaned rows that RLS hides from inventario_app entirely, and would still
+// block the final tenants DELETE the orchestration layer runs afterwards.
+//
+// location_groups and users are deleted last (in that order): location_groups
+// because every group-scoped row and currency_migrations FK it NO ACTION (and
+// it FKs users NO ACTION via created_by), and users because virtually every
+// tenant-scoped table FKs user_id/created_by -> users NO ACTION. The tenants
+// row itself is left for the caller to drop.
+//
+// Idempotent: a second call after a clean purge is a no-op (every DELETE
+// affects zero rows).
+func (r *TenantPurger) PurgeTenantDependents(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+
+	return store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Data + auth tables first, in FK-safe order.
+		for _, nameFn := range tenantPurgeOrder {
+			if err := r.purgeTable(ctx, tx, nameFn(r.tableNames), tenantID); err != nil {
+				return err
+			}
+		}
+
+		// location_groups next: now that every group-scoped row and
+		// currency_migrations is gone, the only remaining inbound FKs are
+		// users.default_group_id (SET NULL) — harmless — so the parent rows
+		// can be removed. location_groups.created_by -> users is NO ACTION, so
+		// this must precede the users DELETE below.
+		if err := r.purgeTable(ctx, tx, string(r.tableNames.LocationGroups()), tenantID); err != nil {
+			return err
+		}
+
+		// users last: almost every tenant-scoped table FKs user_id/created_by
+		// -> users NO ACTION, so the rows referencing them must all be gone by
+		// now. users.default_group_id was cleared (SET NULL) by the
+		// location_groups DELETE above.
+		if err := r.purgeTable(ctx, tx, string(r.tableNames.Users()), tenantID); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// purgeTable runs a single `DELETE FROM <table> WHERE tenant_id = $1` and wraps
+// any error with the offending table + tenant for diagnosis.
+func (r *TenantPurger) purgeTable(ctx context.Context, tx *sqlx.Tx, table, tenantID string) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE tenant_id = $1", table)
+	if _, err := tx.ExecContext(ctx, query, tenantID); err != nil {
+		return errxtrace.Wrap(
+			"failed to purge tenant dependents",
+			err,
+			errx.Attrs("table", table, "tenant_id", tenantID),
+		)
+	}
+	return nil
+}

--- a/go/registry/postgres/tenant_purger_test.go
+++ b/go/registry/postgres/tenant_purger_test.go
@@ -1,0 +1,171 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/appctx"
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register file:// driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+// seededTenant bundles the ids a purge test needs to assert against one tenant.
+type seededTenant struct {
+	tenantID string
+}
+
+// seedTenantWithDependents creates a tenant + admin user + active group, then a
+// representative spread of dependent rows across the FK graph: the inventory
+// hierarchy (location/area/commodity), a file, a tag, and the two tenant-only
+// auth tables (refresh_tokens, login_events). It returns the ids so the test
+// can prove they vanish (or survive) after a purge.
+func seedTenantWithDependents(c *qt.C, ctx context.Context, fs *registry.FactorySet, dbx *sqlx.DB, slug, email string) seededTenant {
+	c.Helper()
+
+	svc := fs.CreateServiceRegistrySet()
+
+	tenant, err := fs.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Tenant " + slug,
+		Slug:   slug,
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Email:               email,
+		Name:                "Admin " + slug,
+		IsActive:            true,
+	}
+	c.Assert(user.SetPassword("Password123"), qt.IsNil)
+	createdUser, err := fs.UserRegistry.Create(ctx, user)
+	c.Assert(err, qt.IsNil)
+
+	groupSlug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	group, err := svc.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Name:                "Group " + slug,
+		Slug:                groupSlug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           createdUser.ID,
+		GroupCurrency:       models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// User+group-aware set so the inventory/file/tag seeds land with the right
+	// tenant + group + created_by stamped from context. The seed helpers read
+	// the user + group (incl. currency) off the context for validation.
+	userSet := postgres.NewRegistrySetWithUserAndGroupID(dbx, createdUser.ID, tenant.ID, group.ID)
+	userCtx := appctx.WithUser(ctx, createdUser)
+	userCtx = appctx.WithGroup(userCtx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: group.ID},
+			TenantID: tenant.ID,
+		},
+		GroupCurrency: models.Currency("USD"),
+	})
+	areaID := seedTagArea(c, userSet, userCtx)
+	seedTagCommodity(c, userSet, userCtx, areaID, "Widget "+slug)
+	seedTagFile(c, userSet, userCtx, "file-"+slug)
+	mustCreateTag(c, userSet.TagRegistry, userCtx, models.TagKindCommodity, "tag-"+slug)
+
+	// Tenant-only auth rows.
+	_, err = svc.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: tenant.ID,
+			UserID:   createdUser.ID,
+		},
+		TokenHash: "hash-" + slug,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+
+	uid := createdUser.ID
+	_, err = svc.LoginEventRegistry.Create(ctx, models.LoginEvent{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		UserID:              &uid,
+		Email:               email,
+		Outcome:             models.LoginOutcomeOK,
+		Method:              models.LoginMethodPassword,
+	})
+	c.Assert(err, qt.IsNil)
+
+	return seededTenant{tenantID: tenant.ID}
+}
+
+// countRowsForTenant counts rows in a table for one tenant, reading under the
+// background-worker role so RLS doesn't hide foreign-tenant rows (the same
+// bypass the purger itself relies on).
+func countRowsForTenant(c *qt.C, dbx *sqlx.DB, table, tenantID string) int {
+	c.Helper()
+	var n int
+	err := store.DoAsBackgroundWorker(context.Background(), dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		return tx.GetContext(ctx, &n, "SELECT COUNT(*) FROM "+table+" WHERE tenant_id = $1", tenantID)
+	})
+	c.Assert(err, qt.IsNil)
+	return n
+}
+
+// TestTenantPurger_Postgres_PurgesAllTenantDependents is the #2115 regression:
+// a tenant carrying data across the FK graph (inventory hierarchy, file, tag,
+// group, user, refresh_token, login_event) must be fully cleared by
+// PurgeTenantDependents so the subsequent tenants DELETE succeeds. A second
+// tenant's rows must survive untouched, and a repeat purge must be a no-op.
+func TestTenantPurger_Postgres_PurgesAllTenantDependents(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+
+	a := seedTenantWithDependents(c, ctx, fs, dbx, "tenant-a", "admin@a.example")
+	b := seedTenantWithDependents(c, ctx, fs, dbx, "tenant-b", "admin@b.example")
+
+	purger := postgres.NewTenantPurger(dbx)
+
+	err = purger.PurgeTenantDependents(ctx, a.tenantID)
+	c.Assert(err, qt.IsNil)
+
+	// Every dependent table is empty for tenant A.
+	for _, table := range []string{
+		"locations", "areas", "commodities", "files", "tags",
+		"location_groups", "users", "refresh_tokens", "login_events",
+	} {
+		c.Assert(countRowsForTenant(c, dbx, table, a.tenantID), qt.Equals, 0,
+			qt.Commentf("table %s should be empty for purged tenant A", table))
+	}
+
+	// The final tenants DELETE is what was broken before the fix: any orphaned
+	// dependent would trip a NO ACTION FK here. It succeeding is the regression.
+	err = fs.TenantRegistry.Delete(ctx, a.tenantID)
+	c.Assert(err, qt.IsNil)
+	_, err = fs.TenantRegistry.Get(ctx, a.tenantID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// Tenant B is untouched — same table set still carries its rows.
+	for _, table := range []string{
+		"locations", "areas", "commodities", "files", "tags",
+		"location_groups", "users", "refresh_tokens", "login_events",
+	} {
+		c.Assert(countRowsForTenant(c, dbx, table, b.tenantID) > 0, qt.IsTrue,
+			qt.Commentf("table %s must still carry tenant B rows", table))
+	}
+
+	// Idempotent: a second purge after the rows are gone is a clean no-op.
+	err = purger.PurgeTenantDependents(ctx, a.tenantID)
+	c.Assert(err, qt.IsNil)
+}

--- a/go/registry/postgres/user_purger.go
+++ b/go/registry/postgres/user_purger.go
@@ -1,0 +1,252 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.UserPurger = (*UserPurger)(nil)
+
+// UserPurger hard-deletes a single user's auth / identity rows and orphans the
+// few user-authorship columns that are nullable, all in one background-worker
+// transaction (#2116). It exists because the bare `DELETE FROM users` that the
+// GDPR "delete my data" path used to issue is rejected by ~43 NO ACTION child
+// FKs pointing at users(id) — the worker must clear (or null) every dependent
+// before the parent users row can be removed by the orchestration layer.
+//
+// IMPORTANT classification (see the migration audit in the PR description):
+//   - DELETE rows the user OWNS (auth/identity/per-user idempotency): refresh
+//     tokens, login events, email verifications, password resets, magic-link
+//     tokens, MFA secret, OAuth identities, system-admin grant (user_id),
+//     settings, group memberships, operation slots, commodity scan audits,
+//     and the user_concurrency_slots / thumbnail_generation_jobs the user
+//     created.
+//   - SET NULL the authorship back-refs that are NULLABLE: login_events.user_id
+//     (already nulled by the DELETE-by-user above — see note), and
+//     system_admin_grants.granted_by (the *operator* who granted someone else's
+//     grant; nullable + already ON DELETE SET NULL at the schema level, but we
+//     null it explicitly so the purge transaction owns the scoping).
+//
+// CONTENT AUTHORSHIP THAT CANNOT BE ORPHANED (flagged, NOT handled here):
+// every commodities/files/areas/locations/exports/location_groups/tags/...
+// row carries BOTH a NOT NULL user_id (the RLS owner) AND a NOT NULL
+// created_by / created_by_user_id. Neither column is nullable, so a user's
+// shared content CANNOT be orphaned without a schema migration. Deleting a
+// user who still owns content is therefore impossible by design today — the
+// orchestration layer must first re-own (transfer) or purge that content (e.g.
+// the GroupPurger path) before calling PurgeUserDependents. See the PR summary
+// table for the full list of NOT NULL created_by columns.
+//
+// It does NOT touch the users row itself — the orchestration layer
+// (services.* user-delete flow) issues the final DELETE FROM users after this
+// returns clean.
+type UserPurger struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+// NewUserPurger returns a UserPurger bound to the default table names.
+func NewUserPurger(dbx *sqlx.DB) *UserPurger {
+	return NewUserPurgerWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewUserPurgerWithTableNames returns a UserPurger using a custom TableNames
+// (used by tests that want to sandbox against renamed tables).
+func NewUserPurgerWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *UserPurger {
+	return &UserPurger{dbx: dbx, tableNames: tableNames}
+}
+
+// userDeleteByUserID is the FK-safe DELETE sequence for tables that carry a
+// `user_id` column AND a `tenant_id` column. Each entry resolves to the
+// fully-qualified table name; PurgeUserDependents issues
+// `DELETE FROM <table> WHERE tenant_id = $1 AND user_id = $2` against each one
+// inside a single background-worker transaction. tenant_id is added as
+// defense-in-depth so the worker role can't wipe another tenant's rows on a
+// bad userID.
+//
+// Order: deepest children first. None of these tables is a parent of another
+// in this slice (they are all leaf auth/identity/per-user rows), so the order
+// is cosmetic, but kept stable for readability.
+var userDeleteByUserID = []func(t store.TableNames) string{
+	// Auth / session.
+	func(t store.TableNames) string { return string(t.RefreshTokens()) },
+	func(t store.TableNames) string { return string(t.LoginEvents()) },
+	func(t store.TableNames) string { return string(t.EmailVerifications()) },
+	func(t store.TableNames) string { return string(t.PasswordResets()) },
+	func(t store.TableNames) string { return string(t.MagicLinkTokens()) },
+	func(t store.TableNames) string { return string(t.UserMFASecrets()) },
+	func(t store.TableNames) string { return string(t.UserOAuthIdentities()) },
+
+	// Per-user concurrency / operation bookkeeping.
+	func(t store.TableNames) string { return string(t.OperationSlots()) },
+
+	// Per-user settings.
+	func(t store.TableNames) string { return string(t.Settings()) },
+
+	// AI vision per-user audit + rate-limit rows.
+	func(t store.TableNames) string { return string(t.CommodityScanAudits()) },
+
+	// NB: group_memberships is intentionally NOT here — it is keyed solely by
+	// member_user_id (no plain user_id column), so it can't ride the
+	// user_id template. It is handled by its own DELETE in PurgeUserDependents.
+
+	// Per-user/per-group notification overrides.
+	func(t store.TableNames) string { return string(t.GroupNotificationPrefs()) },
+}
+
+// PurgeUserDependents clears every user-scoped auth/identity row (and nulls the
+// nullable authorship back-refs) for a single user, inside one background-worker
+// transaction. All operations succeed or none do.
+//
+// Idempotent: a second call after a clean purge is a no-op (every statement
+// affects zero rows).
+//
+// PRECONDITION (not enforced here, see the type doc): the user must no longer
+// OWN any shared content (commodities/files/areas/locations/exports/groups/
+// tags/...). Those rows carry NOT NULL user_id + NOT NULL created_by columns
+// that cannot be orphaned, so this purger deliberately does not touch them; the
+// final DELETE FROM users will fail with an FK violation if any remain, which
+// is the intended loud failure rather than a silent content wipe.
+func (r *UserPurger) PurgeUserDependents(ctx context.Context, tenantID, userID string) error {
+	if tenantID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if userID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+
+	return store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Thumbnail chain (#2117 parity): user_concurrency_slots.job_id ->
+		// thumbnail_generation_jobs (NO ACTION) and
+		// thumbnail_generation_jobs.user_id -> users (NO ACTION). Slots carry
+		// no user_id of their own, so they're reached through the user's jobs.
+		// Order: slots (deepest child) -> jobs.
+		if err := r.purgeThumbnailChain(ctx, tx, tenantID, userID); err != nil {
+			return err
+		}
+
+		// Tables keyed by user_id (+ tenant_id defense-in-depth).
+		for _, nameFn := range userDeleteByUserID {
+			table := nameFn(r.tableNames)
+			query := fmt.Sprintf("DELETE FROM %s WHERE tenant_id = $1 AND user_id = $2", table)
+			if _, err := tx.ExecContext(ctx, query, tenantID, userID); err != nil {
+				return errxtrace.Wrap(
+					"failed to purge user dependents",
+					err,
+					errx.Attrs("table", table, "tenant_id", tenantID, "user_id", userID),
+				)
+			}
+		}
+
+		// Group memberships are keyed SOLELY by member_user_id (there is no
+		// plain user_id column on this table), so this single DELETE removes
+		// every membership row that names the user as the member. It lives here
+		// rather than in the user_id loop above for exactly that reason.
+		memberships := string(r.tableNames.GroupMemberships())
+		memberQuery := fmt.Sprintf(
+			"DELETE FROM %s WHERE tenant_id = $1 AND member_user_id = $2", memberships,
+		)
+		if _, err := tx.ExecContext(ctx, memberQuery, tenantID, userID); err != nil {
+			return errxtrace.Wrap(
+				"failed to purge user memberships by member_user_id",
+				err,
+				errx.Attrs("table", memberships, "tenant_id", tenantID, "user_id", userID),
+			)
+		}
+
+		// system_admin_grants is NON-RLS and carries NO tenant_id column, so it
+		// can't ride the tenant_id template. Two FKs point at users(id):
+		//   user_id    -> ON DELETE CASCADE (the granted user) — DELETE the row.
+		//   granted_by -> ON DELETE SET NULL (the operator who granted it,
+		//                 NULLABLE) — null it so deleting this user as an
+		//                 *operator* doesn't drop someone else's grant.
+		if err := r.purgeSystemAdminGrants(ctx, tx, userID); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// purgeThumbnailChain removes the thumbnail generation jobs the user created
+// (and their concurrency slots). Neither user_concurrency_slots nor (in this
+// chain) the slots carry the user_id directly usable for the slot delete —
+// slots are scoped through the jobs they reference. Both DELETEs run BEFORE the
+// jobs are removed, in FK-safe order (slots -> jobs).
+//
+// thumbnail_generation_jobs carries tenant_id + user_id, so the jobs DELETE is
+// tenant-scoped as defense-in-depth.
+//
+// Idempotent: a user with no jobs matches zero rows on every statement.
+func (r *UserPurger) purgeThumbnailChain(ctx context.Context, tx *sqlx.Tx, tenantID, userID string) error {
+	jobs := string(r.tableNames.ThumbnailGenerationJobs())
+	slots := string(r.tableNames.UserConcurrencySlots())
+
+	jobSubquery := fmt.Sprintf(
+		"SELECT id FROM %s WHERE tenant_id = $1 AND user_id = $2", jobs,
+	)
+
+	slotQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE job_id IN (%s)", slots, jobSubquery,
+	)
+	if _, err := tx.ExecContext(ctx, slotQuery, tenantID, userID); err != nil {
+		return errxtrace.Wrap(
+			"failed to purge user thumbnail concurrency slots",
+			err,
+			errx.Attrs("table", slots, "tenant_id", tenantID, "user_id", userID),
+		)
+	}
+
+	jobQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE tenant_id = $1 AND user_id = $2", jobs,
+	)
+	if _, err := tx.ExecContext(ctx, jobQuery, tenantID, userID); err != nil {
+		return errxtrace.Wrap(
+			"failed to purge user thumbnail generation jobs",
+			err,
+			errx.Attrs("table", jobs, "tenant_id", tenantID, "user_id", userID),
+		)
+	}
+
+	return nil
+}
+
+// purgeSystemAdminGrants handles the non-RLS system_admin_grants table, which
+// has no tenant_id column. The grant the user HAS is deleted; any grant the
+// user GRANTED to someone else has its granted_by nulled (nullable column,
+// schema-level ON DELETE SET NULL — done explicitly so the purge transaction
+// owns the operation). Both statements are idempotent.
+func (r *UserPurger) purgeSystemAdminGrants(ctx context.Context, tx *sqlx.Tx, userID string) error {
+	grants := string(r.tableNames.SystemAdminGrants())
+
+	nullQuery := fmt.Sprintf(
+		"UPDATE %s SET granted_by = NULL WHERE granted_by = $1", grants,
+	)
+	if _, err := tx.ExecContext(ctx, nullQuery, userID); err != nil {
+		return errxtrace.Wrap(
+			"failed to null system_admin_grants.granted_by for user",
+			err,
+			errx.Attrs("table", grants, "user_id", userID),
+		)
+	}
+
+	deleteQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE user_id = $1", grants,
+	)
+	if _, err := tx.ExecContext(ctx, deleteQuery, userID); err != nil {
+		return errxtrace.Wrap(
+			"failed to purge system_admin_grants for user",
+			err,
+			errx.Attrs("table", grants, "user_id", userID),
+		)
+	}
+
+	return nil
+}

--- a/go/registry/postgres/user_purger_test.go
+++ b/go/registry/postgres/user_purger_test.go
@@ -1,0 +1,110 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestUserPurger_Postgres_PurgesAuthRowsKeepsContent is the #2116 regression:
+// PurgeUserDependents must hard-delete a user's auth / identity rows (refresh
+// tokens, MFA secret) so the eventual DELETE FROM users isn't blocked by the
+// NO ACTION child FKs, while LEAVING the user's authored content rows in place
+// (commodities/areas/locations carry NOT NULL user_id + NOT NULL created_by,
+// so orphaning is impossible — the purger must not touch them, and the
+// orchestration layer reassigns ownership before the final user delete).
+func TestUserPurger_Postgres_PurgesAuthRowsKeepsContent(t *testing.T) {
+	c := qt.New(t)
+
+	set, _ := setupTestRegistrySet(t)
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	fs := postgres.NewFactorySet(dbx)
+
+	user := getTestUser(c, set)
+	tenantID := user.TenantID
+	userID := user.ID
+
+	ctx := appctx.WithUser(context.Background(), user)
+
+	// -- seed auth/identity rows the purge must remove --------------------
+
+	_, err = fs.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
+		TenantUserAwareEntityID: models.WithTenantUserAwareEntityID("", tenantID, userID),
+		TokenHash:               "hash-user-a",
+		ExpiresAt:               time.Now().Add(24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	_, err = fs.UserMFASecretRegistry.Create(ctx, models.UserMFASecret{
+		TenantUserAwareEntityID: models.WithTenantUserAwareEntityID("", tenantID, userID),
+		SecretEncrypted:         "encrypted-secret",
+		BackupCodesHashed:       models.ValuerSlice[string]{},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// -- seed authored content that must SURVIVE the purge ----------------
+
+	areaID := seedTagArea(c, set, ctx)
+	commodityID := seedTagCommodity(c, set, ctx, areaID, "Owned Drill")
+
+	// -- a different user whose auth rows must stay untouched --------------
+
+	otherUserModel := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               "other@test-org.com",
+		Name:                "Other User",
+		IsActive:            true,
+	}
+	c.Assert(otherUserModel.SetPassword("Password123"), qt.IsNil)
+	otherUser, err := fs.UserRegistry.Create(ctx, otherUserModel)
+	c.Assert(err, qt.IsNil)
+
+	_, err = fs.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
+		TenantUserAwareEntityID: models.WithTenantUserAwareEntityID("", tenantID, otherUser.ID),
+		TokenHash:               "hash-other",
+		ExpiresAt:               time.Now().Add(24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// -- purge user A -----------------------------------------------------
+
+	err = fs.UserPurger.PurgeUserDependents(context.Background(), tenantID, userID)
+	c.Assert(err, qt.IsNil)
+
+	// User A's auth rows are gone.
+	tokensA, err := fs.RefreshTokenRegistry.GetByUserID(context.Background(), userID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tokensA, qt.HasLen, 0)
+
+	_, err = fs.UserMFASecretRegistry.GetByUser(context.Background(), tenantID, userID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// User A's authored content STILL EXISTS — orphaning is schema-impossible
+	// (NOT NULL created_by), so the purger leaves it for ownership transfer.
+	serviceSet := fs.CreateServiceRegistrySet()
+	commodity, err := serviceSet.CommodityRegistry.Get(context.Background(), commodityID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(commodity.GetID(), qt.Equals, commodityID)
+
+	// User B's auth rows are untouched.
+	tokensB, err := fs.RefreshTokenRegistry.GetByUserID(context.Background(), otherUser.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tokensB, qt.HasLen, 1)
+
+	// Idempotent: a second purge after the rows are gone is a clean no-op.
+	err = fs.UserPurger.PurgeUserDependents(context.Background(), tenantID, userID)
+	c.Assert(err, qt.IsNil)
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -2169,6 +2169,46 @@ type GroupPurger interface {
 	PurgeGroupDependents(ctx context.Context, tenantID, groupID string) error
 }
 
+// TenantPurger hard-deletes every tenant-scoped dependent row belonging to a
+// single Tenant, in a FK-safe order, before the tenants row itself is dropped
+// by the orchestration layer (#2115). It is the tenant-level analogue of
+// GroupPurger: where GroupPurger clears one group's subtree, TenantPurger
+// clears the union of every group's data PLUS the tenant-only rows GroupPurger
+// never touches (users, settings, refresh_tokens, login_events, the auth-token
+// tables, location_groups themselves, …).
+//
+// The tenants row itself is NOT touched here — the caller (services.admin
+// DeleteTenant) drops it after the dependents are gone, exactly as
+// GroupPurgeService handles the final location_groups DELETE separately so blob
+// cleanup and tenant removal remain explicit at the orchestration layer.
+type TenantPurger interface {
+	// PurgeTenantDependents deletes all dependent entities for the given
+	// tenant. Implementations must be idempotent — a second call on the same
+	// tenant after a partial failure must succeed and leave the database in
+	// the same state.
+	PurgeTenantDependents(ctx context.Context, tenantID string) error
+}
+
+// UserPurger hard-deletes a single user's auth / identity rows (and orphans the
+// nullable authorship back-refs) before the users row itself is dropped by the
+// orchestration layer (#2116). It exists because a bare DELETE FROM users is
+// rejected by the many NO ACTION child FKs pointing at users(id).
+//
+// PRECONDITION: the user must no longer OWN shared content
+// (commodities/files/areas/locations/exports/groups/tags/…). Those rows carry
+// NOT NULL user_id + NOT NULL created_by columns that cannot be orphaned, so
+// this purger deliberately does not touch them; the final DELETE FROM users
+// will fail loudly with an FK violation if any remain. The users row itself is
+// NOT touched here — the caller (services.admin DeleteUser) drops it after the
+// dependents are gone.
+type UserPurger interface {
+	// PurgeUserDependents deletes all auth/identity dependent rows for the
+	// given tenant/user pair. Implementations must be idempotent — a second
+	// call on the same user after a partial failure must succeed and leave the
+	// database in the same state.
+	PurgeUserDependents(ctx context.Context, tenantID, userID string) error
+}
+
 // Set contains ready-to-use registries that have been created with proper user or service context.
 // This is the result of calling CreateUserRegistrySet() or CreateServiceRegistrySet() on a FactorySet.
 type Set struct {

--- a/go/services/admin/service.go
+++ b/go/services/admin/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
 )
 
 // ErrLastSystemAdmin is re-exported from the registry layer for callers
@@ -27,6 +28,31 @@ var ErrLastSystemAdmin = registry.ErrLastSystemAdmin
 type Service struct {
 	factorySet *registry.FactorySet
 	cleanup    func() error
+	// fileService is optional. When set (via SetFileService), DeleteTenant
+	// deletes the tenant's physical blobs before purging its DB rows. When
+	// nil, blob cleanup is skipped with a loud WARNING — the DB rows are
+	// still purged, but object-storage objects are orphaned (the caller must
+	// wire a fileService to get full cleanup). It is a setter rather than a
+	// constructor parameter so the 20-odd existing NewService(dbConfig)
+	// callers that never delete a tenant don't have to thread an upload
+	// location they don't need.
+	fileService *services.FileService
+}
+
+// SetFileService wires the optional file service used by DeleteTenant to
+// remove a tenant's physical blobs before its DB rows are purged. Callers that
+// perform a tenant hard-delete must call this (e.g. the tenants delete CLI,
+// which builds it from the --upload-location flag); other admin callers can
+// leave it unset.
+func (s *Service) SetFileService(fileService *services.FileService) {
+	s.fileService = fileService
+}
+
+// FactorySet exposes the underlying registry factory set so callers (e.g. the
+// tenants delete CLI) can construct a matching FileService bound to the same
+// backend before invoking DeleteTenant.
+func (s *Service) FactorySet() *registry.FactorySet {
+	return s.factorySet
 }
 
 // NewService creates a new admin service with proper registry abstraction
@@ -219,17 +245,48 @@ func (s *Service) UpdateTenant(ctx context.Context, idOrSlug string, req TenantU
 	return updatedTenant, nil
 }
 
-// DeleteTenant deletes a tenant
+// DeleteTenant hard-deletes a tenant and every row that depends on it,
+// mirroring the GroupPurgeService orchestration order (#2115). Before this the
+// method issued a bare DELETE FROM tenants, which the ~35 NO ACTION child FKs
+// rejected — so deleting any tenant that had ever held data failed.
+//
+// Order (each step aborts the whole operation on error):
+//
+//	a) delete the tenant's physical blobs first, so a dead object store aborts
+//	   the operation before any DB row is touched (idempotent + retryable). If
+//	   no fileService was wired, blob cleanup is skipped with a loud WARNING and
+//	   the blobs are orphaned — the DB purge still proceeds.
+//	b) purge every tenant-scoped dependent row (TenantPurger), in FK-safe order.
+//	c) drop the now-childless tenants row itself.
 func (s *Service) DeleteTenant(ctx context.Context, idOrSlug string) error {
-	// Get existing tenant to validate it exists
+	// Validate the tenant exists (and resolve slug -> id).
 	tenant, err := s.GetTenant(ctx, idOrSlug)
 	if err != nil {
 		return err
 	}
 
-	// Delete tenant
+	// (a) Physical blobs first — fail fast so a down object store aborts
+	// before we mutate the database.
+	if s.fileService != nil {
+		if err := s.fileService.DeletePhysicalFilesForTenant(ctx, tenant.ID); err != nil {
+			return errxtrace.Wrap("failed to delete tenant physical blobs", err)
+		}
+	} else {
+		slog.Warn(
+			"DeleteTenant: no file service wired — skipping physical blob cleanup; object-storage blobs for this tenant will be orphaned",
+			"tenant_id", tenant.ID,
+			"tenant_slug", tenant.Slug,
+		)
+	}
+
+	// (b) Purge every tenant-scoped dependent row in FK-safe order.
+	if err := s.factorySet.TenantPurger.PurgeTenantDependents(ctx, tenant.ID); err != nil {
+		return errxtrace.Wrap("failed to purge tenant dependents", err)
+	}
+
+	// (c) Drop the now-childless tenants row.
 	if err := s.factorySet.TenantRegistry.Delete(ctx, tenant.ID); err != nil {
-		return fmt.Errorf("failed to delete tenant: %w", err)
+		return errxtrace.Wrap("failed to delete tenant row", err)
 	}
 
 	return nil
@@ -416,17 +473,49 @@ func (s *Service) UpdateUser(ctx context.Context, idOrEmail string, req UserUpda
 	return updatedUser, nil
 }
 
-// DeleteUser deletes a user
+// DeleteUser hard-deletes a user's account along with its auth / identity rows
+// (#2116). Before this the method issued a bare DELETE FROM users, which the
+// many NO ACTION child FKs pointing at users(id) rejected, so deleting any user
+// that had ever logged in failed.
+//
+// Order (each step aborts the whole operation on error):
+//
+//	a) purge the user's auth/identity dependent rows (UserPurger): refresh
+//	   tokens, login events, MFA secret, OAuth identities, memberships, …
+//	b) drop the users row itself.
+//
+// IMPORTANT: every content table (commodities/files/areas/locations/exports/
+// tags/…) carries a NOT NULL created_by_user_id (and a NOT NULL user_id RLS
+// owner), neither of which can be orphaned without a schema change. A user who
+// still OWNS content therefore CANNOT be hard-deleted today: the final
+// UserRegistry.Delete will fail with an FK violation. We surface that as a
+// clear, honest error rather than claiming success — full GDPR deletion of a
+// content-owning user needs ownership transfer or content purge first, which is
+// out of scope here.
 func (s *Service) DeleteUser(ctx context.Context, idOrEmail string) error {
-	// Get existing user to validate it exists
+	// Validate the user exists (and resolve email -> id + tenant).
 	user, err := s.GetUser(ctx, idOrEmail)
 	if err != nil {
 		return err
 	}
 
-	// Delete user
+	// (a) Purge the user's auth / identity dependent rows so the parent
+	// users row has no remaining NO ACTION children from those tables.
+	if err := s.factorySet.UserPurger.PurgeUserDependents(ctx, user.TenantID, user.ID); err != nil {
+		return errxtrace.Wrap("failed to purge user dependents", err)
+	}
+
+	// (b) Drop the users row. If the user still owns content, the NOT NULL
+	// created_by_user_id / user_id FKs reject this DELETE — report the real
+	// cause instead of a misleading generic failure.
 	if err := s.factorySet.UserRegistry.Delete(ctx, user.ID); err != nil {
-		return fmt.Errorf("failed to delete user: %w", err)
+		return errxtrace.Wrap(
+			fmt.Sprintf(
+				"cannot delete user %s (%s): they still own content (commodities, files, areas, locations, exports, tags, …) which cannot be orphaned — reassign or delete that content first",
+				user.ID, user.Email,
+			),
+			err,
+		)
 	}
 
 	return nil

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -262,6 +262,46 @@ func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID,
 	return nil
 }
 
+// DeletePhysicalFilesForTenant deletes every physical blob (and its
+// thumbnails) that belongs to the given tenant. It is the tenant-level
+// analogue of DeletePhysicalFilesForGroup, intended for the admin tenant
+// hard-delete flow (#2115), and likewise uses a service-mode file registry to
+// bypass tenant/group RLS. Database rows are NOT touched here — that is the
+// responsibility of the TenantPurger.
+//
+// Unlike the group variant there is no ListByGroup-style narrowing index for a
+// whole tenant, so this lists every file in service mode and filters by
+// TenantID in application code (the same O(total_files) scan the group purger
+// avoids, but acceptable for a one-shot administrative hard-delete).
+//
+// The method is fail-fast: the first blob that fails to delete aborts the
+// entire sweep so the orchestration layer can leave the tenant intact and the
+// operator can retry once object storage is healthy.
+func (s *FileService) DeletePhysicalFilesForTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return errxtrace.Wrap("tenantID is required", registry.ErrFieldRequired)
+	}
+
+	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
+	files, err := fileReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list files for tenant", err)
+	}
+
+	for _, file := range files {
+		if file == nil || file.TenantID != tenantID {
+			continue
+		}
+		if file.File == nil || file.File.OriginalPath == "" {
+			continue
+		}
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+			return errxtrace.Wrap(fmt.Sprintf("failed to delete physical blobs for file %s", file.ID), err)
+		}
+	}
+	return nil
+}
+
 // deletePhysicalFileAndThumbnails deletes the physical file and all its
 // thumbnails. `tenantID` is the tenant that owns the row — used to
 // derive the canonical thumbnail blob keys (#1793). For legacy rows


### PR DESCRIPTION
## What

Both admin hard-deletes were a **bare single-table `DELETE`** that Postgres rejects the moment the row has any child — every inbound FK to `tenants(id)` (~35) / `users(id)` (~43) is `NO ACTION` — while the CLI printed `✅ deleted successfully`. This mirrors the **GroupPurger pattern merged in #2138**: an app-level FK-safe purge in one background-worker transaction. **No schema migration.**

**Closes #2115 · Closes #2116**

### #2115 — TenantPurger
`registry/postgres/tenant_purger.go` (+ memory mirror, + DSN test). `PurgeTenantDependents(ctx, tenantID)` deletes all **37 tenant-scoped tables in FK-safe order** in one tx — every one carries `tenant_id`, so (unlike GroupPurger) no subquery-scoping is needed. `DeleteTenant` is rewritten to the GroupPurgeService order:
1. delete physical blobs first (new `FileService.DeletePhysicalFilesForTenant`, fail-fast so a down object store aborts before any DB mutation),
2. `PurgeTenantDependents`,
3. `TenantRegistry.Delete` (drops the now-childless `tenants` row).

The `tenants delete` CLI gains `--upload-location` so blob cleanup binds to the real storage backend.

### #2116 — UserPurger
`registry/postgres/user_purger.go` (+ memory mirror, + DSN test). `PurgeUserDependents(ctx, tenantID, userID)` `DELETE`s the user's **auth/identity** rows (refresh_tokens, login_events, email/password/magic-link tokens, MFA secret, OAuth identities, settings, group memberships by `member_user_id`, notification prefs, operation_slots, scan-audits, and the thumbnail job→slot chain) and `SET NULL`s `system_admin_grants.granted_by`, all in one tx.

> ### ⚠️ Known limitation (surfaced, not hacked)
> Every content table's `created_by_user_id` **and** `user_id` (the RLS owner) is **NOT NULL**, so a user who still **owns content** (commodities/files/areas/locations/exports/…) cannot be orphaned and therefore **cannot be hard-deleted** without a schema change. `DeleteUser` now **fails loudly** with a clear *"they still own content — reassign or delete it first"* error instead of the old silent FK abort + false-success CLI message. Full GDPR-delete of a content-owning user needs a follow-up **schema decision** (nullable `created_by` + `SET NULL`, or content-reassign-on-delete). The back-office user / refresh-token / MFA `NO ACTION` FKs are a sibling follow-up.

## How it was built
Scout (read the merged GroupPurger template) → fleet: two agents built the self-contained `tenant_purger.go` / `user_purger.go` (+ memory + DSN tests) in parallel on disjoint files; one agent wired the shared glue (interfaces, factory, registry-set, service orchestration, blob cleanup, CLI). Orchestrator verified centrally — and **caught a real bug the agent missed**: the user purger looped `WHERE user_id=$2` over `group_memberships`, which is keyed solely by `member_user_id` (no `user_id` column) → `SQLSTATE 42703`. Fixed (the table is already handled by its own `member_user_id` DELETE).

## Verification
- Go: `go build ./...`, `go vet`, `golangci-lint`, `go tool qtlint`, `go tool nolintguard` — all clean; full unit suite green.
- `inventool db migrations generate --check` → **schema in sync** (no migration — purgers are app-level).
- **DSN-gated purger tests green against a real Postgres (`-race`)**: TenantPurger purges every tenant table + a second tenant survives + idempotent; UserPurger deletes auth rows, **authored content SURVIVES with `created_by` intact**, other users untouched, idempotent; the existing **GroupPurger test still passes** (no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--upload-location` flag to tenant deletion command for removing physical uploaded blobs
  * Enhanced tenant deletion workflow to safely clean up dependent data before removing tenant
  * Improved user deletion to purge authentication and identity data before user removal

* **Tests**
  * Added regression tests for tenant and user hard-deletion operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->