### PR TITLE
feat(auth): rotate tenant refresh token + reuse detection + /refresh rate limit (#967)

### DIFF
--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -124,6 +124,11 @@ back-office plane (#1785):
   **new** row id as its `rti` claim so `/users/me/sessions` keeps resolving the caller's
   current session. A stolen cookie is therefore valid only until the legitimate client's
   next refresh (≈ the access-token lifetime, 15 min).
+  - Sessions-list effect: because each refresh **replaces** the row, a refresh-only session
+    shows `last_used_at` as null on `GET /users/me/sessions` (the FE falls back to
+    `created_at`, which advances each rotation), and the active row's id / IP / user-agent
+    now reflect the **latest** refresh rather than the original login. `is_current` is
+    unaffected — it is resolved from the access token's `rti` claim, not the cookie hash.
 - **Reuse detection (H4).** `GetByTokenHash` returns revoked rows unfiltered, so a cookie
   that hashes to an already-revoked row means the legitimate session has rotated past it —
   i.e. a replay. The handler revokes **all** of that user's refresh tokens

--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -91,14 +91,15 @@ sequenceDiagram
     I->>I: Is a refresh already in progress? → queue request
     I->>A: POST /api/v1/auth/refresh (sends refresh_token cookie automatically)
     A->>A: Hash the cookie value
-    A->>DB: Look up token by hash
+    A->>DB: Look up token by hash (revoked rows ARE returned, not filtered)
     DB-->>A: RefreshToken record
-    A->>A: Check IsValid() (not expired, not revoked)
+    A->>A: Revoked? → reuse detected (#967 H4): revoke ALL the user's tokens + audit-warn → 401
+    A->>A: Else IsValid()? (revoked_at nil, not expired)
     A->>DB: Look up user
     DB-->>A: User record
-    A->>A: Issue new JWT access token (15 min)
-    A->>DB: Update refresh token last_used_at
-    A-->>I: 200 {access_token, ...}
+    A->>DB: Rotate (#967 H2): INSERT a fresh 30-day row, then revoke the consumed row
+    A->>A: Issue new JWT access token (15 min), rti = NEW row id
+    A-->>I: 200 {access_token, ...} + Set-Cookie: rotated refresh_token
     I->>I: Store new access_token in localStorage
     I->>I: Notify all queued requests with new token
     I->>C: Retry original request with new token
@@ -111,6 +112,33 @@ Key properties of the refresh logic (`frontend/src/lib/http.ts`, fetch-based —
   infinite loops on credential failures.
 - **Graceful degradation**: if the refresh call itself fails (cookie missing, token
   expired, revoked), the interceptor clears local auth state and redirects to `/login`.
+
+### Server-side hardening (#967)
+
+`POST /api/v1/auth/refresh` rotates and self-defends; the tenant plane now mirrors the
+back-office plane (#1785):
+
+- **Rotation (H2).** Every successful refresh persists a fresh 30-day refresh-token row
+  (BEFORE revoking the consumed one, so a transient DB error leaves the existing session
+  usable) and sets a new `refresh_token` cookie. The minted access token carries the
+  **new** row id as its `rti` claim so `/users/me/sessions` keeps resolving the caller's
+  current session. A stolen cookie is therefore valid only until the legitimate client's
+  next refresh (≈ the access-token lifetime, 15 min).
+- **Reuse detection (H4).** `GetByTokenHash` returns revoked rows unfiltered, so a cookie
+  that hashes to an already-revoked row means the legitimate session has rotated past it —
+  i.e. a replay. The handler revokes **all** of that user's refresh tokens
+  (`RevokeByUserID`), emits a `slog.Warn("Refresh token reuse detected", …)` plus a durable
+  audit row (`Action="refresh_token_reuse_detected"`), and returns a `401` byte-identical to
+  the plain-expired response (opaque to the attacker). A genuinely *expired* (never-revoked)
+  token is **not** treated as theft — no cascade.
+  - Trade-off: a benign stale tab replaying after logout/rotation also trips the cascade
+    (one extra "reuse detected" log + an idempotent revoke-all). The FE single-flights
+    refresh per tab, so this only happens across tabs racing the same expiry; it is the
+    intended, safe H4 semantics, not a real incident.
+- **Rate limit (H1).** `/refresh` has its own generous per-IP budget
+  (`CheckRefreshAttempt`, 60 / 15 min) — deliberately NOT the tight login budget, since
+  periodic multi-tab refresh is normal traffic and refresh tokens (256-bit) are
+  unbrute-forceable. Exceeding it returns `429` with `Retry-After`. `/logout` is unlimited.
 
 > **Impersonation sessions are not refreshable.** When an admin starts an impersonation
 > session (`POST /api/v1/admin/users/{userID}/impersonate`), the server replaces the admin's
@@ -227,7 +255,8 @@ refresh_tokens table
 ├── token_hash   (VARCHAR 128) — SHA-256 of the raw token, URL-safe base64
 ├── expires_at   (TIMESTAMP)   — 30 days from creation
 ├── created_at   (TIMESTAMP)
-├── last_used_at (TIMESTAMP)   — updated on each successful refresh
+├── last_used_at (TIMESTAMP)   — set on login; refresh now ROTATES (revokes this row,
+│                                 inserts a fresh one) rather than bumping this in place (#967)
 ├── ip_address   (VARCHAR 45)  — client IP at creation
 ├── user_agent   (TEXT)        — browser UA at creation
 └── revoked_at   (TIMESTAMP)   — set on logout; NULL = active

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -2608,7 +2608,8 @@ export type paths = {
         put?: never;
         /**
          * Refresh access token
-         * @description Issue a new short-lived access token using the refresh token stored in the httpOnly cookie.
+         * @description Issue a new short-lived access token using the refresh token stored in the httpOnly cookie. Rotates the refresh token: the consumed cookie value is revoked and a new value is set.
+         *     Replaying an already-rotated cookie is treated as theft and revokes all of the user's sessions.
          */
         post: {
             parameters: {

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -341,7 +342,8 @@ func populateUserSystemAdminFlagFromAccessToken(accessTokenString string, user *
 
 // refresh issues a new access token using a valid refresh token cookie.
 // @Summary Refresh access token
-// @Description Issue a new short-lived access token using the refresh token stored in the httpOnly cookie.
+// @Description Issue a new short-lived access token using the refresh token stored in the httpOnly cookie. Rotates the refresh token: the consumed cookie value is revoked and a new value is set.
+// @Description Replaying an already-rotated cookie is treated as theft and revokes all of the user's sessions.
 // @Tags auth
 // @Produce json
 // @Success 200 {object} LoginResponse "OK"
@@ -397,7 +399,36 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !refreshToken.IsValid() {
+	// Reuse detection (#967 H4). GetByTokenHash returns revoked rows
+	// UNFILTERED, so a presented cookie that hashes to an already-revoked
+	// row means one of two things: a legitimate client racing its own
+	// rotation (rare, and indistinguishable from theft), or — the case we
+	// must defend — an attacker replaying a refresh token that the
+	// legitimate session has since rotated away from (#967 H2). We treat any
+	// revoked-row presentation as theft and revoke ALL of the user's active
+	// sessions, so a stolen cookie can at most trigger one more rotation
+	// before the whole session family is invalidated. This runs BEFORE the
+	// user-active / blacklist checks so theft is caught even for a
+	// since-deactivated user. The 401 is byte-identical to the plain-expired
+	// branch below so the response is opaque to the attacker.
+	if refreshToken.RevokedAt != nil {
+		if err := api.refreshTokenRegistry.RevokeByUserID(r.Context(), refreshToken.UserID); err != nil {
+			slog.Error("Failed to revoke all sessions on refresh-token reuse", "user_id", refreshToken.UserID, "error", err)
+		}
+		slog.Warn("Refresh token reuse detected",
+			"user_id", refreshToken.UserID,
+			"token_id", refreshToken.ID,
+			"ip", clientIPTruncated(r),
+			"request_id", middleware.GetReqID(r.Context()))
+		uid := refreshToken.UserID
+		tid := refreshToken.TenantID
+		api.logAuth(r.Context(), "refresh_token_reuse_detected", &uid, &tid, false, r, nil)
+		clearRefreshCookie(w, r)
+		http.Error(w, "Refresh token expired or revoked", http.StatusUnauthorized)
+		return
+	} else if !refreshToken.IsValid() {
+		// Genuinely expired (RevokedAt == nil, past ExpiresAt): no theft, no
+		// cascade — keep the original behaviour and just clear the cookie.
 		slog.Warn("Expired or revoked refresh token", "token_id", refreshToken.ID)
 		clearRefreshCookie(w, r)
 		http.Error(w, "Refresh token expired or revoked", http.StatusUnauthorized)
@@ -428,31 +459,62 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Carry the refreshed-from row id as "rti" so /users/me/sessions can
-	// identify the caller's own session without the refresh cookie.
-	accessTokenString, _, err := api.issueAccessToken(r.Context(), user, refreshToken.ID)
+	// Rotate the refresh token (#967 H2). The tenant plane previously only
+	// bumped last_used_at and never re-issued the cookie, so a stolen refresh
+	// cookie stayed valid for its full 30-day TTL with no way to detect
+	// replay. Mirroring the back-office plane (#1785), we now:
+	//
+	//   1. persist a FRESH 30-day row BEFORE revoking the consumed one, so a
+	//      transient registry error leaves the operator's existing session
+	//      usable (vs. half-rotated and signed out);
+	//   2. mint the access token carrying the NEW row id as "rti" — see the
+	//      CRITICAL note below;
+	//   3. best-effort revoke the consumed row. Combined with reuse detection
+	//      above, the consumed cookie now hashes to a revoked row, so any
+	//      replay of it trips the theft cascade.
+	newRTI, newRawRefreshToken, err := api.persistRefreshToken(r.Context(), r, user)
+	if err != nil {
+		slog.Error("Failed to issue rotated refresh token", "user_id", user.ID, "error", err)
+		http.Error(w, "Failed to rotate session", http.StatusInternalServerError)
+		return
+	}
+
+	// CRITICAL: pass the NEW row id (newRTI), NOT refreshToken.ID, as the
+	// "rti" claim. /users/me/sessions resolves the caller's current session
+	// by this claim first; stamping the old (about-to-be-revoked) row id
+	// would make is_current false for the live session and let
+	// revokeAllOtherSessions nuke the caller's own session.
+	accessTokenString, _, err := api.issueAccessToken(r.Context(), user, newRTI)
 	if err != nil {
 		slog.Error("Failed to generate access token on refresh", "user_id", user.ID, "error", err)
+		// Roll back the freshly-persisted row so a failed mint doesn't leave
+		// an orphaned valid refresh row with no cookie ever handed out.
+		api.rollbackRefreshToken(r.Context(), user.ID, newRTI)
 		http.Error(w, "Failed to generate token", http.StatusInternalServerError)
 		return
 	}
 
-	// Update last-used timestamp on the refresh token (best-effort).
-	now := time.Now()
-	refreshToken.LastUsedAt = &now
-	if _, err := api.refreshTokenRegistry.Update(r.Context(), *refreshToken); err != nil {
-		slog.Error("Failed to update refresh token last_used_at", "token_id", refreshToken.ID, "error", err)
+	// Revoke the consumed row (best-effort). The access token is already
+	// minted and the new cookie will overwrite the old one in the browser,
+	// so a transient revoke failure must NOT 500 — but log loudly so a
+	// partial rotation is visible. We do NOT bump last_used_at on the new
+	// row: the tenant registry has no BumpLastUsedAt and login() leaves it
+	// nil on a fresh row too, so a freshly-rotated session reads the same as
+	// a freshly-logged-in one.
+	if err := api.refreshTokenRegistry.RevokeByID(r.Context(), user.ID, refreshToken.ID); err != nil {
+		slog.Error("Failed to revoke consumed refresh token (rotation partially completed)",
+			"old_token_id", refreshToken.ID, "new_token_id", newRTI, "user_id", user.ID, "error", err)
 	}
 
 	// Re-generate the CSRF token so it stays in sync with the new access token.
 	csrfToken := api.generateCSRFTokenForUser(r.Context(), user.ID)
 
-	// refresh() does not rotate the refresh cookie (writeLoginResponse writes
-	// no cookie), so a session that only ever refreshes would never evict a
-	// stale pre-#1750 cookie left at the legacy /api/v1/auth path. Clear it
-	// explicitly here — cheap, idempotent, and closes the migration window
-	// for refresh-only sessions (#1750/#1771).
-	clearLegacyRefreshCookie(w, r)
+	// Write the NEW refresh cookie. setRefreshTokenCookie -> writeRefreshCookie
+	// emits the canonical flags (Path=/api/v1, HttpOnly, SameSite=Strict,
+	// Secure-on-HTTPS) and clears any stale legacy /api/v1/auth cookie
+	// internally, subsuming the explicit clearLegacyRefreshCookie the old
+	// no-rotation path needed.
+	api.setRefreshTokenCookie(w, r, newRawRefreshToken)
 
 	// Reuse the freshly-minted access-token claim instead of doing a
 	// second SystemAdminGrantRegistry.Exists lookup on the hot refresh
@@ -901,7 +963,7 @@ func Auth(params AuthParams) func(r chi.Router) {
 	return func(r chi.Router) {
 		r.With(AuthLoginRateLimitMiddleware(params.RateLimiter)).Post("/login", api.login)
 		r.With(AuthLoginRateLimitMiddleware(params.RateLimiter)).Post("/login/mfa", api.loginMFA)
-		r.Post("/refresh", api.refresh)
+		r.With(AuthRefreshRateLimitMiddleware(params.RateLimiter)).Post("/refresh", api.refresh)
 		r.Post("/logout", api.logout)
 		// Magic-link passwordless sign-in. Both routes are public/no-auth.
 		// The request route is per-email throttled (magic-link limiter) on

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -47,9 +48,13 @@ type mockRefreshTokenRegistryForAuth struct {
 	tokensByHash map[string]*models.RefreshToken
 	updates      []models.RefreshToken
 	createCount  int
+	createErr    error
 }
 
 func (m *mockRefreshTokenRegistryForAuth) Create(_ context.Context, rt models.RefreshToken) (*models.RefreshToken, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
 	m.createCount++
 	if rt.ID == "" {
 		rt.ID = fmt.Sprintf("rt-created-%d", m.createCount)
@@ -1130,6 +1135,42 @@ func TestAuthAPI_Refresh_RevokesConsumedRowAndStampsNewRTI(t *testing.T) {
 	c.Assert(claims["rti"], qt.Not(qt.Equals), oldRowID)
 }
 
+// TestAuthAPI_Refresh_PersistFailurePreservesSession pins the #967 H2
+// crash-safety contract: persist-BEFORE-revoke means a transient Create error
+// during rotation returns 500 WITHOUT revoking the consumed row, so the
+// caller's existing session stays usable rather than half-rotated / signed out.
+func TestAuthAPI_Refresh_PersistFailurePreservesSession(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-persistfail", "tenant-persistfail"
+
+	raw, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	refreshReg := &mockRefreshTokenRegistryForAuth{
+		tokensByHash: map[string]*models.RefreshToken{
+			hash: {
+				TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+					TenantID: tenantID,
+					UserID:   userID,
+				},
+				TokenHash: hash,
+				ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			},
+		},
+		createErr: errors.New("refresh_tokens insert failed"),
+	}
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+
+	resp := postRefresh(apiserver.AuthParams{UserRegistry: userReg, RefreshTokenRegistry: refreshReg, JWTSecret: jwtSecret}, raw)
+
+	c.Assert(resp.Code, qt.Equals, http.StatusInternalServerError)
+	c.Assert(resp.Body.String(), qt.Contains, "Failed to rotate session")
+	// The consumed row must NOT be revoked — a failed rotation leaves the
+	// existing session intact (no reuse cascade fired either).
+	c.Assert(refreshReg.tokensByHash[hash].RevokedAt, qt.IsNil)
+	c.Assert(refreshReg.revokeByUserIDCalled, qt.IsFalse)
+}
+
 // TestAuthAPI_Refresh_ReuseDetectionRevokesAllSessions pins the #967 H4 theft
 // cascade: after one rotation, replaying the now-revoked original cookie is
 // treated as theft — it 401s with the SAME body as the expired branch, ALL of
@@ -1279,7 +1320,9 @@ func TestAuthAPI_Refresh_RateLimited429(t *testing.T) {
 		}
 	}
 	c.Assert(last.Code, qt.Equals, http.StatusTooManyRequests)
-	c.Assert(last.Header().Get("Retry-After"), qt.Not(qt.Equals), "")
+	retryAfter, err := strconv.Atoi(last.Header().Get("Retry-After"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(retryAfter > 0, qt.IsTrue)
 }
 
 // TestAuthAPI_Refresh_ImpersonationNotRotated pins the #967 care point that the

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -45,10 +45,11 @@ type mockRefreshTokenRegistryForAuth struct {
 	revokeByUserIDCalled bool
 	revokeByUserIDArg    string
 
-	tokensByHash map[string]*models.RefreshToken
-	updates      []models.RefreshToken
-	createCount  int
-	createErr    error
+	tokensByHash  map[string]*models.RefreshToken
+	updates       []models.RefreshToken
+	createCount   int
+	createErr     error
+	revokeByIDErr error
 }
 
 func (m *mockRefreshTokenRegistryForAuth) Create(_ context.Context, rt models.RefreshToken) (*models.RefreshToken, error) {
@@ -119,6 +120,9 @@ func (m *mockRefreshTokenRegistryForAuth) RevokeByUserID(_ context.Context, user
 }
 
 func (m *mockRefreshTokenRegistryForAuth) RevokeByID(_ context.Context, userID, id string) error {
+	if m.revokeByIDErr != nil {
+		return m.revokeByIDErr
+	}
 	for _, rt := range m.tokensByHash {
 		if rt.ID == id && rt.UserID == userID {
 			if rt.RevokedAt == nil {
@@ -1169,6 +1173,39 @@ func TestAuthAPI_Refresh_PersistFailurePreservesSession(t *testing.T) {
 	// existing session intact (no reuse cascade fired either).
 	c.Assert(refreshReg.tokensByHash[hash].RevokedAt, qt.IsNil)
 	c.Assert(refreshReg.revokeByUserIDCalled, qt.IsFalse)
+}
+
+// TestAuthAPI_Refresh_RevokeOldFailureStill200 pins that revoking the consumed
+// row is best-effort: a transient RevokeByID failure during rotation must NOT
+// sign the user out — the new token + cookie are already minted, so the
+// response stays 200 (a regression turning this into a 500 would log the user
+// out on a revoke flake).
+func TestAuthAPI_Refresh_RevokeOldFailureStill200(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-revokefail", "tenant-revokefail"
+
+	raw, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	refreshReg := &mockRefreshTokenRegistryForAuth{
+		tokensByHash: map[string]*models.RefreshToken{
+			hash: {
+				TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+					TenantID: tenantID,
+					UserID:   userID,
+				},
+				TokenHash: hash,
+				ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			},
+		},
+		revokeByIDErr: errors.New("revoke consumed row flaked"),
+	}
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+
+	resp := postRefresh(apiserver.AuthParams{UserRegistry: userReg, RefreshTokenRegistry: refreshReg, JWTSecret: jwtSecret}, raw)
+
+	c.Assert(resp.Code, qt.Equals, http.StatusOK)
+	c.Assert(refreshCookieValue(resp), qt.Not(qt.Equals), "")
 }
 
 // TestAuthAPI_Refresh_ReuseDetectionRevokesAllSessions pins the #967 H4 theft

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -28,19 +29,36 @@ import (
 // mockRefreshTokenRegistryForAuth implements registry.RefreshTokenRegistry for testing.
 // It records calls to RevokeByUserID and Update so tests can assert what was
 // invoked. When tokensByHash is non-nil the mock acts as a real registry for
-// GetByTokenHash / Update; when nil, GetByTokenHash returns ErrNotFound and
-// Update still records the call but does not persist anything — so existing
-// change-password tests, which only check RevokeByUserID, don't need to opt in.
+// GetByTokenHash / Create / RevokeByID / RevokeByUserID — enough for the #967
+// refresh-rotation + reuse-detection flow to behave like a real store; when
+// nil, GetByTokenHash returns ErrNotFound and Update still records the call but
+// does not persist anything — so existing change-password tests, which only
+// check RevokeByUserID, don't need to opt in.
+//
+// Create persists a fresh row (generated id, keyed by hash) so rotation's
+// persist-then-revoke ordering exercises real lookups; RevokeByID /
+// RevokeByUserID set RevokedAt on the stored rows so a subsequent
+// GetByTokenHash sees the revoked row UNFILTERED — the exact property
+// reuse detection depends on.
 type mockRefreshTokenRegistryForAuth struct {
 	revokeByUserIDCalled bool
 	revokeByUserIDArg    string
 
 	tokensByHash map[string]*models.RefreshToken
 	updates      []models.RefreshToken
+	createCount  int
 }
 
-func (m *mockRefreshTokenRegistryForAuth) Create(_ context.Context, _ models.RefreshToken) (*models.RefreshToken, error) {
-	return nil, nil
+func (m *mockRefreshTokenRegistryForAuth) Create(_ context.Context, rt models.RefreshToken) (*models.RefreshToken, error) {
+	m.createCount++
+	if rt.ID == "" {
+		rt.ID = fmt.Sprintf("rt-created-%d", m.createCount)
+	}
+	stored := rt
+	if m.tokensByHash != nil {
+		m.tokensByHash[rt.TokenHash] = &stored
+	}
+	return &stored, nil
 }
 
 func (m *mockRefreshTokenRegistryForAuth) Get(_ context.Context, _ string) (*models.RefreshToken, error) {
@@ -86,11 +104,26 @@ func (m *mockRefreshTokenRegistryForAuth) ListActiveByUserID(_ context.Context, 
 func (m *mockRefreshTokenRegistryForAuth) RevokeByUserID(_ context.Context, userID string) error {
 	m.revokeByUserIDCalled = true
 	m.revokeByUserIDArg = userID
+	now := time.Now()
+	for _, rt := range m.tokensByHash {
+		if rt.UserID == userID && rt.RevokedAt == nil {
+			rt.RevokedAt = &now
+		}
+	}
 	return nil
 }
 
-func (m *mockRefreshTokenRegistryForAuth) RevokeByID(_ context.Context, _ string, _ string) error {
-	return nil
+func (m *mockRefreshTokenRegistryForAuth) RevokeByID(_ context.Context, userID, id string) error {
+	for _, rt := range m.tokensByHash {
+		if rt.ID == id && rt.UserID == userID {
+			if rt.RevokedAt == nil {
+				now := time.Now()
+				rt.RevokedAt = &now
+			}
+			return nil
+		}
+	}
+	return registry.ErrNotFound
 }
 
 func (m *mockRefreshTokenRegistryForAuth) RevokeAllExceptID(_ context.Context, _ string, _ string) error {
@@ -694,9 +727,10 @@ func TestAuthAPI_Refresh(t *testing.T) {
 		c.Assert(ok, qt.IsTrue)
 		c.Assert(claims["user_id"], qt.Equals, userID)
 
-		// last_used_at should be touched as a side-effect of a successful refresh.
-		c.Assert(refreshReg.updates, qt.HasLen, 1)
-		c.Assert(refreshReg.updates[0].LastUsedAt, qt.IsNotNil)
+		// Rotation (#967 H2): a fresh row is persisted and the consumed row is
+		// not bumped via Update — the new no-rotation-removed contract.
+		c.Assert(refreshReg.createCount, qt.Equals, 1)
+		c.Assert(refreshReg.updates, qt.HasLen, 0)
 	})
 
 	t.Run("missing refresh cookie returns 401", func(t *testing.T) {
@@ -950,6 +984,342 @@ func TestAuthAPI_Refresh_DeletesLegacyPathCookie(t *testing.T) {
 	c.Assert(legacyRefreshCookieDeleted(resp), qt.IsTrue,
 		qt.Commentf("refresh success path must emit a Set-Cookie deleting the legacy /api/v1/auth cookie; got %v",
 			resp.Header().Values("Set-Cookie")))
+}
+
+// refreshCookieValue extracts the value of the refresh_token cookie from a
+// response's Set-Cookie headers, or "" when the response does not set one (or
+// only clears it via Max-Age=0). Used by the #967 rotation tests to follow the
+// cookie chain across refreshes.
+func refreshCookieValue(resp *httptest.ResponseRecorder) string {
+	for _, c := range resp.Result().Cookies() {
+		if c.Name == "refresh_token" && c.MaxAge >= 0 && c.Value != "" {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+// newRefreshTestUser builds a minimal active user for the #967 refresh tests.
+func newRefreshTestUser(userID, tenantID string) *models.User {
+	return &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: userID},
+			TenantID: tenantID,
+		},
+		Email:    "rotate@example.com",
+		Name:     "Rotate User",
+		IsActive: true,
+	}
+}
+
+// seedRefreshRow creates a live refresh-token row in a real memory registry and
+// returns the raw cookie value the client would send. Mirrors how login()
+// persists the row, so the #967 rotation/reuse tests exercise the real
+// GetByTokenHash / Create / RevokeByID lockstep rather than a hand-rolled mock.
+func seedRefreshRow(t *testing.T, reg registry.RefreshTokenRegistry, userID, tenantID string) string {
+	t.Helper()
+	raw, hash, err := models.GenerateRefreshToken()
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken: %v", err)
+	}
+	_, err = reg.Create(context.Background(), models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: tenantID,
+			UserID:   userID,
+		},
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("seed refresh row: %v", err)
+	}
+	return raw
+}
+
+// postRefresh fires POST /refresh with the given cookie value against a freshly
+// wired Auth router and returns the recorder.
+func postRefresh(params apiserver.AuthParams, cookieValue string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/refresh", nil)
+	if cookieValue != "" {
+		// #nosec G124 -- test-only cookie added to a httptest.NewRequest.
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: cookieValue})
+	}
+	resp := httptest.NewRecorder()
+	router := chi.NewRouter()
+	apiserver.Auth(params)(router)
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+// TestAuthAPI_Refresh_RotatesRefreshToken pins the #967 H2 rotation contract on
+// the tenant plane: a successful refresh issues a NEW refresh cookie (value !=
+// original) and a fresh access token; replaying the ORIGINAL cookie returns
+// 401 (it now hashes to a revoked row), while the ROTATED cookie still works.
+func TestAuthAPI_Refresh_RotatesRefreshToken(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-rotate", "tenant-rotate"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	original := seedRefreshRow(t, refreshReg, userID, tenantID)
+
+	params := apiserver.AuthParams{UserRegistry: userReg, RefreshTokenRegistry: refreshReg, JWTSecret: jwtSecret}
+
+	// First refresh: 200, new cookie, fresh access token.
+	resp := postRefresh(params, original)
+	c.Assert(resp.Code, qt.Equals, http.StatusOK)
+	rotated := refreshCookieValue(resp)
+	c.Assert(rotated, qt.Not(qt.Equals), "")
+	c.Assert(rotated, qt.Not(qt.Equals), original)
+
+	var body apiserver.LoginResponse
+	c.Assert(json.Unmarshal(resp.Body.Bytes(), &body), qt.IsNil)
+	c.Assert(body.AccessToken, qt.Not(qt.Equals), "")
+
+	// The rotated cookie works on its first use (asserted BEFORE the replay
+	// below, which fires the H4 theft cascade and revokes everything).
+	again := postRefresh(params, rotated)
+	c.Assert(again.Code, qt.Equals, http.StatusOK)
+
+	// Replaying the ORIGINAL cookie now fails: it hashes to a revoked row.
+	replay := postRefresh(params, original)
+	c.Assert(replay.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+// TestAuthAPI_Refresh_RevokesConsumedRowAndStampsNewRTI pins two #967 H2
+// invariants: after a refresh the consumed row carries RevokedAt, and the
+// minted access token's "rti" claim points at the NEW row id (never the old
+// one). The rti linkage is load-bearing for /users/me/sessions — stamping the
+// stale id would make the live session look non-current.
+func TestAuthAPI_Refresh_RevokesConsumedRowAndStampsNewRTI(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-rti", "tenant-rti"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	original := seedRefreshRow(t, refreshReg, userID, tenantID)
+
+	// Capture the original row id before refresh.
+	originalRow, err := refreshReg.GetByTokenHash(context.Background(), models.HashRefreshToken(original))
+	c.Assert(err, qt.IsNil)
+	oldRowID := originalRow.ID
+
+	resp := postRefresh(apiserver.AuthParams{UserRegistry: userReg, RefreshTokenRegistry: refreshReg, JWTSecret: jwtSecret}, original)
+	c.Assert(resp.Code, qt.Equals, http.StatusOK)
+
+	// The consumed row must now be revoked.
+	consumed, err := refreshReg.GetByTokenHash(context.Background(), models.HashRefreshToken(original))
+	c.Assert(err, qt.IsNil)
+	c.Assert(consumed.RevokedAt, qt.IsNotNil)
+
+	// Resolve the new row id from the rotated cookie, then assert the access
+	// token's rti claim equals it (and not the old row id).
+	rotated := refreshCookieValue(resp)
+	newRow, err := refreshReg.GetByTokenHash(context.Background(), models.HashRefreshToken(rotated))
+	c.Assert(err, qt.IsNil)
+
+	var body apiserver.LoginResponse
+	c.Assert(json.Unmarshal(resp.Body.Bytes(), &body), qt.IsNil)
+	token, err := jwt.Parse(body.AccessToken, func(*jwt.Token) (any, error) { return jwtSecret, nil })
+	c.Assert(err, qt.IsNil)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(claims["rti"], qt.Equals, newRow.ID)
+	c.Assert(claims["rti"], qt.Not(qt.Equals), oldRowID)
+}
+
+// TestAuthAPI_Refresh_ReuseDetectionRevokesAllSessions pins the #967 H4 theft
+// cascade: after one rotation, replaying the now-revoked original cookie is
+// treated as theft — it 401s with the SAME body as the expired branch, ALL of
+// the user's sessions are revoked (so even the legitimately-rotated cookie
+// 401s afterwards), and exactly one audit row is written with
+// Action=="refresh_token_reuse_detected", Success==false.
+func TestAuthAPI_Refresh_ReuseDetectionRevokesAllSessions(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-theft", "tenant-theft"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	auditReg := memreg.NewAuditLogRegistry()
+	auditSvc := services.NewAuditService(auditReg)
+	original := seedRefreshRow(t, refreshReg, userID, tenantID)
+
+	params := apiserver.AuthParams{
+		UserRegistry:         userReg,
+		RefreshTokenRegistry: refreshReg,
+		AuditService:         auditSvc,
+		JWTSecret:            jwtSecret,
+	}
+
+	// Rotate once.
+	resp := postRefresh(params, original)
+	c.Assert(resp.Code, qt.Equals, http.StatusOK)
+	rotated := refreshCookieValue(resp)
+	c.Assert(rotated, qt.Not(qt.Equals), "")
+
+	// Replay the now-revoked original: theft detected. Body must be
+	// byte-identical to the plain-expired branch (opaque to the attacker).
+	theft := postRefresh(params, original)
+	c.Assert(theft.Code, qt.Equals, http.StatusUnauthorized)
+	c.Assert(strings.TrimSpace(theft.Body.String()), qt.Equals, "Refresh token expired or revoked")
+
+	// Cascade: the rotated (legitimate) session row must ALSO be revoked now.
+	// Asserted via the registry rather than by replaying the cookie — a replay
+	// would itself be a second reuse event and inflate the audit count.
+	rotatedRow, err := refreshReg.GetByTokenHash(context.Background(), models.HashRefreshToken(rotated))
+	c.Assert(err, qt.IsNil)
+	c.Assert(rotatedRow.RevokedAt, qt.IsNotNil)
+
+	// Exactly one reuse audit row (from the single replay), marked unsuccessful.
+	logs, err := auditReg.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	reuseRows := 0
+	for _, l := range logs {
+		if l.Action == "refresh_token_reuse_detected" {
+			reuseRows++
+			c.Assert(l.Success, qt.IsFalse)
+		}
+	}
+	c.Assert(reuseRows, qt.Equals, 1)
+}
+
+// TestAuthAPI_Refresh_ExpiredStays401NoCascade pins the #967 H4 boundary: a
+// genuinely expired row (RevokedAt == nil, ExpiresAt in the past) must 401
+// WITHOUT triggering the theft cascade — the user's OTHER active sessions stay
+// live and no reuse audit row is written.
+func TestAuthAPI_Refresh_ExpiredStays401NoCascade(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-expired", "tenant-expired"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	auditReg := memreg.NewAuditLogRegistry()
+	auditSvc := services.NewAuditService(auditReg)
+
+	// Seed one expired-but-active row (the cookie under test) and one healthy
+	// active row (to prove the cascade did NOT fire).
+	expiredRaw, expiredHash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	_, err = refreshReg.Create(context.Background(), models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{TenantID: tenantID, UserID: userID},
+		TokenHash:               expiredHash,
+		ExpiresAt:               time.Now().Add(-time.Minute), // expired, not revoked
+	})
+	c.Assert(err, qt.IsNil)
+	healthyRaw := seedRefreshRow(t, refreshReg, userID, tenantID)
+
+	params := apiserver.AuthParams{
+		UserRegistry:         userReg,
+		RefreshTokenRegistry: refreshReg,
+		AuditService:         auditSvc,
+		JWTSecret:            jwtSecret,
+	}
+
+	resp := postRefresh(params, expiredRaw)
+	c.Assert(resp.Code, qt.Equals, http.StatusUnauthorized)
+	c.Assert(strings.TrimSpace(resp.Body.String()), qt.Equals, "Refresh token expired or revoked")
+
+	// No cascade: the healthy row is untouched and still refreshes.
+	healthyRow, err := refreshReg.GetByTokenHash(context.Background(), models.HashRefreshToken(healthyRaw))
+	c.Assert(err, qt.IsNil)
+	c.Assert(healthyRow.RevokedAt, qt.IsNil)
+
+	// No reuse audit row was written.
+	logs, err := auditReg.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	for _, l := range logs {
+		c.Assert(l.Action, qt.Not(qt.Equals), "refresh_token_reuse_detected")
+	}
+}
+
+// TestAuthAPI_Refresh_RateLimited429 pins the #967 H1 dedicated refresh budget:
+// hammering /auth/refresh past refreshAttemptsLimit from one IP returns 429
+// with a Retry-After header. Uses the real in-memory limiter so the sliding
+// window is exercised end-to-end.
+func TestAuthAPI_Refresh_RateLimited429(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-rl", "tenant-rl"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	limiter := services.NewInMemoryAuthRateLimiter()
+
+	params := apiserver.AuthParams{
+		UserRegistry:         userReg,
+		RefreshTokenRegistry: refreshReg,
+		RateLimiter:          limiter,
+		JWTSecret:            jwtSecret,
+	}
+
+	router := chi.NewRouter()
+	apiserver.Auth(params)(router)
+
+	// The refresh budget is 60/15min; fire a few past that from one IP. Each
+	// request rotates, so re-seed a fresh cookie each loop to keep the handler
+	// past the limiter rather than 401-ing on a revoked cookie — but the
+	// limiter rejects before the handler runs once the budget is spent, so the
+	// cookie value is irrelevant on the rejected call.
+	var last *httptest.ResponseRecorder
+	for range 65 {
+		raw := seedRefreshRow(t, refreshReg, userID, tenantID)
+		req := httptest.NewRequest("POST", "/refresh", nil)
+		req.RemoteAddr = "203.0.113.7:54321"
+		// #nosec G124 -- test-only cookie.
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: raw})
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		last = rec
+		if rec.Code == http.StatusTooManyRequests {
+			break
+		}
+	}
+	c.Assert(last.Code, qt.Equals, http.StatusTooManyRequests)
+	c.Assert(last.Header().Get("Retry-After"), qt.Not(qt.Equals), "")
+}
+
+// TestAuthAPI_Refresh_ImpersonationNotRotated pins the #967 care point that the
+// impersonation guard stays FIRST: an impersonation-marker refresh cookie is
+// rejected with 401 ErrImpersonationTokenCannotRefresh before any cookie
+// lookup, so no new row is created, no cookie is rotated, and no reuse audit
+// row is written.
+func TestAuthAPI_Refresh_ImpersonationNotRotated(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const userID, tenantID = "user-imp", "tenant-imp"
+
+	refreshReg := memreg.NewRefreshTokenRegistry()
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: newRefreshTestUser(userID, tenantID)}}
+	auditReg := memreg.NewAuditLogRegistry()
+	auditSvc := services.NewAuditService(auditReg)
+
+	params := apiserver.AuthParams{
+		UserRegistry:         userReg,
+		RefreshTokenRegistry: refreshReg,
+		AuditService:         auditSvc,
+		JWTSecret:            jwtSecret,
+	}
+
+	// The impersonation-start flow plants a marker value in the refresh cookie
+	// (impersonationRefreshCookieMarker). Its detectable prefix is "imp:".
+	resp := postRefresh(params, "imp:some-impersonation-marker-payload")
+	c.Assert(resp.Code, qt.Equals, http.StatusUnauthorized)
+	c.Assert(strings.TrimSpace(resp.Body.String()), qt.Equals, apiserver.ErrImpersonationTokenCannotRefresh.Error())
+
+	// No row was created and no cookie was rotated.
+	c.Assert(refreshCookieValue(resp), qt.Equals, "")
+	rows, err := refreshReg.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(rows, qt.HasLen, 0)
+
+	// No reuse audit row.
+	logs, err := auditReg.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(logs, qt.HasLen, 0)
 }
 
 // refreshCookieCleared reports whether the response includes a Set-Cookie

--- a/go/apiserver/rate_limit_middleware.go
+++ b/go/apiserver/rate_limit_middleware.go
@@ -197,6 +197,48 @@ func AuthLoginRateLimitMiddleware(limiter services.AuthRateLimiter) func(http.Ha
 	}
 }
 
+// AuthRefreshRateLimitMiddleware enforces per-IP rate limiting on the
+// /auth/refresh endpoint (#967). It deliberately uses a dedicated, generous
+// refresh budget (CheckRefreshAttempt) rather than the tight login budget:
+// /auth/refresh is hit periodically and concurrently by every open tab, so
+// the login limit would lock out honest multi-tab sessions. Keying is
+// remoteAddrIP (proxy headers ignored) so a forged X-Forwarded-For can't
+// move the bucket — identical to AuthLoginRateLimitMiddleware. Fails open on
+// a limiter backend error, consistent with the other limiters here; the real
+// theft defences are refresh-token rotation and reuse detection (#967 H2/H4).
+func AuthRefreshRateLimitMiddleware(limiter services.AuthRateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if limiter == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ip := remoteAddrIP(r)
+			res, err := limiter.CheckRefreshAttempt(r.Context(), ip)
+			if err != nil {
+				// Fail-open: do not make refresh unavailable due to limiter backend outages.
+				slog.Error("Auth refresh rate limiter error", "error", err, "ip", ip)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", res.Limit))
+			w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", res.Remaining))
+			w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", res.ResetAt.Unix()))
+
+			if !res.Allowed {
+				retryAfter := max(int(time.Until(res.ResetAt).Seconds()), 0)
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+				slog.Warn("Refresh rate limit exceeded", "ip", ip, "retry_after_seconds", retryAfter)
+				http.Error(w, "Rate limit exceeded. Please try again later.", http.StatusTooManyRequests)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // RegistrationRateLimitMiddleware enforces per-IP rate limiting on registration endpoints.
 func RegistrationRateLimitMiddleware(limiter services.AuthRateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -1914,7 +1914,7 @@ const docTemplate = `{
         },
         "/auth/refresh": {
             "post": {
-                "description": "Issue a new short-lived access token using the refresh token stored in the httpOnly cookie.",
+                "description": "Issue a new short-lived access token using the refresh token stored in the httpOnly cookie. Rotates the refresh token: the consumed cookie value is revoked and a new value is set.\nReplaying an already-rotated cookie is treated as theft and revokes all of the user's sessions.",
                 "produces": [
                     "application/json"
                 ],

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -1907,7 +1907,7 @@
         },
         "/auth/refresh": {
             "post": {
-                "description": "Issue a new short-lived access token using the refresh token stored in the httpOnly cookie.",
+                "description": "Issue a new short-lived access token using the refresh token stored in the httpOnly cookie. Rotates the refresh token: the consumed cookie value is revoked and a new value is set.\nReplaying an already-rotated cookie is treated as theft and revokes all of the user's sessions.",
                 "produces": [
                     "application/json"
                 ],

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -5881,8 +5881,9 @@ paths:
       - oauth
   /auth/refresh:
     post:
-      description: Issue a new short-lived access token using the refresh token stored
-        in the httpOnly cookie.
+      description: |-
+        Issue a new short-lived access token using the refresh token stored in the httpOnly cookie. Rotates the refresh token: the consumed cookie value is revoked and a new value is set.
+        Replaying an already-rotated cookie is treated as theft and revokes all of the user's sessions.
       produces:
       - application/json
       responses:

--- a/go/registry/memory/refresh_tokens_test.go
+++ b/go/registry/memory/refresh_tokens_test.go
@@ -1,0 +1,48 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// TestRefreshTokenRegistryMemory_GetByTokenHash_ReturnsRevokedRow pins, for the
+// in-memory backend, the same property the postgres suite pins: GetByTokenHash
+// returns a row even after it has been revoked (it does NOT filter on
+// RevokedAt). The #967 reuse-detection handler relies on this so a
+// replayed-after-rotation cookie surfaces the revoked row rather than
+// ErrNotFound — keeping the two backends in lockstep on the one property the
+// theft cascade depends on.
+func TestRefreshTokenRegistryMemory_GetByTokenHash_ReturnsRevokedRow(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r := memory.NewRefreshTokenRegistry()
+
+	_, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+
+	created, err := r.Create(ctx, models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: "tenant-1",
+			UserID:   "user-1",
+		},
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.RevokedAt, qt.IsNil)
+
+	err = r.RevokeByID(ctx, "user-1", created.ID)
+	c.Assert(err, qt.IsNil)
+
+	got, err := r.GetByTokenHash(ctx, hash)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.ID, qt.Equals, created.ID)
+	c.Assert(got.RevokedAt, qt.IsNotNil)
+}

--- a/go/registry/postgres/refresh_tokens_test.go
+++ b/go/registry/postgres/refresh_tokens_test.go
@@ -1,0 +1,62 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestRefreshTokenRegistryPostgres_GetByTokenHash_ReturnsRevokedRow pins the
+// property the #967 reuse-detection handler depends on: GetByTokenHash returns
+// a row even after it has been revoked (it does NOT filter on
+// revoked_at IS NULL). Without this, a replayed-after-rotation cookie would
+// surface as ErrNotFound and the theft cascade could never fire. Exercised in
+// service mode (RLS-bypass) because /auth/refresh resolves the row in service
+// mode.
+func TestRefreshTokenRegistryPostgres_GetByTokenHash_ReturnsRevokedRow(t *testing.T) {
+	c := qt.New(t)
+
+	set, _ := setupTestRegistrySet(t)
+	user := getTestUser(c, set)
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	fs := postgres.NewFactorySet(dbx)
+	serviceSet := fs.CreateServiceRegistrySet()
+	r := serviceSet.RefreshTokenRegistry
+
+	ctx := context.Background()
+	_, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+
+	created, err := r.Create(ctx, models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: user.TenantID,
+			UserID:   user.ID,
+		},
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.RevokedAt, qt.IsNil)
+
+	// Revoke the row.
+	err = r.RevokeByID(ctx, user.ID, created.ID)
+	c.Assert(err, qt.IsNil)
+
+	// GetByTokenHash must still return the row, now carrying RevokedAt — the
+	// in-handler theft discriminator.
+	got, err := r.GetByTokenHash(ctx, hash)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.ID, qt.Equals, created.ID)
+	c.Assert(got.RevokedAt, qt.IsNotNil)
+}

--- a/go/services/auth_rate_limiter.go
+++ b/go/services/auth_rate_limiter.go
@@ -14,6 +14,18 @@ const (
 	loginAttemptsLimit  = 5
 	loginAttemptsWindow = 15 * time.Minute
 
+	// refresh-token endpoint throttling (#967). Deliberately NOT the login
+	// budget (5/15min): /auth/refresh is hit periodically and concurrently
+	// by every open tab (a multi-tab user with a short access-token TTL can
+	// legitimately fire a handful of refreshes a minute), so reusing the
+	// tight login budget would lock out honest sessions. Per-IP, generous
+	// (60/15min) — enough headroom for legitimate multi-tab refresh, tight
+	// enough that a credential-stuffing loop replaying stolen cookies is
+	// still bounded. The refresh-token rotation + reuse-detection (#967 H2/H4)
+	// are the real theft defences; this limiter just caps brute-force volume.
+	refreshAttemptsLimit  = 60
+	refreshAttemptsWindow = 15 * time.Minute
+
 	registrationAttemptsLimit  = 3
 	registrationAttemptsWindow = time.Hour
 
@@ -91,6 +103,13 @@ type RateLimitResult struct {
 //   - Fail-open behavior on backend errors (Redis outage must not take API down).
 type AuthRateLimiter interface {
 	CheckLoginAttempt(ctx context.Context, ip string) (RateLimitResult, error)
+	// CheckRefreshAttempt throttles the /auth/refresh endpoint (#967) on a
+	// per-IP basis. The endpoint takes no body and reads only the httpOnly
+	// refresh cookie, so the source IP is the only stable key. The budget is
+	// deliberately generous (see refreshAttemptsLimit) — far looser than the
+	// login budget — so periodic multi-tab refresh is never throttled while a
+	// stolen-cookie replay loop is still capped.
+	CheckRefreshAttempt(ctx context.Context, ip string) (RateLimitResult, error)
 	CheckRegistrationAttempt(ctx context.Context, ip string) (RateLimitResult, error)
 	CheckPasswordResetAttempt(ctx context.Context, email string) (RateLimitResult, error)
 	// CheckMagicLinkAttempt throttles passwordless sign-in ("magic link")
@@ -193,6 +212,11 @@ func NewRedisAuthRateLimiterFromURL(redisURL string) (*RedisAuthRateLimiter, err
 func (l *RedisAuthRateLimiter) CheckLoginAttempt(ctx context.Context, ip string) (RateLimitResult, error) {
 	key := fmt.Sprintf("rate:auth:login:ip:%s", hashKeyPart(ip))
 	return l.checkRate(ctx, key, loginAttemptsLimit, loginAttemptsWindow)
+}
+
+func (l *RedisAuthRateLimiter) CheckRefreshAttempt(ctx context.Context, ip string) (RateLimitResult, error) {
+	key := fmt.Sprintf("rate:auth:refresh:ip:%s", hashKeyPart(ip))
+	return l.checkRate(ctx, key, refreshAttemptsLimit, refreshAttemptsWindow)
 }
 
 func (l *RedisAuthRateLimiter) CheckRegistrationAttempt(ctx context.Context, ip string) (RateLimitResult, error) {
@@ -377,6 +401,11 @@ func (l *InMemoryAuthRateLimiter) CheckLoginAttempt(_ context.Context, ip string
 	return l.checkRate(key, loginAttemptsLimit, loginAttemptsWindow), nil
 }
 
+func (l *InMemoryAuthRateLimiter) CheckRefreshAttempt(_ context.Context, ip string) (RateLimitResult, error) {
+	key := fmt.Sprintf("rate:auth:refresh:ip:%s", hashKeyPart(ip))
+	return l.checkRate(key, refreshAttemptsLimit, refreshAttemptsWindow), nil
+}
+
 func (l *InMemoryAuthRateLimiter) CheckRegistrationAttempt(_ context.Context, ip string) (RateLimitResult, error) {
 	key := fmt.Sprintf("rate:auth:register:ip:%s", hashKeyPart(ip))
 	return l.checkRate(key, registrationAttemptsLimit, registrationAttemptsWindow), nil
@@ -540,6 +569,10 @@ type NoOpAuthRateLimiter struct{}
 
 func (NoOpAuthRateLimiter) CheckLoginAttempt(_ context.Context, _ string) (RateLimitResult, error) {
 	return RateLimitResult{Allowed: true, Limit: loginAttemptsLimit, Remaining: loginAttemptsLimit, ResetAt: time.Now().Add(loginAttemptsWindow)}, nil
+}
+
+func (NoOpAuthRateLimiter) CheckRefreshAttempt(_ context.Context, _ string) (RateLimitResult, error) {
+	return RateLimitResult{Allowed: true, Limit: refreshAttemptsLimit, Remaining: refreshAttemptsLimit, ResetAt: time.Now().Add(refreshAttemptsWindow)}, nil
 }
 
 func (NoOpAuthRateLimiter) CheckRegistrationAttempt(_ context.Context, _ string) (RateLimitResult, error) {

--- a/go/services/auth_rate_limiter_test.go
+++ b/go/services/auth_rate_limiter_test.go
@@ -80,6 +80,42 @@ func TestInMemoryAuthRateLimiter_AccountLockout(t *testing.T) {
 	c.Assert(lim.ClearFailedLogins(ctx, email), qt.IsNil)
 }
 
+// TestInMemoryAuthRateLimiter_CheckRefreshAttempt_PerIP pins the #967 H1
+// dedicated refresh budget: per-IP, generous (refreshAttemptsLimit), and
+// independent of the login budget. The (refreshAttemptsLimit+1)-th call from
+// one IP is denied while a different IP keeps its own bucket.
+func TestInMemoryAuthRateLimiter_CheckRefreshAttempt_PerIP(t *testing.T) {
+	c := qt.New(t)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	lim := NewInMemoryAuthRateLimiter()
+	lim.now = func() time.Time { return now }
+
+	ctx := context.Background()
+	ip := "7.7.7.7"
+
+	for i := range refreshAttemptsLimit {
+		res, err := lim.CheckRefreshAttempt(ctx, ip)
+		c.Assert(err, qt.IsNil)
+		c.Assert(res.Allowed, qt.IsTrue)
+		c.Assert(res.Limit, qt.Equals, refreshAttemptsLimit)
+		c.Assert(res.Remaining, qt.Equals, refreshAttemptsLimit-1-i)
+		now = now.Add(time.Second)
+	}
+
+	res, err := lim.CheckRefreshAttempt(ctx, ip)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Allowed, qt.IsFalse)
+	c.Assert(res.Remaining, qt.Equals, 0)
+
+	// A different IP keeps its own bucket.
+	res, err = lim.CheckRefreshAttempt(ctx, "6.6.6.6")
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Allowed, qt.IsTrue)
+}
+
 func TestInMemoryAuthRateLimiter_CheckPublicScanAttempt_PerIP(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What

Hardens the **tenant** refresh-token flow — issue #967 H1/H2/H4 — bringing it to parity with the back-office plane (#1785). Previously `POST /api/v1/auth/refresh` only bumped `last_used_at` and never re-issued the cookie, so a stolen refresh cookie stayed valid for its full **30-day TTL with no theft signal**.

## Changes (all tenant-plane)

### H2 — Refresh-token rotation
Each successful `/refresh` now:
1. persists a **fresh 30-day row BEFORE** revoking the consumed one (a transient DB error leaves the existing session usable, not half-rotated);
2. mints the access token with the **new** row id as its `rti` claim — *load-bearing*: `/users/me/sessions` resolves the caller's current session by `rti`, so stamping the old (about-to-be-revoked) id would make `is_current` false and let "sign out other sessions" nuke the caller's own session;
3. `rollbackRefreshToken` on mint failure, best-effort `RevokeByID` of the consumed row, and `setRefreshTokenCookie` writes the rotated cookie.

A stolen cookie is now valid only until the client's next refresh (≈ the 15-min access-token lifetime).

### H4 — Reuse detection
`GetByTokenHash` returns revoked rows unfiltered, so a cookie that hashes to an **already-revoked** row is a replay of a rotated-away token. The handler revokes **all** of that user's tokens (`RevokeByUserID`), emits `slog.Warn("Refresh token reuse detected", …)` + a durable audit row (`Action="refresh_token_reuse_detected"`), and returns a `401` **byte-identical** to the plain-expired branch (opaque to the attacker). A genuinely *expired* (never-revoked) token is **not** treated as theft. Runs before the user-active / blacklist checks so theft is caught even for a since-deactivated user; the impersonation guard stays first.

### H1 — Dedicated `/refresh` rate limit
`/refresh` gets its **own generous per-IP budget** (`CheckRefreshAttempt`, 60/15 min) rather than the tight login budget — periodic multi-tab refresh is normal traffic and 256-bit refresh tokens are unbrute-forceable. `429` + `Retry-After` on exceed; `/logout` left unlimited.

## Notable decisions

- **No new registry method, no migration** — `Create`/`GetByTokenHash`/`RevokeByID`/`RevokeByUserID` already exist in both postgres + memory impls. Added a **lockstep regression test in both backends** pinning that `GetByTokenHash` returns revoked rows (the property H4 depends on).
- **Reuse-detection is intentionally strict.** A review pass flagged a "persistent forced-logout griefing" concern (a revoked row survives its 30-day TTL, so an attacker who captured one cookie could keep replaying it). Adversarial verification **refuted** treating this as a regression: it trades the old *silent 30-day account takeover* for a *noisy, audited, availability-only* forced-logout — the textbook RFC 6819 §5.2.2.3 / OWASP outcome. Gating the cascade on token freshness would *blind* detection (an attacker just waits >15 min). Left strict by design.
- **Cross-tab race (documented trade-off):** the FE single-flights refresh per tab, so the cascade only false-positives when two tabs race the same expiry → both land at `/login?reason=session_expired` (no data loss). A `BroadcastChannel` cross-tab single-flight is an easy FE follow-up → filed separately.

## Tests
Rotation happy-path, consumed-row-revoked + `rti`-claim assertion, the H4 reuse cascade (with a real `AuditLogger` — asserts all sessions revoked + the audit row), expired-stays-401 (no cascade), the `/refresh` 429, impersonation-not-rotated, persist-failure preserves session, and the registry lockstep regression in both backends.

## Verification (all green locally)
- BE: `go build ./...`, `go vet`, `go test ./apiserver ./services ./registry/memory` + an ephemeral-Postgres run of the lockstep test, `golangci-lint`/`nolintguard`/`qtlint` — **0 issues**.
- Codegen: swagger `@Description` + `go/docs` + `frontend/src/types/api.d.ts` regenerated; `devdocs/REFRESH_TOKEN_SYSTEM.md` updated.
- FE: `prettier --check` on `api.d.ts` clean; no FE type/shape break.

Reviewed by a 4-dimension adversarial brigade (Go correctness, security threat-model, test quality, FE/contract): **0 confirmed HIGH/MEDIUM**, 15 verified positives; the two LOW test nits it raised are fixed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refresh tokens now rotate automatically on each refresh.
  * Added rate limiting on refresh requests (60 per 15 minutes per IP).
  * Refresh-token theft detection automatically revokes all sessions when reuse is detected.

* **Documentation**
  * Updated authentication API documentation for refresh-token rotation and theft-detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->