### PR TITLE
fix(files): enforce PUT /files attribute validation without breaking the attach flow

### DIFF
--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -483,7 +483,14 @@ func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	file.Tags = models.StringSlice(tagSlugs)
-	file.Path = textutils.CleanFilename(input.Data.Attributes.Path)
+	// Preserve the persisted path when the client omits it. Link-only PUTs
+	// (the commodity-attach flow, #1983 Part A / PR #2032) send no `path`;
+	// blanking it here would orphan the file's display name and break the
+	// download filename (file.Path+file.Ext). Only overwrite when the client
+	// actually supplied a new filename. (#2033)
+	if cleaned := textutils.CleanFilename(input.Data.Attributes.Path); cleaned != "" {
+		file.Path = cleaned
+	}
 
 	// Only update entity linking for non-export files or if values haven't changed
 	if file.LinkedEntityType != "export" {

--- a/go/apiserver/files_update_test.go
+++ b/go/apiserver/files_update_test.go
@@ -1,0 +1,108 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/checkers"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// seedCommodityFile creates a file row attached to the first fixture commodity
+// with the given on-disk path, returning the created entity.
+func seedCommodityFile(c *qt.C, params apiserver.Params, user *models.User, path string) *models.FileEntity {
+	registrySet := getRegistrySetFromParams(params, user)
+	commodities := must.Must(registrySet.CommodityRegistry.List(context.Background()))
+	c.Assert(len(commodities) > 0, qt.IsTrue, qt.Commentf("fixture must have ≥1 commodity"))
+
+	return must.Must(registrySet.FileRegistry.Create(context.Background(), models.FileEntity{
+		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryImages,
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   commodities[0].ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         path,
+			OriginalPath: path + ".jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+		},
+	}))
+}
+
+func putFile(params apiserver.Params, user *models.User, slug, fileID, body string) *httptest.ResponseRecorder {
+	req := must.Must(http.NewRequest(
+		http.MethodPut,
+		"/api/v1/g/"+slug+"/files/"+fileID,
+		bytes.NewReader([]byte(body)),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{}).ServeHTTP(rr, req)
+	return rr
+}
+
+// TestUpdateFile_LinkOnlyPutPreservesPath is the core regression for #2033's
+// secondary bug: the live commodity-attach flow (PR #2032) PUTs with NO `path`,
+// and the handler used to blank the persisted path with CleanFilename("") = "".
+// After the fix the path is preserved and the request still succeeds.
+func TestUpdateFile_LinkOnlyPutPreservesPath(t *testing.T) {
+	c := qt.New(t)
+
+	params, user, group := newParams()
+	file := seedCommodityFile(c, params, user, "original-name")
+
+	// Mirror frontend/src/features/commodities/draft.ts::uploadPendingFiles:
+	// link-only PUT, no `path`, no `linked_entity_meta`.
+	body := `{"data":{"id":"` + file.ID + `","type":"files","attributes":{` +
+		`"linked_entity_type":"commodity","linked_entity_id":"` + file.LinkedEntityID + `"}}}`
+	rr := putFile(params, user, group.Slug, file.ID, body)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	// Path must NOT have been blanked.
+	c.Check(rr.Body.Bytes(), checkers.JSONPathEquals("$.attributes.path"), "original-name")
+
+	// And persisted state confirms it.
+	registrySet := getRegistrySetFromParams(params, user)
+	fresh := must.Must(registrySet.FileRegistry.Get(context.Background(), file.ID))
+	c.Check(fresh.Path, qt.Equals, "original-name")
+}
+
+// TestUpdateFile_NewPathOverwrites confirms a non-empty `path` still renames.
+func TestUpdateFile_NewPathOverwrites(t *testing.T) {
+	c := qt.New(t)
+
+	params, user, group := newParams()
+	file := seedCommodityFile(c, params, user, "original-name")
+
+	body := `{"data":{"id":"` + file.ID + `","type":"files","attributes":{"path":"renamed"}}}`
+	rr := putFile(params, user, group.Slug, file.ID, body)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Check(rr.Body.Bytes(), checkers.JSONPathEquals("$.attributes.path"), "renamed")
+}
+
+// TestUpdateFile_RejectsBogusLinkedEntityMeta proves the previously-dead nested
+// validator now runs end-to-end: a non-empty invalid `linked_entity_meta` is
+// rejected with 422 instead of silently persisting.
+func TestUpdateFile_RejectsBogusLinkedEntityMeta(t *testing.T) {
+	c := qt.New(t)
+
+	params, user, group := newParams()
+	file := seedCommodityFile(c, params, user, "original-name")
+
+	body := `{"data":{"id":"` + file.ID + `","type":"files","attributes":{` +
+		`"linked_entity_type":"commodity","linked_entity_id":"` + file.LinkedEntityID + `",` +
+		`"linked_entity_meta":"BOGUS"}}}`
+	rr := putFile(params, user, group.Slug, file.ID, body)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -315,7 +315,17 @@ func (fd *FileUpdateRequestData) ValidateWithContext(ctx context.Context) error 
 	fields := make([]*validation.FieldRules, 0)
 	fields = append(fields,
 		validation.Field(&fd.Type, validation.Required, validation.In("files")),
-		validation.Field(&fd.Attributes, validation.Required),
+		// Attributes is a struct VALUE, and FileUpdateRequestFileData implements
+		// ValidatableWithContext on a POINTER receiver. ozzo's Field() dereferences
+		// the pointer to a value before type-asserting against
+		// ValidatableWithContext, so the nested validator would be silently
+		// skipped (issue #2033). Invoke it explicitly so the path / linked-entity
+		// rules actually run.
+		validation.Field(&fd.Attributes, validation.Required, validation.WithContext(
+			func(ctx context.Context, _ any) error {
+				return fd.Attributes.ValidateWithContext(ctx)
+			},
+		)),
 	)
 	return validation.ValidateStructWithContext(ctx, fd, fields...)
 }
@@ -336,37 +346,65 @@ func (fur *FileUpdateRequestFileData) Validate() error {
 }
 
 // ValidateWithContext validates the FileUpdateRequest with context.
+//
+// ENFORCED CONTRACT (#2033). This validator was previously dead — the parent
+// FileUpdateRequestData.ValidateWithContext passed Attributes by value, so
+// ozzo never invoked this pointer-receiver method (see that method's comment).
+// Now that it runs, the rules are deliberately calibrated so that bad values
+// are rejected WITHOUT breaking the live "attach uploaded file to commodity"
+// flow (#1983 Part A / PR #2032), which sends a metadata-only PUT carrying
+// NO `path` and NO `linked_entity_meta` and relies on the server preserving
+// the path (apiserver/files.go::updateFile) and deriving the bucket:
+//
+//   - `path` is NOT required. On a link-only PUT the client omits it; the
+//     handler preserves the persisted path instead of blanking it. We only
+//     bound its length here.
+//   - `linked_entity_meta` is validated against the per-type enum ONLY WHEN
+//     it is present (non-empty). It is NOT required, because the server
+//     derives the bucket from the file category / MIME when the client omits
+//     it. A non-empty bad value (e.g. "BOGUS") is still rejected.
+//   - `linked_entity_id` IS required whenever `linked_entity_type` is set —
+//     both live attach flows always send it, and a link without a target is
+//     meaningless.
+//
+// Note (#1989): the commodity meta enum here is still the legacy
+// images|invoices|manuals set. #1989 will migrate it to images|documents;
+// because this validator is now live, that swap can target this single spot.
 func (fur *FileUpdateRequestFileData) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 
 	fields = append(fields,
 		validation.Field(&fur.Title, validation.Length(0, 255)), // Title is now optional
 		validation.Field(&fur.Description, validation.Length(0, 1000)),
-		validation.Field(&fur.Path, validation.Required),
+		// Path is intentionally NOT Required: link-only PUTs omit it and the
+		// handler preserves the persisted path. Bound length only.
+		validation.Field(&fur.Path, validation.Length(0, 1024)),
 		validation.Field(&fur.Tags, validation.Length(0, 100)),                                                // Allow up to 100 tags
 		validation.Field(&fur.LinkedEntityType, validation.In("", "commodity", "export", "location", "area")), // Allow export/location/area for existing files
 		validation.Field(&fur.LinkedEntityID, validation.Length(0, 255)),
 		validation.Field(&fur.LinkedEntityMeta, validation.Length(0, 255)),
 	)
 
-	// If linked entity type is specified, validate the linked entity ID and meta
+	// If a linked entity type is specified, require the ID and — WHEN PRESENT —
+	// validate the meta against the per-type enum. Meta is left optional so the
+	// server can derive the bucket; only a non-empty invalid value is rejected.
 	switch fur.LinkedEntityType {
 	case "commodity":
 		fields = append(fields,
 			validation.Field(&fur.LinkedEntityID, validation.Required),
-			validation.Field(&fur.LinkedEntityMeta, validation.Required, validation.In("images", "invoices", "manuals")),
+			validation.Field(&fur.LinkedEntityMeta, validation.In("", "images", "invoices", "manuals")),
 		)
 	case "export":
 		fields = append(fields,
 			validation.Field(&fur.LinkedEntityID, validation.Required),
-			validation.Field(&fur.LinkedEntityMeta, validation.Required, validation.In("xml-1.0")),
+			validation.Field(&fur.LinkedEntityMeta, validation.In("", "xml-1.0")),
 		)
 	case "location", "area":
 		// Same meta buckets for both ("images" / "files") — see the
 		// model-level validator in models.go for the rationale.
 		fields = append(fields,
 			validation.Field(&fur.LinkedEntityID, validation.Required),
-			validation.Field(&fur.LinkedEntityMeta, validation.Required, validation.In("images", "files")),
+			validation.Field(&fur.LinkedEntityMeta, validation.In("", "images", "files")),
 		)
 	}
 

--- a/go/jsonapi/files_update_validation_test.go
+++ b/go/jsonapi/files_update_validation_test.go
@@ -1,0 +1,179 @@
+package jsonapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/jsonapi"
+)
+
+// newFileUpdateRequest builds a well-formed JSON:API update envelope with the
+// given attributes so each test can vary just the field under test.
+func newFileUpdateRequest(attrs jsonapi.FileUpdateRequestFileData) *jsonapi.FileUpdateRequest {
+	return &jsonapi.FileUpdateRequest{
+		Data: &jsonapi.FileUpdateRequestData{
+			ID:         "file-1",
+			Type:       "files",
+			Attributes: attrs,
+		},
+	}
+}
+
+// TestFileUpdateRequestValidate_Passes covers the request shapes that MUST be
+// accepted — most importantly the live "attach uploaded file to commodity"
+// flow (#1983 Part A / PR #2032), which sends a metadata-only PUT carrying no
+// `path` and no `linked_entity_meta`. Before #2033 the nested attribute
+// validator never ran at all; these guard that enforcing it didn't break a
+// live flow.
+func TestFileUpdateRequestValidate_Passes(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs jsonapi.FileUpdateRequestFileData
+	}{
+		{
+			name: "live commodity attach flow: no path, no meta, server derives",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "commodity",
+				LinkedEntityID:   "commodity-1",
+			},
+		},
+		{
+			name: "commodity attach with valid meta",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				Path:             "receipt.pdf",
+				LinkedEntityType: "commodity",
+				LinkedEntityID:   "commodity-1",
+				LinkedEntityMeta: "images",
+			},
+		},
+		{
+			name: "metadata-only edit: title + tags, no link",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				Title: "Invoice 2026",
+				Tags:  []string{"invoice"},
+			},
+		},
+		{
+			name: "rename: path supplied, no link",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				Path: "renamed-file.jpg",
+			},
+		},
+		{
+			name: "location attach with valid meta",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "location",
+				LinkedEntityID:   "location-1",
+				LinkedEntityMeta: "files",
+			},
+		},
+		{
+			name: "location attach, meta omitted (server derives)",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "location",
+				LinkedEntityID:   "location-1",
+			},
+		},
+		{
+			name: "export relink with valid meta",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "export",
+				LinkedEntityID:   "export-1",
+				LinkedEntityMeta: "xml-1.0",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := newFileUpdateRequest(tc.attrs)
+			err := req.ValidateWithContext(context.Background())
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+// TestFileUpdateRequestValidate_Rejects covers the bad request shapes that
+// MUST now be rejected. Before #2033 the nested FileUpdateRequestFileData
+// validator was silently skipped (Attributes is a struct value, the validator
+// has a pointer receiver), so every one of these slipped through with a 200.
+func TestFileUpdateRequestValidate_Rejects(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs jsonapi.FileUpdateRequestFileData
+	}{
+		{
+			name: "commodity with bogus meta enum",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "commodity",
+				LinkedEntityID:   "commodity-1",
+				LinkedEntityMeta: "BOGUS",
+			},
+		},
+		{
+			name: "commodity link without an id",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "commodity",
+				LinkedEntityMeta: "images",
+			},
+		},
+		{
+			name: "location with meta from the wrong bucket",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "location",
+				LinkedEntityID:   "location-1",
+				LinkedEntityMeta: "manuals",
+			},
+		},
+		{
+			name: "export with non-version meta",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "export",
+				LinkedEntityID:   "export-1",
+				LinkedEntityMeta: "images",
+			},
+		},
+		{
+			name: "unknown linked_entity_type",
+			attrs: jsonapi.FileUpdateRequestFileData{
+				LinkedEntityType: "spaceship",
+				LinkedEntityID:   "x-1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := newFileUpdateRequest(tc.attrs)
+			err := req.ValidateWithContext(context.Background())
+			c.Assert(err, qt.IsNotNil)
+		})
+	}
+}
+
+// TestFileUpdateRequestValidate_TypeRequired guards the outer envelope: a
+// missing/wrong `type` is still rejected independently of the attribute rules.
+func TestFileUpdateRequestValidate_TypeRequired(t *testing.T) {
+	c := qt.New(t)
+	req := &jsonapi.FileUpdateRequest{
+		Data: &jsonapi.FileUpdateRequestData{
+			ID:         "file-1",
+			Type:       "not-files",
+			Attributes: jsonapi.FileUpdateRequestFileData{Path: "f.jpg"},
+		},
+	}
+	err := req.ValidateWithContext(context.Background())
+	c.Assert(err, qt.IsNotNil)
+}
+
+// TestFileUpdateRequestValidate_DataRequired guards the top-level required Data.
+func TestFileUpdateRequestValidate_DataRequired(t *testing.T) {
+	c := qt.New(t)
+	req := &jsonapi.FileUpdateRequest{}
+	err := req.ValidateWithContext(context.Background())
+	c.Assert(err, qt.IsNotNil)
+}


