### PR TITLE
fix(deletes,uploads): close the last orphan-blob leaks (rejected upload, merge-restore, imported-export)

### DIFF
--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -402,6 +402,32 @@ func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Rea
 	if err != nil {
 		return "", 0, errxtrace.Wrap("failed to create a new writer", err)
 	}
+
+	// Track whether the save ran to completion. gocloud's Writer has no
+	// Abort: a rejected upload (invalid MIME type, oversize 413, mid-stream
+	// copy error) has already streamed some bytes, and the deferred
+	// fw.Close() below COMMITS them as a durable blob. With no owning file
+	// row (the handler aborts before creating one) that blob is an orphan
+	// that nothing will ever clean up (issue #2125).
+	saved := false
+
+	// Two defers run LIFO. The fw.Close() defer is registered LAST so it
+	// runs FIRST, committing whatever was written; this cleanup defer is
+	// registered FIRST so it runs AFTER Close, deleting the just-committed
+	// blob on the failure path (the bucket is still open — b.Close() is the
+	// outermost, earliest-registered defer, so it runs last of all).
+	defer func() {
+		if saved {
+			return
+		}
+		// Best-effort orphan cleanup. Swallow+log any delete error: a
+		// failure to remove the partial blob must never mask the real
+		// upload error the caller is about to render.
+		if delErr := b.Delete(ctx, filename); delErr != nil {
+			slog.WarnContext(ctx, "failed to delete partial upload blob after rejected upload (best-effort)",
+				"filename", filename, "error", delErr.Error())
+		}
+	}()
 	defer func() {
 		err = errors.Join(err, fw.Close())
 	}()
@@ -432,6 +458,7 @@ func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Rea
 		return "", 0, errxtrace.Wrap("failed when saving the file", err, errx.Attrs("filename", filename))
 	}
 
+	saved = true
 	return wrappedSrc.MIMEType(), written, nil
 }
 

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -403,21 +403,23 @@ func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Rea
 		return "", 0, errxtrace.Wrap("failed to create a new writer", err)
 	}
 
-	// Track whether the save ran to completion. gocloud's Writer has no
-	// Abort: a rejected upload (invalid MIME type, oversize 413, mid-stream
-	// copy error) has already streamed some bytes, and the deferred
-	// fw.Close() below COMMITS them as a durable blob. With no owning file
-	// row (the handler aborts before creating one) that blob is an orphan
-	// that nothing will ever clean up (issue #2125).
-	saved := false
-
-	// Two defers run LIFO. The fw.Close() defer is registered LAST so it
-	// runs FIRST, committing whatever was written; this cleanup defer is
-	// registered FIRST so it runs AFTER Close, deleting the just-committed
-	// blob on the failure path (the bucket is still open — b.Close() is the
-	// outermost, earliest-registered defer, so it runs last of all).
+	// gocloud's Writer has no Abort: a rejected upload (invalid MIME type,
+	// oversize 413, mid-stream copy error) has already streamed some bytes, and
+	// the deferred fw.Close() below COMMITS them as a durable blob. With no
+	// owning file row (the handler aborts before creating one) that blob is an
+	// orphan that nothing will ever clean up (issue #2125).
+	//
+	// Two defers run LIFO. The fw.Close() defer is registered LAST so it runs
+	// FIRST, folding its own result into err and committing whatever was
+	// written; this cleanup defer is registered FIRST so it runs AFTER Close,
+	// while the bucket is still open (b.Close() is the outermost,
+	// earliest-registered defer, so it runs last of all). Keying off the final
+	// err — not a "saved" flag set before Close — means the cleanup also covers
+	// the case where io.Copy succeeded but fw.Close() failed to commit: the
+	// caller sees an error and creates no row, so the committed-or-partial blob
+	// must still be removed.
 	defer func() {
-		if saved {
+		if err == nil {
 			return
 		}
 		// Best-effort orphan cleanup. Swallow+log any delete error: a
@@ -458,7 +460,6 @@ func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Rea
 		return "", 0, errxtrace.Wrap("failed when saving the file", err, errx.Attrs("filename", filename))
 	}
 
-	saved = true
 	return wrappedSrc.MIMEType(), written, nil
 }
 

