### PR TITLE
feat(cli): wire the real users update command (#2105)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ The system implements enterprise-grade multi-tenancy with:
 - `./inventario users create` - Create users for initial setup
 - `./inventario users list` - List all users with filtering
 - `./inventario users get <id-or-email>` - Get detailed user information
-- `./inventario users update <id-or-email>` - **Not yet implemented** (placeholder; prints a message and exits without changes)
+- `./inventario users update <id-or-email>` - Update user-row fields (email, name, active status, tenant, password); only the flags you pass are changed
 - `./inventario users delete <id-or-email>` - Delete users with confirmation
 - For PostgreSQL: Set POSTGRES_TEST_DSN environment variable for testing
 

--- a/README.md
+++ b/README.md
@@ -160,18 +160,25 @@ Complete CRUD (Create, Read, Update, Delete) operations for users and tenants:
 # Get detailed user information
 ./inventario users get admin@acme.com
 
+# Update a user (only the flags you pass are changed)
+./inventario users update admin@acme.com --name="New Name"
+./inventario users update admin@acme.com --active=false      # block / deactivate
+./inventario users update admin@acme.com --password          # prompts securely
+
 # Delete user with confirmation
 ./inventario users delete admin@acme.com
 
 # Preview operations without making changes
 ./inventario users create --dry-run --email="test@example.com" --tenant="acme"
+./inventario users update admin@acme.com --name="New Name" --dry-run
 ./inventario users delete admin@acme.com --dry-run
 ```
 
-> **Note:** `users update` is **not yet implemented** — the command currently
-> prints a placeholder message and exits 0 without modifying anything. To grant
-> platform-wide system-admin privileges, use `admin grant-system-admin` (see
-> [System Administrators](#system-administrators) below).
+> **Note:** `users update` changes user-row fields only (email, name, active
+> status, tenant, password). To grant platform-wide system-admin privileges,
+> use `admin grant-system-admin` (see
+> [System Administrators](#system-administrators) below) — that privilege is
+> not a user-row field.
 
 **Important**: User and tenant commands only work with PostgreSQL databases. Memory databases are not supported for persistent operations.
 
@@ -245,7 +252,7 @@ canonical worker types, the equivalent admin REST API, and the
 - `create`: Create new users with secure password input and validation
 - `list`: List users with filtering by tenant, active status, and search
 - `get`: Get detailed user information including tenant details
-- `update`: Not yet implemented (placeholder — exits without modifying anything)
+- `update`: Update user-row fields (email, name, active status, tenant, password); only the flags you pass are changed
 - `delete`: Delete users with confirmation prompts
 
 **Common Flags:**

--- a/go/cmd/inventario/db/drop/drop.go
+++ b/go/cmd/inventario/db/drop/drop.go
@@ -63,7 +63,7 @@ func (c *Command) migrateDrop(cfg *Config, dbConfig *shared.DatabaseConfig) erro
 	migr := migrator.New(dsn, fstest.MapFS{})
 
 	fmt.Println("=== MIGRATE DROP ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	fmt.Println()
 
 	return migr.DropDatabase(context.Background(), dryRun, confirm)

--- a/go/cmd/inventario/db/migrate/data/data.go
+++ b/go/cmd/inventario/db/migrate/data/data.go
@@ -107,7 +107,7 @@ func (c *Command) setupData(cfg *Config, dbConfig *shared.DatabaseConfig) error 
 	}
 
 	fmt.Println("=== INITIAL DATASET SETUP ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	if cfg.DryRun {
 		fmt.Println("Mode: DRY RUN (no changes will be made)")
 	} else {

--- a/go/cmd/inventario/db/migrate/down/down.go
+++ b/go/cmd/inventario/db/migrate/down/down.go
@@ -66,7 +66,7 @@ func (c *Command) migrateDown(cfg *Config, dbConfig *shared.DatabaseConfig, targ
 	migr := migrator.NewWithFallback(dsn, c.config.MigrationsDir)
 
 	fmt.Println("=== MIGRATE DOWN ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	fmt.Printf("Target version: %d\n", targetVersion)
 	fmt.Println()
 

--- a/go/cmd/inventario/db/migrate/up/up.go
+++ b/go/cmd/inventario/db/migrate/up/up.go
@@ -56,7 +56,7 @@ func (c *Command) migrateUp(cfg *Config, dbConfig *shared.DatabaseConfig) error 
 	migr := migrator.NewWithFallback(dsn, c.config.MigrationsDir)
 
 	fmt.Println("=== MIGRATE UP ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	fmt.Println()
 
 	migratorArgs := migrator.Args{

--- a/go/cmd/inventario/db/reset/reset.go
+++ b/go/cmd/inventario/db/reset/reset.go
@@ -63,7 +63,7 @@ func (c *Command) migrateReset(cfg *Config, dbConfig *shared.DatabaseConfig) err
 	migr := migrator.NewWithFallback(dsn, c.config.MigrationsDir)
 
 	fmt.Println("=== MIGRATE RESET ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	fmt.Println()
 
 	migratorArgs := migrator.Args{

--- a/go/cmd/inventario/shared/dsn.go
+++ b/go/cmd/inventario/shared/dsn.go
@@ -1,0 +1,28 @@
+package shared
+
+import "net/url"
+
+// RedactDSN masks the password embedded in a database DSN so credentials never
+// leak into terminal history, CI logs, or screen-shared sessions. The username,
+// host, database, and query parameters are preserved to keep diagnostic banners
+// useful for troubleshooting; only the password component of the userinfo is
+// replaced.
+//
+// If the DSN parses as a URL with a password, that password is masked. If it
+// parses but carries no password, it is returned unchanged. If it does not parse
+// as a URL at all, a safe placeholder is returned rather than echoing the raw
+// value — a malformed DSN may still embed credentials we cannot reliably locate.
+func RedactDSN(dsn string) string {
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return "<redacted>"
+	}
+	if parsed.User == nil {
+		return dsn
+	}
+	if _, hasPassword := parsed.User.Password(); !hasPassword {
+		return dsn
+	}
+	parsed.User = url.UserPassword(parsed.User.Username(), "xxxxxx")
+	return parsed.String()
+}

--- a/go/cmd/inventario/shared/dsn_test.go
+++ b/go/cmd/inventario/shared/dsn_test.go
@@ -1,0 +1,56 @@
+package shared_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+)
+
+func TestRedactDSN_MasksPassword(t *testing.T) {
+	c := qt.New(t)
+
+	got := shared.RedactDSN("postgres://user:s3cr3t@localhost:5432/inventario?sslmode=disable")
+
+	c.Assert(got, qt.Equals, "postgres://user:xxxxxx@localhost:5432/inventario?sslmode=disable")
+}
+
+func TestRedactDSN_PreservesUsernameHostAndParams(t *testing.T) {
+	c := qt.New(t)
+
+	got := shared.RedactDSN("postgresql://admin:hunter2@db.internal:6543/app?pool_max_conns=10")
+
+	c.Assert(got, qt.Contains, "admin")
+	c.Assert(got, qt.Contains, "db.internal:6543")
+	c.Assert(got, qt.Contains, "/app")
+	c.Assert(got, qt.Contains, "pool_max_conns=10")
+	c.Assert(got, qt.Not(qt.Contains), "hunter2")
+}
+
+func TestRedactDSN_NoPasswordReturnedUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	dsn := "postgres://user@localhost/inventario"
+
+	c.Assert(shared.RedactDSN(dsn), qt.Equals, dsn)
+}
+
+func TestRedactDSN_NoUserinfoReturnedUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	dsn := "memory://"
+
+	c.Assert(shared.RedactDSN(dsn), qt.Equals, dsn)
+}
+
+func TestRedactDSN_UnparseableNeverEchoesRaw(t *testing.T) {
+	c := qt.New(t)
+
+	// A control character makes url.Parse fail; the raw value (which could embed
+	// credentials) must not be echoed back.
+	got := shared.RedactDSN("postgres://user:s3cr3t@localhost/db\x7f")
+
+	c.Assert(got, qt.Equals, "<redacted>")
+	c.Assert(got, qt.Not(qt.Contains), "s3cr3t")
+}

--- a/go/cmd/inventario/tenants/deletecmd/deletecmd.go
+++ b/go/cmd/inventario/tenants/deletecmd/deletecmd.go
@@ -98,7 +98,7 @@ func (c *Command) deleteTenant(cfg *Config, dbConfig *shared.DatabaseConfig, idO
 	}
 
 	fmt.Println("=== DELETE TENANT ===")
-	fmt.Printf("Database: %s\n", dbConfig.DBDSN)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dbConfig.DBDSN))
 	fmt.Printf("Target: %s\n", idOrSlug)
 	if cfg.DryRun {
 		fmt.Println("Mode: DRY RUN (no changes will be made)")

--- a/go/cmd/inventario/users/deletecmd/deletecmd.go
+++ b/go/cmd/inventario/users/deletecmd/deletecmd.go
@@ -94,7 +94,7 @@ func (c *Command) deleteUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	}
 
 	fmt.Fprintln(out, "=== DELETE USER ===")
-	fmt.Fprintf(out, "Database: %s\n", dbConfig.DBDSN)
+	fmt.Fprintf(out, "Database: %s\n", shared.RedactDSN(dbConfig.DBDSN))
 	fmt.Fprintf(out, "Target: %s\n", idOrEmail)
 	if cfg.DryRun {
 		fmt.Fprintln(out, "Mode: DRY RUN (no changes will be made)")

--- a/go/cmd/inventario/users/mfareset/mfareset.go
+++ b/go/cmd/inventario/users/mfareset/mfareset.go
@@ -92,7 +92,7 @@ func (c *Command) resetMFA(cfg *Config, dbConfig *shared.DatabaseConfig, idOrEma
 	}
 
 	fmt.Fprintln(out, "=== RESET USER MFA ===")
-	fmt.Fprintf(out, "Database: %s\n", dbConfig.DBDSN)
+	fmt.Fprintf(out, "Database: %s\n", shared.RedactDSN(dbConfig.DBDSN))
 	fmt.Fprintf(out, "Target: %s\n", idOrEmail)
 	if cfg.DryRun {
 		fmt.Fprintln(out, "Mode: DRY RUN (no changes will be made)")

--- a/go/cmd/inventario/users/update/config.go
+++ b/go/cmd/inventario/users/update/config.go
@@ -2,11 +2,12 @@ package update
 
 // Config holds configuration for user update command
 type Config struct {
-	// User fields to update
+	// User fields to update. Empty / unset values are left unchanged; the
+	// command tracks which flags were explicitly provided (see update.go) so
+	// that an unset flag never overwrites an existing column.
 	Email    string `yaml:"email" env:"USER_EMAIL" env-default:""`
 	Name     string `yaml:"name" env:"USER_NAME" env-default:""`
-	Role     string `yaml:"role" env:"USER_ROLE" env-default:""`
-	Active   string `yaml:"active" env:"USER_ACTIVE" env-default:""`
+	Active   bool   `yaml:"active" env:"USER_ACTIVE" env-default:"true"`
 	Tenant   string `yaml:"tenant" env:"USER_TENANT" env-default:""`
 	Password bool   `yaml:"password" env:"USER_PASSWORD" env-default:"false"`
 

--- a/go/cmd/inventario/users/update/config.go
+++ b/go/cmd/inventario/users/update/config.go
@@ -12,6 +12,5 @@ type Config struct {
 	Password bool   `yaml:"password" env:"USER_PASSWORD" env-default:"false"`
 
 	// Command options
-	DryRun      bool `yaml:"dry_run" env:"DRY_RUN" env-default:"false"`
-	Interactive bool `yaml:"interactive" env:"INTERACTIVE" env-default:"false"`
+	DryRun bool `yaml:"dry_run" env:"DRY_RUN" env-default:"false"`
 }

--- a/go/cmd/inventario/users/update/update.go
+++ b/go/cmd/inventario/users/update/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 
@@ -118,7 +117,7 @@ func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	}()
 
 	fmt.Fprintln(out, "=== UPDATE USER ===")
-	fmt.Fprintf(out, "Database: %s\n", redactDSN(dbConfig.DBDSN))
+	fmt.Fprintf(out, "Database: %s\n", shared.RedactDSN(dbConfig.DBDSN))
 	fmt.Fprintf(out, "Target: %s\n", idOrEmail)
 	if cfg.DryRun {
 		fmt.Fprintln(out, "Mode: DRY RUN (no changes will be made)")
@@ -277,23 +276,6 @@ func printCrossTenantWarning(out io.Writer) {
 	fmt.Fprintln(out, "    stay in the original tenant and will become inaccessible to them.")
 	fmt.Fprintln(out, "    See https://github.com/denisvmedia/inventario/issues/2179")
 	fmt.Fprintln(out)
-}
-
-// redactDSN masks the password embedded in a database DSN so credentials never
-// leak into terminal history or CI logs. The username is preserved to keep the
-// banner useful for troubleshooting; if the DSN can't be parsed or carries no
-// userinfo, it is returned unchanged (non-postgres DSNs reach here only in the
-// memory:// case, which is rejected earlier).
-func redactDSN(dsn string) string {
-	parsed, err := url.Parse(dsn)
-	if err != nil || parsed.User == nil {
-		return dsn
-	}
-	if _, hasPassword := parsed.User.Password(); !hasPassword {
-		return dsn
-	}
-	parsed.User = url.UserPassword(parsed.User.Username(), "xxxxxx")
-	return parsed.String()
 }
 
 // printUserInfo prints user information in a formatted way

--- a/go/cmd/inventario/users/update/update.go
+++ b/go/cmd/inventario/users/update/update.go
@@ -196,6 +196,9 @@ func (c *Command) buildUpdateRequest(cfg *Config, adminService *admin.Service) (
 
 	if flags.Changed("email") {
 		email := strings.TrimSpace(cfg.Email)
+		if email == "" {
+			return admin.UserUpdateRequest{}, nil, fmt.Errorf("--email cannot be empty or whitespace-only")
+		}
 		req.Email = &email
 		changes = append(changes, fmt.Sprintf("email → %s", email))
 	}

--- a/go/cmd/inventario/users/update/update.go
+++ b/go/cmd/inventario/users/update/update.go
@@ -3,6 +3,8 @@ package update
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -83,9 +85,6 @@ func (c *Command) registerFlags() {
 	c.Cmd().Flags().BoolVar(&c.config.Active, "active", c.config.Active, "Whether the user is active")
 	c.Cmd().Flags().StringVar(&c.config.Tenant, "tenant", c.config.Tenant, "New tenant ID or slug")
 	c.Cmd().Flags().BoolVar(&c.config.Password, "password", c.config.Password, "Change the password (prompted securely)")
-
-	// Command behavior flags
-	c.Cmd().Flags().BoolVar(&c.config.Interactive, "interactive", c.config.Interactive, "Enable interactive prompts")
 }
 
 // updateUser handles the user update process
@@ -119,7 +118,7 @@ func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	}()
 
 	fmt.Fprintln(out, "=== UPDATE USER ===")
-	fmt.Fprintf(out, "Database: %s\n", dbConfig.DBDSN)
+	fmt.Fprintf(out, "Database: %s\n", redactDSN(dbConfig.DBDSN))
 	fmt.Fprintf(out, "Target: %s\n", idOrEmail)
 	if cfg.DryRun {
 		fmt.Fprintln(out, "Mode: DRY RUN (no changes will be made)")
@@ -160,6 +159,14 @@ func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	}
 	fmt.Fprintln(out)
 
+	// Loudly warn about the partial nature of a cross-tenant move: only the
+	// users row is reassigned, so the user's content and group memberships stay
+	// behind and become inaccessible. Printed for both dry-run and live runs so
+	// the operator sees it before deciding to proceed.
+	if c.Cmd().Flags().Changed("tenant") {
+		printCrossTenantWarning(out)
+	}
+
 	// Handle dry run
 	if cfg.DryRun {
 		fmt.Fprintln(out, "💡 This is a dry run. To perform the actual update, run the command without --dry-run")
@@ -195,7 +202,10 @@ func (c *Command) buildUpdateRequest(cfg *Config, adminService *admin.Service) (
 	}
 
 	if flags.Changed("name") {
-		name := cfg.Name
+		name := strings.TrimSpace(cfg.Name)
+		if name == "" {
+			return admin.UserUpdateRequest{}, nil, fmt.Errorf("--name cannot be empty or whitespace-only")
+		}
 		req.Name = &name
 		changes = append(changes, fmt.Sprintf("name → %s", name))
 	}
@@ -257,6 +267,33 @@ func (c *Command) collectPassword() (string, error) {
 		return "", fmt.Errorf("unexpected type returned from password field")
 	}
 	return passwordStr, nil
+}
+
+// printCrossTenantWarning emits a prominent warning that a --tenant move only
+// reassigns the users row, leaving the user's content and memberships behind.
+func printCrossTenantWarning(out io.Writer) {
+	fmt.Fprintln(out, "⚠️  WARNING: --tenant moves only the users row. The user's existing content")
+	fmt.Fprintln(out, "    (commodities, files, areas, locations, exports, tags) and group memberships")
+	fmt.Fprintln(out, "    stay in the original tenant and will become inaccessible to them.")
+	fmt.Fprintln(out, "    See https://github.com/denisvmedia/inventario/issues/2179")
+	fmt.Fprintln(out)
+}
+
+// redactDSN masks the password embedded in a database DSN so credentials never
+// leak into terminal history or CI logs. The username is preserved to keep the
+// banner useful for troubleshooting; if the DSN can't be parsed or carries no
+// userinfo, it is returned unchanged (non-postgres DSNs reach here only in the
+// memory:// case, which is rejected earlier).
+func redactDSN(dsn string) string {
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.User == nil {
+		return dsn
+	}
+	if _, hasPassword := parsed.User.Password(); !hasPassword {
+		return dsn
+	}
+	parsed.User = url.UserPassword(parsed.User.Username(), "xxxxxx")
+	return parsed.String()
 }
 
 // printUserInfo prints user information in a formatted way

--- a/go/cmd/inventario/users/update/update.go
+++ b/go/cmd/inventario/users/update/update.go
@@ -3,11 +3,15 @@ package update
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/internal/input"
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/services/admin"
 )
 
@@ -30,30 +34,78 @@ func New(dbConfig *shared.DatabaseConfig) *Command {
 		Short: "Update an existing user",
 		Long: `Update an existing user in the system.
 
-This command allows you to update user information such as email, name, role,
-active status, tenant assignment, and password.
+This command allows you to update user information such as email, name,
+active status, tenant assignment, and password. Only the fields you pass as
+flags are changed; any flag you omit leaves the corresponding column
+untouched.
+
+To grant or revoke platform-wide system-admin privileges use
+'inventario admin grant-system-admin' / 'revoke-system-admin' instead — that
+privilege lives in a dedicated table, not on the user row.
+
+IMPORTANT: This command ONLY supports PostgreSQL databases. Memory databases
+are not supported for persistent user operations.
 
 Examples:
-  # Interactive mode
-  inventario users update user@example.com
+  # Update the display name
+  inventario users update user@example.com --name="New Name"
 
-  # With flags
-  inventario users update user@example.com --name="New Name" --role=admin
+  # Deactivate (block) a user
+  inventario users update user@example.com --active=false
+
+  # Change the password (prompted securely)
+  inventario users update user@example.com --password
+
+  # Move the user to a different tenant
+  inventario users update user@example.com --tenant=acme
 
   # Dry run to preview changes
   inventario users update user@example.com --name="New Name" --dry-run`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return c.updateUser(&c.config, dbConfig, args[0])
 		},
 	})
 
+	c.registerFlags()
+
 	return c
+}
+
+func (c *Command) registerFlags() {
+	// Dry run flag
+	shared.RegisterDryRunFlag(c.Cmd(), &c.config.DryRun)
+
+	// User configuration flags. Use cmd.Flags().Changed(<name>) at run time to
+	// decide which of these to apply, so an unset flag never overwrites a value.
+	c.Cmd().Flags().StringVar(&c.config.Email, "email", c.config.Email, "New email address")
+	c.Cmd().Flags().StringVar(&c.config.Name, "name", c.config.Name, "New display name")
+	c.Cmd().Flags().BoolVar(&c.config.Active, "active", c.config.Active, "Whether the user is active")
+	c.Cmd().Flags().StringVar(&c.config.Tenant, "tenant", c.config.Tenant, "New tenant ID or slug")
+	c.Cmd().Flags().BoolVar(&c.config.Password, "password", c.config.Password, "Change the password (prompted securely)")
+
+	// Command behavior flags
+	c.Cmd().Flags().BoolVar(&c.config.Interactive, "interactive", c.config.Interactive, "Enable interactive prompts")
 }
 
 // updateUser handles the user update process
 func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrEmail string) error {
 	out := c.Cmd().OutOrStdout()
+
+	// Validate database configuration
+	if err := dbConfig.Validate(); err != nil {
+		return fmt.Errorf("database configuration error: %w", err)
+	}
+
+	// Check if this is a memory database and reject it
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return fmt.Errorf("user update is not supported for memory databases as they don't provide persistence. Please use a PostgreSQL database")
+	}
+
+	// Validate input
+	if strings.TrimSpace(idOrEmail) == "" {
+		return fmt.Errorf("user ID or email is required")
+	}
 
 	// Create admin service
 	adminService, err := admin.NewService(dbConfig)
@@ -67,6 +119,7 @@ func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	}()
 
 	fmt.Fprintln(out, "=== UPDATE USER ===")
+	fmt.Fprintf(out, "Database: %s\n", dbConfig.DBDSN)
 	fmt.Fprintf(out, "Target: %s\n", idOrEmail)
 	if cfg.DryRun {
 		fmt.Fprintln(out, "Mode: DRY RUN (no changes will be made)")
@@ -90,10 +143,129 @@ func (c *Command) updateUser(cfg *Config, dbConfig *shared.DatabaseConfig, idOrE
 	fmt.Fprintf(out, "Found user: %s (%s)\n", originalUser.Name, originalUser.Email)
 	fmt.Fprintf(out, "Current tenant: %s (%s)\n\n", currentTenant.Name, currentTenant.Slug)
 
-	// For now, just show that we found the user and would update it
-	// TODO: Implement proper update logic with service layer
-	fmt.Fprintln(out, "User update functionality needs to be implemented with service layer")
-	fmt.Fprintln(out, "This is a placeholder to fix compilation issues")
+	// Build the update request from the flags the operator actually provided.
+	req, changes, err := c.buildUpdateRequest(cfg, adminService)
+	if err != nil {
+		return err
+	}
+
+	if len(changes) == 0 {
+		fmt.Fprintln(out, "No changes requested. Provide one or more of --email, --name, --active, --tenant or --password.")
+		return nil
+	}
+
+	fmt.Fprintln(out, "The following changes will be applied:")
+	for _, change := range changes {
+		fmt.Fprintf(out, "  • %s\n", change)
+	}
+	fmt.Fprintln(out)
+
+	// Handle dry run
+	if cfg.DryRun {
+		fmt.Fprintln(out, "💡 This is a dry run. To perform the actual update, run the command without --dry-run")
+		return nil
+	}
+
+	// Delegate to the service
+	updatedUser, err := adminService.UpdateUser(context.Background(), idOrEmail, req)
+	if err != nil {
+		return fmt.Errorf("failed to update user: %w", err)
+	}
+
+	fmt.Fprintln(out, "✅ User updated successfully!")
+	c.printUserInfo(updatedUser)
 
 	return nil
+}
+
+// buildUpdateRequest assembles an admin.UserUpdateRequest from the flags that
+// were explicitly set, and returns a human-readable list of the changes. Only
+// flags the operator provided are included so unset flags never overwrite an
+// existing column.
+func (c *Command) buildUpdateRequest(cfg *Config, adminService *admin.Service) (admin.UserUpdateRequest, []string, error) {
+	flags := c.Cmd().Flags()
+
+	var req admin.UserUpdateRequest
+	var changes []string
+
+	if flags.Changed("email") {
+		email := strings.TrimSpace(cfg.Email)
+		req.Email = &email
+		changes = append(changes, fmt.Sprintf("email → %s", email))
+	}
+
+	if flags.Changed("name") {
+		name := cfg.Name
+		req.Name = &name
+		changes = append(changes, fmt.Sprintf("name → %s", name))
+	}
+
+	if flags.Changed("active") {
+		active := cfg.Active
+		req.IsActive = &active
+		changes = append(changes, fmt.Sprintf("active → %t", active))
+	}
+
+	if flags.Changed("tenant") {
+		tenantID, err := c.resolveTenantID(cfg.Tenant, adminService)
+		if err != nil {
+			return admin.UserUpdateRequest{}, nil, err
+		}
+		req.TenantID = &tenantID
+		changes = append(changes, fmt.Sprintf("tenant → %s", tenantID))
+	}
+
+	if flags.Changed("password") && cfg.Password {
+		password, err := c.collectPassword()
+		if err != nil {
+			return admin.UserUpdateRequest{}, nil, err
+		}
+		req.Password = &password
+		changes = append(changes, "password → (updated)")
+	}
+
+	return req, changes, nil
+}
+
+// resolveTenantID converts a tenant ID or slug to the canonical tenant ID.
+func (c *Command) resolveTenantID(tenantIDOrSlug string, adminService *admin.Service) (string, error) {
+	if strings.TrimSpace(tenantIDOrSlug) == "" {
+		return "", fmt.Errorf("tenant ID or slug is required when --tenant is set")
+	}
+
+	tenant, err := adminService.GetTenant(context.Background(), tenantIDOrSlug)
+	if err != nil {
+		return "", fmt.Errorf("tenant not found: %w", err)
+	}
+
+	return tenant.ID, nil
+}
+
+// collectPassword prompts for a new password securely with strength validation.
+func (c *Command) collectPassword() (string, error) {
+	ctx := context.Background()
+	reader := input.NewReader(os.Stdin, c.Cmd().OutOrStdout())
+	passwordField := input.NewPasswordField("New password", reader).
+		ValidateStrength()
+
+	value, err := passwordField.Prompt(ctx)
+	if err != nil {
+		return "", err
+	}
+	passwordStr, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected type returned from password field")
+	}
+	return passwordStr, nil
+}
+
+// printUserInfo prints user information in a formatted way
+func (c *Command) printUserInfo(user *models.User) {
+	out := c.Cmd().OutOrStdout()
+
+	fmt.Fprintf(out, "  ID:       %s\n", user.ID)
+	fmt.Fprintf(out, "  Email:    %s\n", user.Email)
+	fmt.Fprintf(out, "  Name:     %s\n", user.Name)
+	fmt.Fprintf(out, "  Active:   %t\n", user.IsActive)
+	fmt.Fprintf(out, "  Tenant:   %s\n", user.TenantID)
 }

--- a/go/cmd/inventario/users/update/update_test.go
+++ b/go/cmd/inventario/users/update/update_test.go
@@ -82,6 +82,20 @@ func readUser(c *qt.C, fs *registry.FactorySet, id string) *models.User {
 	return user
 }
 
+// seedSecondTenant adds an additional active tenant to the same store backing
+// fs so cross-tenant move tests have a destination to move the user into. The
+// server-generated tenant ID is returned because TenantRegistry.Create ignores
+// any caller-supplied ID; the slug stays stable for --tenant resolution.
+func seedSecondTenant(c *qt.C, fs *registry.FactorySet, slug string) (tenantID string) {
+	created, err := fs.CreateServiceRegistrySet().TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Other Tenant",
+		Slug:   slug,
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+	return created.ID
+}
+
 func TestCommand_New(t *testing.T) {
 	c := qt.New(t)
 
@@ -109,7 +123,6 @@ func TestCommand_Flags(t *testing.T) {
 		"active",
 		"tenant",
 		"password",
-		"interactive",
 	}
 	for _, flagName := range expectedFlags {
 		flag := cobraCmd.Flags().Lookup(flagName)
@@ -118,6 +131,8 @@ func TestCommand_Flags(t *testing.T) {
 
 	// The dead --role flag must NOT exist.
 	c.Assert(cobraCmd.Flags().Lookup("role"), qt.IsNil)
+	// The dead --interactive flag was never consumed and must NOT exist.
+	c.Assert(cobraCmd.Flags().Lookup("interactive"), qt.IsNil)
 }
 
 // TestCommand_LiveUpdate_Mutates is the regression guard against the old no-op
@@ -146,6 +161,32 @@ func TestCommand_LiveUpdate_Mutates(t *testing.T) {
 	c.Assert(updated.IsActive, qt.IsFalse)
 	// Untouched fields are preserved.
 	c.Assert(updated.Email, qt.Equals, "user@example.com")
+}
+
+// TestCommand_LiveUpdate_MovesTenant verifies that a live --tenant update
+// actually reassigns the user's tenant_id (and prints the cross-tenant warning).
+func TestCommand_LiveUpdate_MovesTenant(t *testing.T) {
+	c := qt.New(t)
+
+	fs, userID := seededRegistry(c)
+	otherTenantID := seedSecondTenant(c, fs, "other-tenant")
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	cobraCmd := cmd.Cmd()
+
+	var out bytes.Buffer
+	cobraCmd.SetOut(&out)
+	cobraCmd.SetArgs([]string{
+		"user@example.com",
+		"--tenant=other-tenant",
+	})
+
+	err := cobraCmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "WARNING: --tenant moves only the users row")
+
+	moved := readUser(c, fs, userID)
+	c.Assert(moved.TenantID, qt.Equals, otherTenantID)
 }
 
 // TestCommand_DryRun_MutatesNothing verifies the dry-run path reports the

--- a/go/cmd/inventario/users/update/update_test.go
+++ b/go/cmd/inventario/users/update/update_test.go
@@ -1,0 +1,216 @@
+package update_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/cmd/inventario/users/update"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+const testDSN = "postgres://test:test@localhost/test"
+
+// TestMain lowers the bcrypt cost factor used by models.User.SetPassword for
+// this test binary so the password-change fixtures don't pay the production
+// bcrypt.DefaultCost. Production CLI callers keep DefaultCost.
+func TestMain(m *testing.M) {
+	models.SetBcryptCostForTesting(nil, bcrypt.MinCost)
+	os.Exit(m.Run())
+}
+
+// seededRegistry registers a memory registry under the "postgres" name and
+// pre-populates a tenant plus a single user. The same in-memory store backs
+// every FactorySet the registered factory hands out (including the one the
+// admin service opens), so tests can read the user back through `fs` to assert
+// on the persisted state. The created user's server-generated ID is returned
+// because UserRegistry.Create ignores any caller-supplied ID.
+func seededRegistry(c *qt.C) (fs *registry.FactorySet, userID string) {
+	newFn, _ := memory.NewMemoryRegistrySet()
+
+	// Build and seed the store exactly once, then hand the same FactorySet to
+	// every caller of the registered factory so the admin service shares it.
+	factorySet, err := newFn(registry.Config(testDSN))
+	c.Assert(err, qt.IsNil)
+
+	serviceRegistrySet := factorySet.CreateServiceRegistrySet()
+	ctx := context.Background()
+
+	_, err = serviceRegistrySet.TenantRegistry.Create(ctx, models.Tenant{
+		EntityID: models.EntityID{ID: "test-tenant"},
+		Name:     "Test Tenant",
+		Slug:     "test-tenant",
+		Status:   models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant",
+		},
+		Email:    "user@example.com",
+		Name:     "Original Name",
+		IsActive: true,
+	}
+	err = user.SetPassword("OriginalPass123")
+	c.Assert(err, qt.IsNil)
+
+	created, err := serviceRegistrySet.UserRegistry.Create(ctx, user)
+	c.Assert(err, qt.IsNil)
+
+	wrappedNewFn := func(_ registry.Config) (*registry.FactorySet, error) {
+		return factorySet, nil
+	}
+	registry.Register("postgres", wrappedNewFn)
+	c.Cleanup(func() {
+		registry.Unregister("postgres")
+	})
+
+	return factorySet, created.ID
+}
+
+func readUser(c *qt.C, fs *registry.FactorySet, id string) *models.User {
+	user, err := fs.CreateServiceRegistrySet().UserRegistry.Get(context.Background(), id)
+	c.Assert(err, qt.IsNil)
+	return user
+}
+
+func TestCommand_New(t *testing.T) {
+	c := qt.New(t)
+
+	seededRegistry(c)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Cmd(), qt.IsNotNil)
+	c.Assert(cmd.Cmd().Use, qt.Equals, "update <user-id-or-email>")
+	c.Assert(cmd.Cmd().Short, qt.Equals, "Update an existing user")
+}
+
+func TestCommand_Flags(t *testing.T) {
+	c := qt.New(t)
+
+	seededRegistry(c)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	cobraCmd := cmd.Cmd()
+
+	expectedFlags := []string{
+		"dry-run",
+		"email",
+		"name",
+		"active",
+		"tenant",
+		"password",
+		"interactive",
+	}
+	for _, flagName := range expectedFlags {
+		flag := cobraCmd.Flags().Lookup(flagName)
+		c.Assert(flag, qt.IsNotNil, qt.Commentf("Flag %s should exist", flagName))
+	}
+
+	// The dead --role flag must NOT exist.
+	c.Assert(cobraCmd.Flags().Lookup("role"), qt.IsNil)
+}
+
+// TestCommand_LiveUpdate_Mutates is the regression guard against the old no-op
+// stub: a live update must actually persist the requested changes.
+func TestCommand_LiveUpdate_Mutates(t *testing.T) {
+	c := qt.New(t)
+
+	fs, userID := seededRegistry(c)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	cobraCmd := cmd.Cmd()
+
+	var out bytes.Buffer
+	cobraCmd.SetOut(&out)
+	cobraCmd.SetArgs([]string{
+		"user@example.com",
+		"--name=New Name",
+		"--active=false",
+	})
+
+	err := cobraCmd.Execute()
+	c.Assert(err, qt.IsNil)
+
+	updated := readUser(c, fs, userID)
+	c.Assert(updated.Name, qt.Equals, "New Name")
+	c.Assert(updated.IsActive, qt.IsFalse)
+	// Untouched fields are preserved.
+	c.Assert(updated.Email, qt.Equals, "user@example.com")
+}
+
+// TestCommand_DryRun_MutatesNothing verifies the dry-run path reports the
+// changes but leaves the persisted user untouched.
+func TestCommand_DryRun_MutatesNothing(t *testing.T) {
+	c := qt.New(t)
+
+	fs, userID := seededRegistry(c)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	cobraCmd := cmd.Cmd()
+
+	var out bytes.Buffer
+	cobraCmd.SetOut(&out)
+	cobraCmd.SetArgs([]string{
+		"user@example.com",
+		"--name=Should Not Persist",
+		"--dry-run",
+	})
+
+	err := cobraCmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "DRY RUN")
+
+	unchanged := readUser(c, fs, userID)
+	c.Assert(unchanged.Name, qt.Equals, "Original Name")
+	c.Assert(unchanged.IsActive, qt.IsTrue)
+}
+
+// TestCommand_NoFlags_NoChange verifies that running with no field flags makes
+// no change and reports that nothing was requested.
+func TestCommand_NoFlags_NoChange(t *testing.T) {
+	c := qt.New(t)
+
+	fs, userID := seededRegistry(c)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: testDSN})
+	cobraCmd := cmd.Cmd()
+
+	var out bytes.Buffer
+	cobraCmd.SetOut(&out)
+	cobraCmd.SetArgs([]string{"user@example.com"})
+
+	err := cobraCmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "No changes requested")
+
+	unchanged := readUser(c, fs, userID)
+	c.Assert(unchanged.Name, qt.Equals, "Original Name")
+}
+
+func TestCommand_MemoryDatabaseRejected(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := update.New(&shared.DatabaseConfig{DBDSN: "memory://"})
+	cobraCmd := cmd.Cmd()
+
+	var out bytes.Buffer
+	cobraCmd.SetOut(&out)
+	cobraCmd.SetArgs([]string{"user@example.com", "--name=New Name"})
+
+	err := cobraCmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	// dbConfig.Validate() rejects non-PostgreSQL DSNs before the command's own
+	// explicit memory:// guard is reached, so the operator gets a clear
+	// PostgreSQL-only error either way.
+	c.Assert(err.Error(), qt.Contains, "only support PostgreSQL")
+}

--- a/go/cmd/inventario/users/users.go
+++ b/go/cmd/inventario/users/users.go
@@ -34,7 +34,7 @@ USAGE EXAMPLES:
     inventario users create
 
   Create user with flags:
-    inventario users create --email="admin@acme.com" --tenant="acme" --role="admin"
+    inventario users create --email="admin@acme.com" --tenant="acme"
 
   Preview user creation:
     inventario users create --dry-run --email="test@example.com" --tenant="acme"

--- a/go/cmd/inventool/db/migrations/generate/generate.go
+++ b/go/cmd/inventool/db/migrations/generate/generate.go
@@ -61,7 +61,7 @@ func (c *Command) migrateGenerate(cfg *Config, dbConfig *shared.DatabaseConfig, 
 	dsn := dbConfig.DBDSN
 
 	fmt.Println("=== MIGRATE GENERATE ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", shared.RedactDSN(dsn))
 	fmt.Println()
 
 	gen, err := generator.New(dsn, cfg.GoEntitiesDir)


### PR DESCRIPTION
## What

`inventario users update <id|email>` was a no-op stub: it found the user, printed `User update functionality needs to be implemented with service layer`, and exited `0` without changing anything. The doc drift was already corrected by #2135; this PR resolves the remaining **code** residual of #2105 by wiring the command to the existing `admin.Service.UpdateUser`.

No schema change, no migration, no API request/response shape change, no frontend change.

## Changes

- **Register real cobra flags** in `update.New`: `--email`, `--name`, `--active`, `--tenant`, `--password`, `--dry-run` — matching the create/delete naming conventions. Only flags the operator **explicitly passes** (`cmd.Flags().Changed(...)`) are applied, so an unset flag never overwrites an existing column (optional/pointer semantics on `admin.UserUpdateRequest`).
- **Implement `updateUser`**: builds the request from the provided flags, prints the would-be changes, enforces the same PostgreSQL-only guard as create/delete (rejects `memory://` via `dbConfig.Validate()`), honors `--dry-run` (prints the changes, mutates nothing), then calls `UpdateUser` and prints a clear result. Empty / whitespace-only `--email` and `--name` are rejected up-front.
- `--password` prompts securely with strength validation; `--tenant` resolves a slug/ID to the canonical tenant ID before applying, and prints a prominent warning that a cross-tenant move only reassigns the users row (the user's content + memberships stay behind — tracked in #2179).
- **Remove the dead `--role` surface**: the `Role` field in `update/config.go`, the `--role` help text, and the `--role="admin"` example in `users.go`. System-admin is granted via `admin grant-system-admin` (the dedicated `system_admin_grants` table), not a user-row field.
- **Redact the DB DSN** in command output via a shared `shared.RedactDSN` helper, applied across every CLI command that prints it — no more raw credentials in terminal history / CI logs.
- **Tests** (`update/update_test.go`): live update mutates (regression guard against the old no-op), live tenant-move, dry-run mutates nothing, no-flags makes no change, flag presence, and the PostgreSQL-only guard.
- **Docs**: README and AGENTS updated to describe the now-working command.

## Verification

- `go build ./...`, `go vet`, `golangci-lint run --fix`, `nolintguard`, `qtlint` on the touched packages — `0 issues`
- `go test ./cmd/inventario/users/... ./services/admin/...` — pass

Closes #2105