### PR DESCRIPTION
## Problem (#2033)

`PUT /files/{id}` silently skipped attribute validation. The nested `FileUpdateRequestFileData.ValidateWithContext` (pointer receiver) was **never invoked**: the parent `FileUpdateRequestData.ValidateWithContext` passed `Attributes` by **value** via `validation.Field(&fd.Attributes, …)`, and ozzo's `Field()` dereferences the pointer to a value before type-asserting against `ValidatableWithContext` — which only the pointer satisfies. So the assertion failed and the whole nested validator was dead code.

Consequences:
- The `path` rule never ran.
- The commodity `linked_entity_meta` `In(…)` enum never ran — `linked_entity_meta: "BOGUS"` was accepted and persisted.

Confirmed empirically: a commodity update with `linked_entity_meta="BOGUS"` returned `err = <nil>` before this change.

There is also a secondary handler bug: `updateFile` did `file.Path = CleanFilename(input…Path)` unconditionally, so a link-only PUT (no `path`) **blanked** the persisted path.

## Approach — Option 2 (enforce + keep live flows valid)

This is the delicate part. The live "attach uploaded file to commodity" flow (#1983 Part A / PR #2032, `frontend/src/features/commodities/draft.ts::uploadPendingFiles` and `UploadFilesDialog.tsx`) sends a **metadata-only PUT with NO `path` and NO `linked_entity_meta`** and relies on the server preserving the path and deriving the bucket. Naively re-enabling the old rules (`path` Required, `linked_entity_meta` Required) would 422 that flow.

The enforced contract is calibrated so **bad values are rejected, valid current flows pass**:

- **`path`**: no longer `Required` (length-bounded only). Link-only PUTs omit it; the handler now preserves the persisted path.
- **`linked_entity_meta`**: validated against the per-type enum **only when present** (`In("", …)`); not required, because the server derives the bucket when omitted. A non-empty bad value (`"BOGUS"`) is still rejected.
- **`linked_entity_id`**: still required whenever `linked_entity_type` is set.

The nested validator is now invoked explicitly via `validation.WithContext` so it actually runs regardless of the value/pointer-receiver subtlety.

## Changes

- `go/jsonapi/files.go`
  - `FileUpdateRequestData.ValidateWithContext`: explicitly invoke the nested attribute validator via `validation.WithContext`.
  - `FileUpdateRequestFileData.ValidateWithContext`: relax `path` to length-only; make `linked_entity_meta` enum conditional on presence; document the enforced contract.
- `go/apiserver/files.go`: preserve `file.Path` when the client omits `path` on a link-only PUT instead of blanking it.
- Tests (previously **zero** coverage of `FileUpdateRequest.ValidateWithContext`):
  - `go/jsonapi/files_update_validation_test.go` — request-validator probe matrix (attach flow passes, bogus meta / missing id / wrong bucket / unknown type rejected).
  - `go/apiserver/files_update_test.go` — end-to-end handler: link-only PUT preserves path (200), explicit rename works (200), bogus `linked_entity_meta` → 422.

## Out of scope / follow-up

- This does **not** do #1989's `images|invoices|manuals → images|documents` enum swap. It only re-enables the existing enum. Because the PUT-path `In(…)` is **now live**, #1989 can target this single spot.
- No frontend change is required: the enforced contract was designed to match the existing FE payloads. The attach flows omit `path`/`meta` (now handled by preservation + optional-meta), and the standalone edit form (`FileEditPage`) already requires a non-empty `path` client-side (zod `pathRequired`) and never sends `linked_entity_meta`.

## Verification

- `go build ./...`, `go vet` (only pre-existing, unrelated `internal/fileblob/drivertest` warnings), `golangci-lint run` → 0 issues, `go tool nolintguard`, `go tool qtlint` — all clean on `jsonapi` + `apiserver`.
- `go test ./jsonapi/... ./apiserver/...` — green, including the new regression tests.
- No request/response shape or swagger annotation changes → no swagger/codegen regeneration needed.

Closes #2033