--- a/go/apiserver/uploads_test.go
+++ b/go/apiserver/uploads_test.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -37,9 +38,13 @@ func countBucketKeys(c *qt.C, uploadLocation string) int {
 	iter := b.List(nil)
 	for {
 		obj, err := iter.Next(ctx)
-		if err != nil {
+		if err == io.EOF {
 			break
 		}
+		// A non-EOF error means the List itself failed; fail loudly rather than
+		// silently treating it as end-of-iteration, which would let a broken
+		// listing masquerade as an empty bucket and pass the orphan assertion.
+		c.Assert(err, qt.IsNil)
 		if obj.IsDir {
 			continue
 		}

--- a/go/apiserver/uploads_test.go
+++ b/go/apiserver/uploads_test.go
@@ -2,6 +2,7 @@ package apiserver_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"image"
 	"image/color"
@@ -9,17 +10,54 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
 
 	"github.com/denisvmedia/inventario/apiserver"
 	"github.com/denisvmedia/inventario/internal/backupsign"
 	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/inb"
 )
+
+// countBucketKeys returns the total number of blob keys in the bucket at
+// uploadLocation. Used by the orphan-blob regression tests to assert that a
+// rejected upload leaves the bucket exactly as it found it.
+func countBucketKeys(c *qt.C, uploadLocation string) int {
+	ctx := context.Background()
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+
+	count := 0
+	iter := b.List(nil)
+	for {
+		obj, err := iter.Next(ctx)
+		if err != nil {
+			break
+		}
+		if obj.IsDir {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// tempUploadLocation returns a file:// bucket URL backed by a fresh temp dir so
+// a test can enumerate every key without contaminating the package-shared
+// memfs bucket.
+func tempUploadLocation(c *qt.C) string {
+	tempDir := c.TempDir()
+	if runtime.GOOS == "windows" {
+		return "file:///" + tempDir + "?create_dir=1"
+	}
+	return "file://" + tempDir + "?create_dir=1"
+}
 
 // buildMinimalINB builds a tiny, validly-framed `.inb` container for upload
 // tests. The bytes are binary (sniffed as octet-stream, which the restore-upload
@@ -148,6 +186,100 @@ func TestUploads_restores_invalid(t *testing.T) {
 
 	// Verify the response - should be rejected due to invalid content type
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+// TestUploads_restores_invalid_noOrphanBlob is the #2125 regression: a restore
+// upload whose body fails MIME validation (the restore endpoint only accepts
+// signed `.inb` archives) must NOT leave a partially-written blob behind. The
+// MIME reader returns the sniffed bytes alongside ErrInvalidContentType, so
+// io.Copy has already streamed them into the writer; the deferred Close commits
+// them. Without the saveFile cleanup that commit is an orphan with no owning
+// file row. This test points the upload at a fresh temp bucket so it can
+// enumerate every key and assert the rejected upload left the bucket empty.
+func TestUploads_restores_invalid_noOrphanBlob(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	params.UploadLocation = tempUploadLocation(c)
+
+	// A fresh temp bucket starts empty.
+	c.Assert(countBucketKeys(c, params.UploadLocation), qt.Equals, 0)
+
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	// text/plain is rejected by the restore endpoint's INB-only guard.
+	h := CreateFormFileMIME("files", "not-a-backup.txt", "text/plain")
+	fileWriter, err := bodyWriter.CreatePart(h)
+	c.Assert(err, qt.IsNil)
+	_, err = fileWriter.Write([]byte("this is plainly not a signed .inb backup archive"))
+	c.Assert(err, qt.IsNil)
+	contentType := bodyWriter.FormDataContentType()
+	bodyWriter.Close()
+
+	req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/restores", bodyBuf)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", contentType)
+	addTestUserAuthHeader(req, testUser.ID)
+
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+
+	// The rejected upload left no orphan blob in the bucket.
+	c.Assert(countBucketKeys(c, params.UploadLocation), qt.Equals, 0)
+}
+
+// TestUploads_file_tooLarge_noOrphanBlob is the #2125 + #2101 regression: a
+// /uploads/file body that exceeds the per-file size cap is rejected with 413
+// AND leaves no orphan blob. The oversize error surfaces mid-stream after the
+// writer has already buffered/committed some bytes; the saveFile cleanup must
+// remove them. A fresh temp bucket lets the test enumerate every key.
+func TestUploads_file_tooLarge_noOrphanBlob(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	params.UploadLocation = tempUploadLocation(c)
+	params.MaxUploadBytes = 16 // tiny cap so a small JPEG trips it
+
+	c.Assert(countBucketKeys(c, params.UploadLocation), qt.Equals, 0)
+
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for x := range 64 {
+		for y := range 64 {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 128, A: 255})
+		}
+	}
+	var imgBuf bytes.Buffer
+	c.Assert(jpeg.Encode(&imgBuf, img, &jpeg.Options{Quality: 90}), qt.IsNil)
+	c.Assert(imgBuf.Len() > 16, qt.IsTrue)
+
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	h := CreateFormFileMIME("file", "big-photo.jpg", "image/jpeg")
+	fileWriter, err := bodyWriter.CreatePart(h)
+	c.Assert(err, qt.IsNil)
+	_, err = fileWriter.Write(imgBuf.Bytes())
+	c.Assert(err, qt.IsNil)
+	contentType := bodyWriter.FormDataContentType()
+	bodyWriter.Close()
+
+	req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/file", bodyBuf)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", contentType)
+	addTestUserAuthHeader(req, testUser.ID)
+
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusRequestEntityTooLarge, qt.Commentf("body=%s", rr.Body.String()))
+
+	// The rejected (oversize) upload left no orphan blob.
+	c.Assert(countBucketKeys(c, params.UploadLocation), qt.Equals, 0)
 }
 
 // TestUploads_file_tenantPrefixedKey is the #1793 regression test: a

--- a/go/backup/inb_orphan_blob_test.go
+++ b/go/backup/inb_orphan_blob_test.go
@@ -1,0 +1,150 @@
+//go:build !legacy_xml_backup
+
+package backup_test
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/backup/restore/types"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// attachCommodityFileAtKey is the divergent-key variant of attachCommodityFile:
+// it stores the blob under a caller-chosen OriginalPath that is NOT the canonical
+// BuildFileBlobKey(tenant, uuid, ext) shape (e.g. an upload-time basename key, or
+// a legacy flat key). The export streams from OriginalPath, but on restore the
+// importer always re-keys to the canonical t/<tenant>/files/<uuid><ext>. The two
+// keys therefore differ, which is exactly the condition under which the
+// merge-restore orphan-blob bug (#2125) is observable: a MergeAdd-skip would
+// otherwise write the canonical key with no row to clean it, and a MergeUpdate
+// would re-point the row to the canonical key and strand the old one.
+//
+// Returns the file UUID and the custom (source) blob key it was stored under.
+func (f *inbFixture) attachCommodityFileAtKey(c *qt.C, bucketMeta, customKey, ext, mime string, size int) (fileUUID, sourceKey string) {
+	comReg := must.Must(f.fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+	commodities := must.Must(comReg.List(f.ctx))
+	c.Assert(len(commodities) >= 1, qt.IsTrue)
+	com := commodities[0]
+
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	created := must.Must(fileReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Title:                    "photo",
+		Type:                     models.FileTypeFromMIME(mime),
+		Category:                 models.FileCategoryFromContext("commodity", bucketMeta, mime),
+		Tags:                     models.StringSlice{},
+		LinkedEntityType:         "commodity",
+		LinkedEntityID:           com.ID,
+		LinkedEntityMeta:         bucketMeta,
+		File: &models.File{
+			Path:      "photo",
+			Ext:       ext,
+			MIMEType:  mime,
+			SizeBytes: int64(size),
+		},
+	}))
+
+	// Point the row at the custom (non-canonical) key and write the blob there.
+	created.OriginalPath = customKey
+	must.Must(fileReg.Update(f.ctx, *created))
+
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+	body := bytes.Repeat([]byte("inventario-blob-chunk"), size/21+1)[:size]
+	c.Assert(bucket.WriteAll(f.ctx, customKey, body, nil), qt.IsNil)
+
+	return created.UUID, customKey
+}
+
+// blobExists is a small helper around bucket.Exists for the orphan-blob tests.
+func (f *inbFixture) blobExists(c *qt.C, key string) bool {
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+	return must.Must(bucket.Exists(f.ctx, key))
+}
+
+// TestINBRestore_MergeAddSkip_NoOrphanBlob is a #2125 regression: a MergeAdd
+// restore SKIPS files that already exist, but the `.inb` walker used to stream
+// the member bytes into a fresh canonical blob key BEFORE making the skip
+// decision — leaving a blob with no owning row. The fix decides skip first and
+// drains the bytes instead of writing them. Here the existing file's blob lives
+// under a custom (non-canonical) key, so the canonical key the broken walker
+// would have written is distinguishable: it must NOT exist after the skip.
+func TestINBRestore_MergeAddSkip_NoOrphanBlob(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	const size = 4096
+	customKey := "t/tenant-a/files/legacy-upload-basename.jpg"
+	fileUUID, srcKey := f.attachCommodityFileAtKey(c, "images", customKey, ".jpg", "image/jpeg", size)
+
+	blobKey, _ := f.runExport(c, signer)
+
+	// The canonical key the importer will compute for this file — the key the
+	// broken walker would orphan on skip.
+	canonicalKey := blobkeys.BuildFileBlobKey("tenant-a", fileUUID, ".jpg")
+	c.Assert(canonicalKey, qt.Not(qt.Equals), srcKey)
+	// Pre-condition: the canonical key does not exist yet (only the custom key does).
+	c.Assert(f.blobExists(c, canonicalKey), qt.IsFalse)
+
+	// Restore into the SAME factory with MergeAdd — the file already exists, so
+	// it is skipped.
+	final, err := restoreInbWithOptions(c, f, signer, blobKey, models.RestoreOptions{
+		Strategy: string(types.RestoreStrategyMergeAdd),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+
+	// The skip must NOT have written the canonical blob key — no orphan.
+	c.Assert(f.blobExists(c, canonicalKey), qt.IsFalse,
+		qt.Commentf("MergeAdd skip must not orphan a blob at the canonical key %s", canonicalKey))
+	// The existing file's original blob is untouched.
+	c.Assert(f.blobExists(c, srcKey), qt.IsTrue)
+}
+
+// TestINBRestore_MergeUpdate_DeletesStaleBlob is a #2125 regression: a
+// MergeUpdate restore re-points the existing file row to a freshly-computed
+// canonical blob key. When the existing row's blob lived under a different key
+// (an upload basename key, a different ext) the old blob used to dangle. The fix
+// best-effort deletes the superseded key after the row is re-pointed. Here the
+// existing blob is under a custom key; after the update the canonical key must
+// hold the bytes and the custom (stale) key must be gone.
+func TestINBRestore_MergeUpdate_DeletesStaleBlob(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	const size = 4096
+	customKey := "t/tenant-a/files/legacy-upload-basename.jpg"
+	fileUUID, srcKey := f.attachCommodityFileAtKey(c, "images", customKey, ".jpg", "image/jpeg", size)
+
+	blobKey, _ := f.runExport(c, signer)
+
+	canonicalKey := blobkeys.BuildFileBlobKey("tenant-a", fileUUID, ".jpg")
+	c.Assert(canonicalKey, qt.Not(qt.Equals), srcKey)
+
+	// Restore into the SAME factory with MergeUpdate — the file exists, so it is
+	// updated and re-pointed to the canonical key.
+	final, err := restoreInbWithOptions(c, f, signer, blobKey, models.RestoreOptions{
+		Strategy: string(types.RestoreStrategyMergeUpdate),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+
+	// The restored row points at the canonical key, and the bytes are there.
+	restored := f.fileByUUID(c, fileUUID)
+	c.Assert(restored.File, qt.IsNotNil)
+	c.Assert(restored.File.OriginalPath, qt.Equals, canonicalKey)
+	c.Assert(f.blobExists(c, canonicalKey), qt.IsTrue)
+
+	// The superseded (stale) blob must have been cleaned up — no dangling blob.
+	c.Assert(f.blobExists(c, srcKey), qt.IsFalse,
+		qt.Commentf("MergeUpdate must delete the superseded blob at the old key %s", srcKey))
+}

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path"
 	"sort"
@@ -618,6 +619,18 @@ func (w *inbWalker) handleFileMember(hdr *tar.Header, r io.Reader) error {
 		)
 	}
 
+	// Decide the create/update/skip action BEFORE streaming so a MergeAdd-skip
+	// never writes a blob that has no owning row to clean it up (issue #2125).
+	// The decision depends only on the strategy and whether the file already
+	// exists — both known here — so the bytes can be drained (skip) instead of
+	// committed to blobKey. This mirrors the legacy XML path's
+	// shouldWriteFileBlob guard, which already gates the blob write.
+	action := decideFileStrategyAction(w.options.Strategy, w.existing.Files[pending.ref.ID])
+
+	if action == fileActionSkip {
+		return w.skipFileMember(r, hdr.Size, blobKey)
+	}
+
 	written, err := w.streamFileBytes(blobKey, r, hdr.Size)
 	if err != nil {
 		return err
@@ -636,11 +649,64 @@ func (w *inbWalker) handleFileMember(hdr *tar.Header, r io.Reader) error {
 		fileEntity.GroupID = group.ID
 	}
 
+	// On update, capture the existing row's blob key so a superseded blob can be
+	// removed after the row is re-pointed (resolved before the row update so the
+	// old OriginalPath is still readable).
+	staleBlobKey := w.staleBlobKeyForUpdate(action, pending.ref.ID)
+
 	if err := w.proc.applyStrategyForFileModel(w.ctx, fileEntity, pending.ref.ID, w.stats, w.existing, w.idMapping, w.options); err != nil {
 		return err
 	}
+
+	w.deleteSupersededBlob(staleBlobKey, blobKey)
+
 	w.incBucketStat(pending.bucket)
 	return nil
+}
+
+// skipFileMember drains a file member's bytes (so the byte count still flows
+// into stats and the tar stream advances) WITHOUT writing them to the bucket,
+// for a MergeAdd-skip. This is what prevents the orphan blob a pre-decision
+// stream would leave behind (issue #2125).
+func (w *inbWalker) skipFileMember(r io.Reader, size int64, blobKey string) error {
+	drained, err := io.Copy(io.Discard, io.LimitReader(r, size))
+	if err != nil {
+		return errxtrace.Wrap("failed to drain skipped file member", err, errx.Attrs("blob_key", blobKey))
+	}
+	w.stats.BinaryDataSize += drained
+	w.stats.SkippedCount++
+	return nil
+}
+
+// staleBlobKeyForUpdate returns the existing row's blob key on a MergeUpdate so
+// it can be cleaned up after the row is re-pointed, or "" when there is nothing
+// to clean (not an update, or no existing blob). blobKey is deterministic from
+// the (tenant, file-UUID, ext) tuple, so it usually equals the existing key and
+// the bytes overwrite in place; but when the existing row stored a different key
+// (an upload-time basename key, a different ext) the old blob would dangle
+// without this (issue #2125).
+func (w *inbWalker) staleBlobKeyForUpdate(action fileAction, refID string) string {
+	if action != fileActionUpdate {
+		return ""
+	}
+	if existingFile := w.existing.Files[refID]; existingFile != nil && existingFile.File != nil {
+		return existingFile.File.OriginalPath
+	}
+	return ""
+}
+
+// deleteSupersededBlob best-effort removes the old blob after a MergeUpdate
+// re-pointed the row to newBlobKey. A no-op when the key is unchanged, empty, or
+// no bucket is configured. Swallow+log: a failed cleanup must never fail an
+// otherwise-successful restore (issue #2125).
+func (w *inbWalker) deleteSupersededBlob(staleBlobKey, newBlobKey string) {
+	if staleBlobKey == "" || staleBlobKey == newBlobKey || w.bucket == nil {
+		return
+	}
+	if err := w.bucket.Delete(w.ctx, staleBlobKey); err != nil {
+		slog.WarnContext(w.ctx, "failed to delete superseded file blob after merge-update restore (best-effort)",
+			"stale_blob_key", staleBlobKey, "new_blob_key", newBlobKey, "error", err.Error())
+	}
 }
 
 // streamFileBytes copies a file member's bytes into the destination blob key,

--- a/go/backup/restore/processor/processor_shared.go
+++ b/go/backup/restore/processor/processor_shared.go
@@ -772,8 +772,45 @@ func (l *RestoreOperationProcessor) ensureCommodityTags(ctx context.Context, com
 	return nil
 }
 
+// fileAction is the create/update/skip decision a restore strategy makes for a
+// single file, given whether the file already exists. It is the single source
+// of truth shared by the persistence step (applyStrategyForFileModel) and the
+// `.inb` walker's pre-stream gate, so the blob-write decision and the row-write
+// decision can never disagree (issue #2125).
+type fileAction int
+
+const (
+	fileActionCreate fileAction = iota
+	fileActionUpdate
+	fileActionSkip
+)
+
+// decideFileStrategyAction maps (strategy, existing-file) to the create/update/
+// skip action. existingFile is nil when no matching row is present. This is the
+// non-dry-run decision; dry-run is handled by the caller (the persist functions
+// short-circuit their writes, and the `.inb` walker drains bytes regardless).
+func decideFileStrategyAction(strategy types.RestoreStrategy, existingFile *models.FileEntity) fileAction {
+	switch strategy {
+	case types.RestoreStrategyMergeAdd:
+		if existingFile != nil {
+			return fileActionSkip
+		}
+		return fileActionCreate
+	case types.RestoreStrategyMergeUpdate:
+		if existingFile != nil {
+			return fileActionUpdate
+		}
+		return fileActionCreate
+	case types.RestoreStrategyFullReplace:
+		return fileActionCreate
+	}
+	return fileActionCreate
+}
+
 // applyStrategyForFileModel persists a decoded file row per strategy. The blob
-// bytes were already streamed to the bucket by the per-build decode pass.
+// bytes were already streamed to the bucket by the per-build decode pass (which
+// also gates the write on the same decideFileStrategyAction decision, so a
+// MergeAdd-skip never leaves an orphan blob behind — issue #2125).
 func (l *RestoreOperationProcessor) applyStrategyForFileModel(
 	ctx context.Context,
 	fileEntity *models.FileEntity,
@@ -785,20 +822,16 @@ func (l *RestoreOperationProcessor) applyStrategyForFileModel(
 ) error {
 	existingFile := existing.Files[originalID]
 
-	switch options.Strategy {
-	case types.RestoreStrategyFullReplace, types.RestoreStrategyMergeAdd:
-		if options.Strategy == types.RestoreStrategyMergeAdd && existingFile != nil {
-			stats.SkippedCount++
-			return nil
-		}
-		return l.createFile(ctx, fileEntity, originalID, stats, existing, idMapping, options)
-	case types.RestoreStrategyMergeUpdate:
-		if existingFile == nil {
-			return l.createFile(ctx, fileEntity, originalID, stats, existing, idMapping, options)
-		}
+	switch decideFileStrategyAction(options.Strategy, existingFile) {
+	case fileActionSkip:
+		stats.SkippedCount++
+		return nil
+	case fileActionUpdate:
 		fileEntity.SetID(existingFile.ID)
 		fileEntity.UUID = existingFile.UUID
 		return l.updateFile(ctx, fileEntity, originalID, stats, existing, options)
+	case fileActionCreate:
+		return l.createFile(ctx, fileEntity, originalID, stats, existing, idMapping, options)
 	}
 	return nil
 }

--- a/go/registry/memory/commodities.go
+++ b/go/registry/memory/commodities.go
@@ -235,6 +235,14 @@ func (r *CommodityRegistry) List(ctx context.Context) ([]*models.Commodity, erro
 	return commodities, nil
 }
 
+// Delete removes ONLY the commodity row (and untracks it from its parent
+// area's in-memory index). It does NOT delete the files linked to the commodity
+// or their physical blobs.
+//
+// INVARIANT (#2121): user-initiated commodity deletes MUST go through
+// services.EntityService.DeleteCommodityRecursive, which also removes the linked
+// files (row + best-effort blob). See the postgres twin for the full rationale;
+// the two backends behave identically.
 func (r *CommodityRegistry) Delete(ctx context.Context, id string) error {
 	// Pre-fetch so we know the parent area to untrack once the row is gone.
 	commodity, err := r.Registry.Get(ctx, id)

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -615,6 +615,19 @@ func clonePtrCurrency(c *models.Currency) *models.Currency {
 	return &cp
 }
 
+// Delete removes ONLY the commodity row. Its DB children (loans, services,
+// supply-links) CASCADE and cover_file_id is ON DELETE SET NULL, so the row
+// delete itself is FK-safe — but the files LINKED to the commodity
+// (linked_entity_type='commodity') are NOT cascaded, and their physical blobs
+// are not touched here.
+//
+// INVARIANT (#2121): user-initiated commodity deletes MUST go through
+// services.EntityService.DeleteCommodityRecursive, which collects the linked
+// file IDs, drops this row, and then removes each linked file (row + best-effort
+// blob) via FileService.DeleteFileWithPhysical. Calling this bare row delete
+// directly leaves every linked file's blob orphaned in the bucket. The only
+// legitimate direct callers are tests and the group/tenant purgers, which sweep
+// all of the (tenant, group)'s blobs separately before dropping rows.
 func (r *CommodityRegistry) Delete(ctx context.Context, id string) error {
 	reg := r.newSQLRegistry()
 	err := reg.Delete(ctx, id, nil)

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -138,6 +138,18 @@ func (r *FileRegistry) Update(ctx context.Context, file models.FileEntity) (*mod
 	return &file, nil
 }
 
+// Delete removes ONLY the file row. It does NOT touch the physical blob or its
+// thumbnails, and it does NOT break the thumbnail_generation_jobs FK chain.
+//
+// INVARIANT (#2121): user-initiated file deletes MUST go through
+// services.FileService.DeleteFileWithPhysical, which deletes the thumbnail-job
+// chain, deletes this row, and then best-effort removes the blob + thumbnails.
+// Calling this method directly orphans the physical blob (the bytes stay in the
+// bucket with no row pointing at them). The only legitimate callers of the bare
+// row delete are flows that delete the blobs separately and in bulk — e.g. the
+// group/tenant purgers, which sweep every blob for the (tenant, group) up front
+// via FileService.DeletePhysicalFilesForGroup / ...ForTenant before dropping the
+// rows. New code that deletes a user's file should not call this.
 func (r *FileRegistry) Delete(ctx context.Context, id string) error {
 	reg := r.newSQLRegistry()
 	err := reg.Delete(ctx, id, nil)

--- a/go/services/entity_service.go
+++ b/go/services/entity_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
@@ -350,6 +351,19 @@ func (s *EntityService) DeleteExportWithFile(ctx context.Context, id string) err
 		fileIDToDelete = export.FileID
 	}
 
+	// An imported export carries its uploaded source `.inb` blob under
+	// FilePath until import processing promotes it into a FileEntity row and
+	// sets FileID (#2121). While the export is still pending (FileID == nil)
+	// that blob has no owning file row, so neither the single-file delete here
+	// nor the group sweep (which iterates `files` rows) would ever clean it up
+	// — deleting such an export would leak the source blob permanently. When
+	// there is no linked FileID, remember FilePath so it can be cleaned up
+	// after the row delete.
+	var sourceBlobToDelete string
+	if fileIDToDelete == nil && export.FilePath != "" {
+		sourceBlobToDelete = export.FilePath
+	}
+
 	// Delete the export first to avoid foreign key constraint violation
 	err = expReg.Delete(ctx, id)
 	if err != nil {
@@ -361,6 +375,17 @@ func (s *EntityService) DeleteExportWithFile(ctx context.Context, id string) err
 		err = s.fileService.DeleteFileWithPhysical(ctx, *fileIDToDelete)
 		if err != nil && !errors.Is(err, registry.ErrNotFound) {
 			return errxtrace.Wrap("failed to delete export file", err)
+		}
+	}
+
+	// Best-effort clean up the orphaned source blob of a pending imported
+	// export. Swallow+log: the export row is already gone, so a failed blob
+	// delete must not resurrect an error for a successful logical delete (the
+	// same row-first / blob-best-effort contract as DeleteFileWithPhysical).
+	if sourceBlobToDelete != "" {
+		if delErr := s.fileService.DeletePhysicalFile(ctx, sourceBlobToDelete); delErr != nil {
+			slog.WarnContext(ctx, "failed to delete pending imported-export source blob (best-effort)",
+				"export_id", id, "source_blob_key", sourceBlobToDelete, "error", delErr.Error())
 		}
 	}
 

--- a/go/services/entity_service_test.go
+++ b/go/services/entity_service_test.go
@@ -496,6 +496,52 @@ func TestEntityService_DeleteExportWithFile(t *testing.T) {
 	}
 }
 
+// TestEntityService_DeleteExport_CleansPendingImportSourceBlob is the #2121
+// regression: an imported export carries its uploaded source `.inb` blob under
+// FilePath until import processing promotes it into a FileEntity (FileID). While
+// the export is still pending (FileID == nil) that blob has no owning file row,
+// so neither the single-file delete nor the group/tenant file sweep (both
+// iterate `files` rows) would ever clean it up. Deleting such an export must
+// best-effort remove its source blob so it doesn't leak permanently.
+func TestEntityService_DeleteExport_CleansPendingImportSourceBlob(t *testing.T) {
+	c := qt.New(t)
+
+	tempDir := c.TempDir()
+	uploadLocation := uploadLocationForTempDir(tempDir)
+
+	factorySet := memory.NewFactorySet()
+	ctx := newTestContext(factorySet)
+	registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+	service := services.NewEntityService(factorySet, uploadLocation)
+
+	// Write the uploaded source blob a pending imported export would point at.
+	sourceKey := "t/test-tenant/restores/uploaded-backup.inb"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, sourceKey, []byte("signed-inb-bytes"), nil), qt.IsNil)
+	c.Assert(must.Must(b.Exists(ctx, sourceKey)), qt.IsTrue)
+
+	// A pending imported export: FilePath set, FileID still nil.
+	export := must.Must(registrySet.ExportRegistry.Create(ctx, models.Export{
+		Type:        models.ExportTypeImported,
+		Status:      models.ExportStatusPending,
+		Description: "Pending import",
+		FilePath:    sourceKey,
+		Imported:    true,
+	}))
+
+	c.Assert(service.DeleteExportWithFile(ctx, export.ID), qt.IsNil)
+
+	// The export row is gone…
+	_, err := registrySet.ExportRegistry.Get(ctx, export.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// …and its orphaned source blob was cleaned up, not leaked.
+	c.Assert(must.Must(b.Exists(ctx, sourceKey)), qt.IsFalse,
+		qt.Commentf("pending imported-export source blob %s must not leak", sourceKey))
+}
+
 // TestDeleteFileWithPhysical_DeletesThumbnailJob asserts the #2117 cleanup
 // order: deleting a file also removes the thumbnail-generation job that
 // references it and the concurrency slot that references that job, so the


### PR DESCRIPTION
## What

Finishes the **"no data loss"** delete-path class from the #2087 code audit — the orphan-blob leaks left after the delete-ordering fixes already shipped in #2138 / #2158.

**Closes #2121 · Closes #2125**

The audit (2026-06-20) predates #2138/#2151/#2158, so each finding was re-verified against current code; the already-fixed ones were dropped. No schema migration.

## Fixes (genuinely-still-broken findings only)

### #2125 — upload/restore orphan blobs
- **Rejected upload** (`apiserver/uploads.go` `saveFile`): gocloud's `blob.Writer` has no `Abort`, so the deferred `fw.Close()` *commits* whatever bytes were streamed before a rejection (invalid MIME via `mimekit.ErrInvalidContentType`, oversize 413, or any mid-stream copy error) — and the handler aborts before creating an owning `files` row, so the blob is a permanent orphan. Now a LIFO cleanup defer best-effort `Delete`s the blob on the failure path (registered before the `fw.Close()` defer so it runs *after* the commit; swallow+log so cleanup never masks the real error). A `saved` flag suppresses cleanup on success. Covers both `/uploads/file` and `/uploads/restores`.
- **Merge-restore** (`backup/restore/processor/*`): bytes were streamed into a fresh UUID key *before* the create/update/skip decision → `MergeAdd`-skip orphaned the just-written blob and `MergeUpdate` left the old blob dangling, so storage grew on every repeated merge-restore. Now a single shared `decideFileStrategyAction` drives both the stream decision and `applyStrategyForFileModel`: skip drains to `io.Discard` (no write), update captures the stale key before the row re-point and best-effort deletes the superseded blob after.

### #2121 — delete-path robustness
- **Imported-export source-blob leak** (`services/entity_service.go` `DeleteExportWithFile`): a `pending` imported export has `FileID=nil`, so its uploaded source blob (`export.FilePath`) was invisible to both single-delete and the group sweep (which iterate `files` rows only). Now best-effort cleaned when the export is deleted.
- **Bare registry deletes** (`registry/postgres/{files,commodities}.go`, `registry/memory/commodities.go`): documented the invariant that `Delete` is a bare row-delete that does **not** touch blobs, and that user-initiated deletes must go through `FileService.DeleteFileWithPhysical` / `DeleteCommodityRecursive`. Call-site audit confirms the only prod callers already do (the bare calls are test-only).

### Verified already-fixed → dropped
- Blob-before-row in `DeleteFileWithPhysical` — fixed by #2117/#2138 (now row-first / blob-best-effort).
- Non-atomic `DeleteArea` / `DeleteLocationRecursive` — fixed by #2120/#2138 (row-first, enclosing tx).
- `RestoreOperation.Delete` is already atomic (children deleted in the same tx callback); **no collision with the in-flight #2164**, which touches `ListByExport`, not `Delete`.

## Tests
New regression tests (`apiserver/uploads_test.go`, `services/entity_service_test.go`, `backup/inb_orphan_blob_test.go`), each confirmed to **fail without its fix** (orphan/stale blob = 1, want 0) and pass with it. They run on a memory/`file://` bucket the test inspects directly — the orphan behavior is blob-layer + apiserver/processor and registry-backend-independent, so no postgres DSN is required.

## Verification (all green locally)
`go build ./...` (default + `legacy_xml_backup`), `go vet`, `golangci-lint run`, `qtlint`, `nolintguard`, `go test ./apiserver/... ./services/... ./backup/... ./registry/memory/...`; postgres-gated suites compile. No migration (`migrations --check` in sync).

---
With this PR + the in-flight #2164 (#2118/#2123/#2130), the entire 🟠 data-lifecycle bucket of #2087 closes. Part of #2087.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Failed uploads no longer leave orphaned partial files in storage
  * Restore operations now properly clean up outdated files during updates
  * Deleting pending imports now removes associated orphaned source files

* **Tests**
  * Added regression tests for upload failure cleanup
  * Added regression tests for restore file cleanup
  * Added regression test for pending import cleanup

* **Documentation**
  * Clarified file deletion behavior across the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->