### PR TITLE
docs: require user-facing changes to keep the user docs valid & complete

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,8 @@ Thanks for opening a PR. Follow project conventions documented in AGENTS.md.
 - [ ] `make test`
 - [ ] (frontend) `make test-frontend`
 - [ ] (frontend) `make test-e2e`
+
+## Documentation
+
+<!-- See "User-facing changes & documentation" in AGENTS.md. -->
+- [ ] I checked the user documentation: this PR leaves [`docs/site/`](docs/site) accurate and complete — or it has no user-facing impact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,27 @@ Match the mock exactly unless there is an explicit, recorded reason to diverge.
 - [`devdocs/frontend/design-deviations.md`](devdocs/frontend/design-deviations.md) — current deviation log (read before designing a surface; append after landing one).
 - [`design-mocks/src/views/UIShowcaseView.tsx`](design-mocks/src/views/UIShowcaseView.tsx) — UI primitive catalog (consult when the mock is silent).
 
+## User-facing changes & documentation
+
+The end-user documentation site lives in [`docs/site/`](docs/site) (Astro Starlight, published to GitHub Pages — see the "User documentation" section of [CONTRIBUTING.md](CONTRIBUTING.md)). Its pages are grounded in the real UI, with embedded screenshots.
+
+**Any user-facing change MUST keep that documentation valid and complete.** This is part of "done": a PR that ships a user-facing change but leaves the docs stale, wrong, or missing is not finished. Backend changes count too — if they alter behavior a user can observe, they are user-facing.
+
+A change is **user-facing** if it alters what a user sees or does, including:
+
+- New, changed, or removed UI: pages, dialogs, fields, buttons, menus, labels, flows, defaults, empty/error states users read.
+- Changed behavior, limits, or validation a user can hit (e.g. a field's max length, a required→optional field, a status lifecycle, a rate limit).
+- New or changed settings, preferences, CLI subcommands, or user-facing API behavior.
+
+When you make such a change:
+
+1. **Find the affected page(s)** under `docs/site/src/content/docs/` (e.g. `items.md`, `settings-and-account.md`, `backup-and-restore.md`). Search the docs for the feature, field name, label, or limit you touched.
+2. **Make the docs match reality** — fix now-false claims, add missing steps/fields for new behavior, update labels and limits, and confirm cross-links plus the splash card grid (`index.mdx`) still cover the feature. Verify every claim against the actual app, not from memory.
+3. **Refresh screenshots** when a documented surface changed visually. Use the [`screenshot-review`](.claude/skills/screenshot-review/SKILL.md) skill / `e2e/screenshots.mjs`, then replace the matching file under `docs/site/src/assets/screenshots/`.
+4. **Validate**: `cd docs/site && DOCS_VERSION=edge npm run build` succeeds (no broken links/images), and `markdownlint-cli2` run with no args (the CI invocation) reports zero errors.
+
+If a user-facing change genuinely has **no** documentation impact, say so explicitly in the PR rather than silently skipping the check. If a new feature is large enough to warrant its own page, add one and wire it into both the sidebar (`astro.config.mjs`) and the splash grid (`index.mdx`). Translations (`cs`/`ru`) are additive and fall back to English, so English is the bar that must always stay current.
+
 ## Key Patterns and Conventions
 
 ### Registry Pattern


### PR DESCRIPTION
## What

Two related changes that make "keep the user docs current" a standing requirement after the published docs site landed in #2146 / #2153:

1. **`AGENTS.md`** — adds a **"User-facing changes & documentation"** section: any user-facing change must keep the docs site (`docs/site/`) valid and complete as part of "done".
2. **`.github/pull_request_template.md`** — adds a **Documentation** checkbox surfacing that rule at PR time, with an explicit no-user-facing-impact escape hatch.

## Why

#2153 shipped the published user docs. Without a standing rule + a PR-time prompt, those pages drift the first time a field, label, limit, flow, or setting changes — exactly the staleness the #2153 self-review had to clean up after the fact (wrong currency-settings link, a non-implemented drag-and-drop claim, a `maxLength` mismatch, a screenshot on the wrong tab). This bakes the check into the workflow so it happens at change time.

## The rule (summary)

- Defines what counts as **user-facing** (UI, observable behavior/limits/validation, settings, CLI, user-facing API — backend included).
- On such a change: find the affected page(s) under `docs/site/src/content/docs/`, make claims/labels/limits match reality (verified against the app, not memory), refresh screenshots when a surface changed, and validate with `DOCS_VERSION=edge npm run build` + `markdownlint-cli2` (CI invocation).
- No doc impact must be stated, not skipped silently; new large features get their own page wired into the sidebar + splash grid. English is the bar (cs/ru fall back).

## Validation

- `markdownlint-cli2` (run the CI way, no args): 0 errors.
- Docs-only change (`AGENTS.md` + PR template); no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance on when changes are considered user-facing and what documentation updates are required.
  * Introduced a documentation verification workflow, including rebuilding the docs site and running markdown linting.
* **Process / Tooling**
  * Updated the pull request template with a dedicated checklist to confirm docs accuracy for each change.
* **Note**
  * No user-facing feature changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->