### PR TITLE
fix(security): /metrics auth, CI vuln-scanning, authz defense-in-depth (#2102, #2097, #2113)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,21 +20,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for patch and minor updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+      - name: Enable auto-merge for patch updates only
+        # PATCH-ONLY (#2097). `gh pr merge --auto` only completes once every
+        # required status check passes, so branch protection on master is what
+        # actually gates this on the new security checks (go-govulncheck,
+        # dependency-review, the docker.yml image scan). Minor and major
+        # updates are held for manual review — a minor bump can still pull in
+        # behavioural changes that lint/typecheck/unit tests miss.
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on major updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+      - name: Comment on minor and major updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
-          gh pr comment "$PR_URL" --body "⚠️ This is a **major version update**. Please review the changelog before merging."
+          gh pr comment "$PR_URL" --body "⚠️ This is a **${UPDATE_TYPE#version-update:semver-} version update**. Auto-merge is restricted to patch updates — please review the changelog and CI results before merging."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   renovate:
@@ -54,32 +61,41 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if major update
-        id: check-major
+      - name: Classify update type
+        id: classify
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
         run: |
-          # Check if this is a major update based on title or labels
-          if echo "$PR_TITLE" | grep -qiE '\bmajor\b'; then
-            echo "is_major=true" >> $GITHUB_OUTPUT
-          elif echo "$PR_LABELS" | grep -qi 'major'; then
-            echo "is_major=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_major=false" >> $GITHUB_OUTPUT
+          # PATCH-ONLY auto-merge (#2097). Renovate doesn't expose a
+          # structured update-type to the PR event, so derive it from the
+          # title/labels it stamps. Anything that isn't unambiguously a patch
+          # (major, minor, or unclassifiable) is held for manual review.
+          # renovate.json's packageRules also restrict automerge to patch, so
+          # this is defence-in-depth, not the sole gate.
+          is_patch=false
+          if echo "$PR_TITLE" | grep -qiE '\b(major|minor)\b'; then
+            is_patch=false
+          elif echo "$PR_LABELS" | grep -qiE 'major|minor'; then
+            is_patch=false
+          elif echo "$PR_TITLE" | grep -qiE '\bpatch\b' || echo "$PR_LABELS" | grep -qi 'patch'; then
+            is_patch=true
           fi
+          echo "is_patch=$is_patch" >> "$GITHUB_OUTPUT"
 
-      - name: Enable auto-merge for patch and minor updates
-        if: steps.check-major.outputs.is_major != 'true'
+      - name: Enable auto-merge for patch updates only
+        # `gh pr merge --auto` waits for required status checks, so branch
+        # protection on master gates this on the new security checks.
+        if: steps.classify.outputs.is_patch == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on major updates
-        if: steps.check-major.outputs.is_major == 'true'
+      - name: Comment on non-patch updates
+        if: steps.classify.outputs.is_patch != 'true'
         run: |
-          gh pr comment "$PR_URL" --body "⚠️ This is a **major version update**. Please review the changelog before merging."
+          gh pr comment "$PR_URL" --body "⚠️ Auto-merge is restricted to **patch** updates. This update is minor/major or could not be classified as a patch — please review the changelog and CI results before merging."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+# Scans the dependency diff (added / updated manifest + lockfile entries) on
+# every pull request and fails when a HIGH/CRITICAL-severity advisory is
+# introduced. Runs unconditionally — it's security-critical and cheap, and a
+# new vulnerable dependency can ride in on a PR that touches no Go/JS source
+# (e.g. a lockfile-only bump), so it deliberately does NOT use the path
+# filters that gate the per-ecosystem checks.
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v5
+        with:
+          # Block the PR only on HIGH/CRITICAL advisories; lower severities
+          # are surfaced in the PR summary without failing the check.
+          fail-on-severity: high

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,8 +112,12 @@ jobs:
           file: ./Dockerfile
           target: production
           platforms: ${{ matrix.platform }}
-          provenance: false
-          sbom: false
+          # Supply-chain attestations: SLSA provenance + SBOM, attached to the
+          # per-arch image on push so consumers can verify build origin and
+          # enumerate components (#2097). `mode=max` records full build
+          # metadata in the provenance predicate.
+          provenance: mode=max
+          sbom: true
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ env.CACHE_SCOPE_PREFIX }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE_PREFIX }}-${{ matrix.arch }}
@@ -346,6 +350,83 @@ jobs:
             [ -z "$tag" ] && continue
             docker buildx imagetools inspect "$tag"
           done <<< "${{ steps.meta.outputs.tags }}"
+
+  scan-image:
+    name: Scan image for vulnerabilities
+    needs: merge
+    # `merge` is skipped on fork PRs and on PRs that change no image input
+    # (its `build` dependency is gated), so this job is skipped with it. Gate
+    # to PR and master-push events: tag releases reuse master HEAD's already
+    # scanned layers, and the SARIF upload is only meaningful for PRs / the
+    # default branch.
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to publish results to the GitHub Security > Code scanning tab.
+      security-events: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      # The merge job tags every commit's manifest list with an immutable
+      # sha-<7> tag — pull that exact ref so the scan can't race onto a stale
+      # pr-N / edge pointer. Mirrors _wait-for-docker-image.yml's tag logic.
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Checkout code
+        # Brings .trivyignore (repo-root allowlist) into the workspace so the
+        # scanner honours documented, time-boxed CVE exceptions.
+        uses: actions/checkout@v7
+
+      - name: Compute image ref
+        id: ref
+        run: |
+          set -euo pipefail
+          echo "image=${IMAGE}:sha-${COMMIT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan image with Trivy (SARIF report)
+        # exit-code 0: this pass only produces the SARIF for the Security tab;
+        # the gating happens in the next step. Pinned Trivy DB is fetched at
+        # run time. `.trivyignore` in the workspace is auto-discovered.
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.ref.outputs.image }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          # Image scan only — ignore unfixed advisories so we don't block on
+          # CVEs with no available upstream fix (they still appear in the
+          # report); use .trivyignore for everything else.
+          ignore-unfixed: true
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        # Surface findings even when the gating step below fails the job.
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
+
+      - name: Fail on HIGH/CRITICAL vulnerabilities
+        # Second pass with exit-code 1 turns unignored HIGH/CRITICAL findings
+        # into a job failure. DB is cached from the SARIF pass (--skip-db-update
+        # via the action's `skip-setup-trivy`/cache is implicit on the runner).
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.ref.outputs.image }}
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
 
   # Pin the just-published master image SHA for the master ArgoCD
   # ApplicationSet (infra/argocd/applicationset-master.yaml). That appset

--- a/.github/workflows/go-govulncheck.yml
+++ b/.github/workflows/go-govulncheck.yml
@@ -1,0 +1,65 @@
+name: Go Vulnerability Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Resolve which ecosystems this PR touches. Mirrors go-test.yml / go-lint.yml
+  # so a PR that doesn't touch the Go surface skips this check; any change to
+  # CI itself (`ci` filter) forces it back on.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/filters.yml
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    needs: changes
+    # PR: only run when go-relevant paths changed (or any .github/** change
+    # forces the conservative fallback). Push to master always runs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.go == 'true' ||
+      needs.changes.outputs.ci == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.4
+          cache: true
+          cache-dependency-path: go/go.sum
+
+      # govulncheck is the official Go vulnerability scanner. It reads the
+      # Go vuln database and reports only vulnerabilities reachable from the
+      # call graph, so it fails the job exclusively on actionable findings.
+      # The tool binary is version-pinned (the vuln DB itself is always
+      # fetched fresh at run time, so a pinned binary stays current on data);
+      # bump deliberately in its own PR like the golangci-lint pin.
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
+        working-directory: go

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,17 @@
+# Trivy vulnerability allowlist for the production container image scan
+# (see the `scan-image` job in .github/workflows/docker.yml).
+#
+# The image scan fails the Docker workflow on any unignored HIGH/CRITICAL
+# finding. Add a CVE here ONLY as a deliberate, time-boxed exception — e.g.
+# an advisory with no fixed version yet, or one that is not reachable in our
+# usage. Every entry MUST carry an expiry date and a justification so stale
+# suppressions surface for review.
+#
+# Format (one finding id per line; trailing comments are ignored by Trivy):
+#   CVE-2024-12345  # exp:2025-01-01 — no upstream fix yet; not reachable, <reason>
+#
+# Trivy also honours an inline `exp:` directive, after which the suppression
+# is automatically ignored:
+#   CVE-2024-12345 exp:2025-01-01
+#
+# Keep this file empty unless an exception is actively required.

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,11 @@ WORKDIR /app/go
 CMD ["go", "test", "-v", "./..."]
 
 # Stage 5: Production runtime
-FROM alpine:latest AS production
+# Pinned to an explicit version + multi-arch digest (matches the precision of
+# the node:/golang: base pins above) so the runtime base is reproducible and
+# can't drift to a newly-published `latest`. Renovate's `docker` manager keeps
+# the digest current; bump both the tag and the @sha256 together.
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS production
 
 # Install runtime dependencies
 RUN apk --no-cache add ca-certificates tzdata curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,13 +101,18 @@ CMD ["go", "test", "-v", "./..."]
 
 # Stage 5: Production runtime
 # Pinned to an explicit version + multi-arch digest (matches the precision of
-# the node:/golang: base pins above) so the runtime base is reproducible and
-# can't drift to a newly-published `latest`. Renovate's `docker` manager keeps
-# the digest current; bump both the tag and the @sha256 together.
+# the node:/golang: base pins above) so the runtime base layer is reproducible
+# and can't drift to a newly-published `latest`. Renovate's `docker` manager
+# keeps the digest current; bump both the tag and the @sha256 together.
 FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS production
 
-# Install runtime dependencies
-RUN apk --no-cache add ca-certificates tzdata curl
+# Install runtime dependencies. `apk upgrade` first so base-image packages pick
+# up security patches at build time even when the pinned digest lags a CVE fix
+# — otherwise the image scan (Trivy, #2097) flags a fixed-but-not-yet-repinned
+# OS CVE as HIGH and fails the build (e.g. CVE-2026-45447 in libssl3/libcrypto3,
+# fixed in openssl 3.5.7-r0). Keeps the digest pin for the base layer while
+# staying current on patches; --no-cache leaves no apk index behind.
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates tzdata curl
 
 # Create non-root user
 RUN addgroup -g 1001 -S inventario && \

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -399,9 +399,78 @@ manually:
   from `deploy/monitoring/prometheus/rules/inventario.rules.yml` — `InventarioTargetDown`,
   `InventarioHighErrorRate` (5xx > 5%), `InventarioHighLatencyP95` (p95 > 1s)) and point
   Alertmanager at a real receiver (email/Slack/PagerDuty).
-- [ ] ⚠️ **Keep `/metrics` off the public internet.** It is unauthenticated and exposes
-  installation-wide aggregate gauges (tenant/user/commodity counts, storage bytes). Scrape
-  it only from the in-cluster Prometheus — never route it through the public ingress.
+- [ ] ⚠️ **Protect `/metrics` with the bearer token and keep it off the public internet.**
+  It exposes installation-wide aggregate gauges (tenant/user/commodity counts, storage
+  bytes). Configure the token per **§B10a** below, scrape it only from the in-cluster
+  Prometheus, and never route it through the public ingress.
+
+### B10a. Metrics authentication — required security hardening (#2102)
+
+⚠️ **`/metrics` (API `:3333` and each worker `:3334`) leaks installation-wide gauges**
+(`inventario_tenants`, `inventario_users`, `inventario_commodities`,
+`inventario_file_storage_bytes`). When no token is configured the endpoint is **open** and
+the app logs a one-time startup warning. Gate it with a bearer token:
+
+- [ ] **Generate a metrics token** (strong random, ≥ 32 bytes):
+
+  ```bash
+  openssl rand -hex 32   # → INVENTARIO_RUN_METRICS_TOKEN
+  ```
+
+- [ ] **Store it in the runtime Secret** (alongside `INVENTARIO_RUN_JWT_SECRET`,
+  `INVENTARIO_RUN_FILE_SIGNING_KEY`, …) under the key `INVENTARIO_RUN_METRICS_TOKEN`
+  (see Appendix B). The chart loads the whole Secret as env vars, so every workload
+  (`run.all` / `run.apiserver` / workers) receives the token and enforces
+  `Authorization: Bearer <token>` on `/metrics`, rejecting mismatches with HTTP 401.
+
+- [ ] **Or set it inline** with `metrics.token` (mirrored into the chart-managed Secret as
+  `INVENTARIO_RUN_METRICS_TOKEN`). Use the Secret key when `secrets.existingSecret` is set —
+  `metrics.token` is ignored in that mode.
+
+- [ ] **Wire the Prometheus Operator to send the token.** With
+  `metrics.serviceMonitor.enabled=true` and a token configured (inline **or** the
+  `INVENTARIO_RUN_METRICS_TOKEN` key in `secrets.existingSecret`), the chart automatically adds
+  an `authorization` stanza to the ServiceMonitor pointing at the runtime Secret:
+
+  ```yaml
+  metrics:
+    token: ""                  # leave empty when using secrets.existingSecret;
+                               # supply INVENTARIO_RUN_METRICS_TOKEN in that Secret
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: kps           # match your Prometheus Operator instance
+  ```
+
+  The Secret must live in the **same namespace** as the ServiceMonitor.
+
+- [ ] **Vanilla (operator-less) Prometheus** discovers pods via
+  `metrics.podAnnotations.enabled=true`, but pod annotations cannot carry a token — add the
+  header in your scrape job's `scrape_config`:
+
+  ```yaml
+  authorization:
+    type: Bearer
+    credentials_file: /etc/prometheus/secrets/inventario-runtime/INVENTARIO_RUN_METRICS_TOKEN
+  ```
+
+- [ ] **Defense-in-depth: also block `/metrics` at the ingress controller.** The chart does
+  NOT route it through its own ingress, but the default rule is `path: /` — block the path
+  explicitly. ingress-nginx:
+  `nginx.ingress.kubernetes.io/server-snippet: |` then `location = /metrics { return 401; }`.
+  Traefik: attach a Middleware rejecting `/metrics`.
+
+- [ ] **Verify** Prometheus scrapes successfully with the token — check the Prometheus UI
+  `Targets` tab for the inventario ServiceMonitor endpoint showing **UP**, and confirm an
+  unauthenticated `curl` to `/metrics` returns `401`.
+
+### B10b. Disable the API docs UI in production (#2102)
+
+- [ ] ⚠️ **Keep the interactive Swagger/OpenAPI docs off in production.** The chart defaults
+  `app.enableApiDocs=false`, which sets `INVENTARIO_RUN_ENABLE_API_DOCS=false` and removes the
+  `/swagger` UI so the full API surface is not advertised to anonymous callers. Leave it at
+  the default for prod; only flip `app.enableApiDocs=true` on dev/preview overlays if you
+  want the docs UI. Confirm `GET /swagger` returns 404 after deploy.
 
 ### B11. Backups & disaster recovery
 
@@ -464,6 +533,7 @@ app:
   publicUrl: "https://inventario.example.com"
   uploadLocation: "s3://inventario-prod?prefix=uploads/&region=auto&endpoint=https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com"
   allowedOrigins: ""           # SPA is same-origin; leave empty to deny cross-origin
+  enableApiDocs: false         # keep /swagger off in prod (chart default; shown for clarity)
 
 email:
   provider: smtp
@@ -513,6 +583,8 @@ setupJob:
     # adminPassword comes from the Secret key SETUP_ADMIN_PASSWORD
 
 metrics:
+  # token: ""                  # leave empty here; INVENTARIO_RUN_METRICS_TOKEN comes
+                               # from the runtime Secret (Appendix B). See §B10a.
   serviceMonitor:
     enabled: true              # turn on once kube-prometheus-stack is installed
     labels:
@@ -534,6 +606,7 @@ kubectl -n inventario create secret generic inventario-runtime \
   --from-literal=MIGRATOR_DB_DSN='postgres://inventario_migrator:PASS@PGHOST:5432/inventario?sslmode=require' \
   --from-literal=INVENTARIO_RUN_JWT_SECRET='<openssl rand -hex 32>' \
   --from-literal=INVENTARIO_RUN_FILE_SIGNING_KEY='<openssl rand -hex 32>' \
+  --from-literal=INVENTARIO_RUN_METRICS_TOKEN='<openssl rand -hex 32>' \
   --from-literal=SETUP_ADMIN_PASSWORD='<initial admin password>' \
   --from-literal=INVENTARIO_RUN_SMTP_PASSWORD='<mailtrap smtp password>' \
   --from-literal=INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY='<anthropic api key>' \

--- a/devdocs/CSRF_PROTECTION.md
+++ b/devdocs/CSRF_PROTECTION.md
@@ -18,7 +18,7 @@ Inventario implements comprehensive CSRF protection for all state-changing opera
 2. **CSRF Middleware** (`go/apiserver/csrf_middleware.go`)
    - Validates CSRF tokens for state-changing HTTP requests
    - Bypasses safe methods (GET, HEAD, OPTIONS)
-   - Implements fail-open design for backend errors
+   - Fails **closed** on backend errors for state-changing requests (#2113, L-6): a CSRF store outage rejects POST/PUT/PATCH/DELETE with `403` rather than silently bypassing validation. Safe methods are unaffected (they never reach the validation call).
 
 3. **Frontend Integration** (`frontend/src/lib/http.ts`)
    - The single fetch-based HTTP wrapper (no axios) stores the CSRF token in memory
@@ -149,7 +149,7 @@ The CORS configuration automatically includes:
 - Invalid token rejection
 - Expired token handling
 - Nil service disables CSRF
-- Service error fail-open behavior
+- Service error fail-closed behavior for state-changing requests (safe methods still allowed)
 - All mutating methods require tokens
 
 ### Running Tests
@@ -197,7 +197,7 @@ go test -v ./csrf/inmemory -run TestService_GenerateToken
 - [ ] Monitor CSRF service errors in logs
 - [ ] Ensure Redis has proper backup/replication
 - [ ] Test CSRF protection with security scanning tools
-- [ ] Verify fail-open behavior is acceptable for your use case
+- [ ] Ensure the CSRF store (Redis) is highly available: state-changing requests fail **closed** (403) on a store outage
 - [ ] Document CSRF token handling for API consumers
 
 ## References

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -59,6 +59,54 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/admin/debug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get debug information
+         * @description get debug information about file storage, database driver, and operating system (back-office only)
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["debug.Info"];
+                    };
+                };
+                /** @description Unauthorized - back-office authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/groups": {
         parameters: {
             query?: never;
@@ -3036,45 +3084,6 @@ export type paths = {
                     };
                     content: {
                         "application/json": string[];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get debug information
-         * @description get debug information about file storage, database driver, and operating system
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["debug.Info"];
                     };
                 };
             };

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/denisvmedia/inventario/csrf"
+	"github.com/denisvmedia/inventario/debug"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/services"
 )
@@ -113,6 +114,14 @@ type AdminParams struct {
 	// (#1750). Zero falls back to the 30-min default; values above the
 	// 30-min ceiling are clamped down inside the handler.
 	ImpersonationTTL time.Duration
+
+	// DebugInfo backs GET /admin/debug (issue #2113, L-4). The debug
+	// endpoint exposes operational configuration (file-storage driver,
+	// database driver, OS) and so was moved off the tenant surface — where
+	// any authenticated tenant user could read it — onto the back-office
+	// plane, gated by RequireBackofficeAuth like every other admin route.
+	// May be nil; the handler then reports zero-valued debug info.
+	DebugInfo *debug.Info
 }
 
 // Admin returns the router configurator for /api/v1/admin/*. Mounted
@@ -200,6 +209,12 @@ func Admin(params AdminParams) func(r chi.Router) {
 		factorySet:   params.FactorySet,
 		auditService: params.AuditService,
 	}
+	// #2113 L-4: GET /admin/debug — moved off the tenant surface onto the
+	// back-office plane. DebugInfo may be nil; the handler then encodes the
+	// zero value (same as the legacy /debug behaviour with a nil info).
+	debugAPIInst := &debugAPI{
+		debugInfo: params.DebugInfo,
+	}
 	// #1785 Phase 5 removed the legacy `RequireSystemAdmin` gate from
 	// every admin route: the CRUD subtree is gated by RequireBackofficeAuth
 	// (Phase 3), impersonation/start is gated by RequirePlatformAdmin
@@ -263,7 +278,7 @@ func Admin(params AdminParams) func(r chi.Router) {
 		// tokens (and vice versa).
 		r.Group(func(r chi.Router) {
 			r.Use(backofficeAuth)
-			adminBackofficeRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI, workersAPI)
+			adminBackofficeRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI, workersAPI, debugAPIInst)
 		})
 	}
 }
@@ -289,8 +304,14 @@ func adminBackofficeRoutes(
 	groupMembersAPI *adminGroupMembersAPI,
 	impersonationAPI *adminImpersonationAPI,
 	workersAPI *adminWorkersAPI,
+	debugAPIInst *debugAPI,
 ) {
 	r.Get("/_ping", adminPing)
+
+	// #2113 L-4: operational debug info, back-office-gated. Previously at
+	// /api/v1/debug behind only tenant JWT auth (any authenticated tenant
+	// user could read it); now restricted to the back-office plane.
+	r.Get("/debug", debugAPIInst.getDebugInfo)
 
 	// #1746: tenants + users listing endpoints. Each handler
 	// audit-logs via params.AuditService and bypasses RLS at the

--- a/go/apiserver/api_docs_gate_test.go
+++ b/go/apiserver/api_docs_gate_test.go
@@ -1,0 +1,60 @@
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// The GET /swagger/* API documentation UI is gated behind EnableAPIDocs
+// (issue #2113, L-5): default on for dev/e2e, production sets it false so the
+// API surface is not served publicly.
+
+func TestAPIDocs_MountedWhenEnabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.EnableAPIDocs = true
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The swagger handler serves an index redirect at /swagger/index.html.
+	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Anything other than 404 proves the route is mounted (the swagger UI
+	// returns 200/301/302 depending on the asset).
+	c.Assert(rr.Code, qt.Not(qt.Equals), http.StatusNotFound)
+}
+
+func TestAPIDocs_NotMountedWhenDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.EnableAPIDocs = false
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAPIDocs_DocJSONNotServedWhenDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.EnableAPIDocs = false
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/doc.json", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
 	"net"
@@ -197,6 +198,20 @@ type Params struct {
 	SupportEmail            string                // Destination for /api/v1/feedback submissions (issue #1387). Empty leaves the route mounted but it returns 503.
 	RedisPinger             RedisPinger           // Optional Redis dependency check for /readyz
 
+	// MetricsToken is the optional shared-secret bearer token for GET
+	// /metrics (issue #2102). When non-empty, /metrics requires the header
+	// "Authorization: Bearer <token>", compared with
+	// crypto/subtle.ConstantTimeCompare. When empty, /metrics is open
+	// (legacy behaviour) and APIServer() logs a one-time startup warning so
+	// operators know the installation-wide business gauges are exposed.
+	MetricsToken string
+
+	// EnableAPIDocs gates GET /swagger/* (Swagger UI + doc.json) (issue
+	// #2102 / L-5). Default true preserves dev / e2e; production sets it
+	// false so the API surface is not served publicly. When false the
+	// /swagger routes are not mounted (404).
+	EnableAPIDocs bool
+
 	// FeatureCurrencyMigration gates the /currency-migrations endpoints
 	// and the requireGroupNotMigrating lock middleware (issue #202 / #1551).
 	// Default true now that the feature shipped under #1604 — flipping
@@ -354,6 +369,42 @@ func (p *Params) Validate() error {
 	return nil
 }
 
+// MetricsTokenMiddleware enforces optional bearer-token authentication on
+// GET /metrics (issue #2102). When token is non-empty it requires the header
+// "Authorization: Bearer <token>" and compares it with
+// crypto/subtle.ConstantTimeCompare to keep the check constant-time. When the
+// token is empty the middleware is a no-op, preserving the legacy "open
+// /metrics" behaviour that keeps local development frictionless — the one-time
+// "open metrics" warning is emitted by APIServer() at startup, not here.
+func MetricsTokenMiddleware(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// Build the expected header once per construction, not per request.
+		expected := []byte("Bearer " + token)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			got := []byte(r.Header.Get("Authorization"))
+			// ConstantTimeCompare returns 0 on a length mismatch, so the
+			// explicit length guard is only to keep the comparison's timing
+			// independent of where the first differing byte falls.
+			if len(got) != len(expected) || subtle.ConstantTimeCompare(got, expected) != 1 {
+				slog.Warn("Unauthorized /metrics access attempt",
+					"remote_addr", r.RemoteAddr,
+					"user_agent", r.UserAgent(),
+					"path", r.URL.Path,
+				)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	renderDecodeOnce.Do(func() {
 		render.Decode = JSONAPIAwareDecoder
@@ -389,12 +440,28 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	//	w.Write([]byte("Welcome to Inventario!"))
 	// })
 	//
-	// RESTy routes for "swagger" resource
-	r.Mount("/swagger", swagger.Handler(
-		swagger.URL("/swagger/doc.json"),
-	))
+	// RESTy routes for "swagger" resource. Gated behind EnableAPIDocs
+	// (issue #2102 / L-5): default on for dev/e2e, production sets it false
+	// so the API documentation surface is not served publicly. When off the
+	// routes are simply not mounted and 404 like any unknown path.
+	if params.EnableAPIDocs {
+		r.Mount("/swagger", swagger.Handler(
+			swagger.URL("/swagger/doc.json"),
+		))
+	}
 	r.Group(Health(params.FactorySet, params.RedisPinger))
-	r.Method(http.MethodGet, "/metrics", promhttp.Handler())
+	// GET /metrics (issue #2102): gated behind an optional bearer token. When
+	// params.MetricsToken is empty the middleware is a no-op (legacy open
+	// behaviour) and the one-time warning below fires so operators notice the
+	// installation-wide gauges are exposed; when set, /metrics requires
+	// "Authorization: Bearer <token>".
+	if params.MetricsToken == "" {
+		slog.Warn("GET /metrics is unauthenticated (no metrics token configured). " +
+			"This is acceptable for local development but exposes installation-wide business gauges " +
+			"(inventario_tenants/users/commodities/file_storage_bytes). " +
+			"Set INVENTARIO_RUN_METRICS_TOKEN (or --metrics-token) to a strong random value to require bearer-token auth.")
+	}
+	r.With(MetricsTokenMiddleware(params.MetricsToken)).Method(http.MethodGet, "/metrics", promhttp.Handler())
 
 	// Resolve blacklister: default to in-memory if not provided.
 	blacklist := params.TokenBlacklister
@@ -528,7 +595,18 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			RateLimiter:      rateLimiter,
 			AuditService:     auditSvc,
 			JWTSecret:        params.JWTSecret,
+			// Public URL drives the Origin/Referer CSRF check on
+			// /backoffice/auth/refresh (#2113, L-1). Empty leaves the
+			// check off (dev / single-host setups rely on SameSite=Strict).
+			PublicURL: params.PublicURL,
 		}))
+
+		// Create user aware middlewares for protected routes. Defined here
+		// (before the public group below) because /invites — whose
+		// POST /invites/{token}/accept leg is authenticated — is mounted
+		// inside the global-rate-limit group so its public GET leg is also
+		// rate-limited (issue #2113, L-3).
+		userMiddlewares := createUserAwareMiddlewares(params.JWTSecret, params.FactorySet, blacklist, csrfSvc)
 
 		// Unauthenticated public routes: apply the global per-IP rate limit as a
 		// defence-in-depth layer on top of their dedicated rate limiters.
@@ -586,10 +664,16 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			if params.SeedEndpointEnabled {
 				r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet, params.UploadLocation))
 			}
+			// Invites are mounted WITHOUT userMiddlewares so that
+			// GET /invites/{token} remains public (the invitee is typically
+			// unauthenticated at first). It lives inside this global
+			// rate-limit group (issue #2113, L-3) so the unauthenticated
+			// token-lookup leg gets per-IP rate limiting as defence-in-depth
+			// against invite-token enumeration. POST /invites/{token}/accept
+			// is wrapped with the userMiddlewares chain inside the Invites
+			// router itself.
+			r.Route("/invites", Invites(groupService, userMiddlewares))
 		})
-
-		// Create user aware middlewares for protected routes
-		userMiddlewares := createUserAwareMiddlewares(params.JWTSecret, params.FactorySet, blacklist, csrfSvc)
 
 		// Protected routes (authentication required).
 		// Authenticated users are not subject to the global per-IP rate limit; a
@@ -599,7 +683,10 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		// System requires a settings registry.
 		// Non-group-scoped routes (system, debug, users, groups management)
 		r.With(userMiddlewares...).Route("/system", System(params.DebugInfo, params.StartTime))
-		r.With(userMiddlewares...).Route("/debug", Debug(params))
+		// GET /debug moved to /admin/debug behind the back-office plane
+		// (issue #2113, L-4): it leaks operational config (storage/db driver,
+		// OS) and must not be readable by an ordinary tenant user. Wired into
+		// AdminParams.DebugInfo below.
 		// Backup-signing public key (#534): server-global, any authenticated
 		// user may read the public half so the FE / CLI can verify .inb archives.
 		r.With(userMiddlewares...).Route("/backup", BackupSigning(params))
@@ -626,6 +713,8 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			// refresh token when an impersonation session is ended via
 			// logout rather than POST /admin/impersonation/end (#1750).
 			ImpersonationStore: impersonationStore,
+			// #2113 L-4: GET /admin/debug now lives on the back-office plane.
+			DebugInfo: params.DebugInfo,
 		}))
 		// The former /api/v1/users admin CRUD was removed together with the
 		// tenant-level `users.role` column. Per-group user management lives
@@ -650,11 +739,8 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			EmailService: emailSvc,
 			SupportEmail: params.SupportEmail,
 		}, rateLimiter))
-		// Invites are mounted WITHOUT userMiddlewares so that GET /invites/{token}
-		// remains public (the invitee is typically unauthenticated at first).
-		// POST /invites/{token}/accept is wrapped with the userMiddlewares chain
-		// inside the Invites router itself.
-		r.Route("/invites", Invites(groupService, userMiddlewares))
+		// (/invites is mounted above, inside the global rate-limit group —
+		// issue #2113, L-3.)
 
 		// Group-scoped data routes: /api/v1/g/{groupSlug}/...
 		// GroupSlugResolverMiddleware runs BEFORE RegistrySetMiddleware so the

--- a/go/apiserver/backoffice_auth.go
+++ b/go/apiserver/backoffice_auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -238,6 +239,12 @@ type BackofficeAuthAPI struct {
 	rateLimiter            services.AuthRateLimiter
 	auditService           services.AuditLogger
 	jwtSecret              []byte
+	// publicHost is the host[:port] of the deployment's public URL,
+	// derived from BackofficeAuthParams.PublicURL. Used by refresh() to
+	// reject cross-origin POSTs (issue #2113, L-1) as defence-in-depth on
+	// top of the cookie's SameSite=Strict attribute. Empty (dev / tests
+	// without PublicURL wired) disables the check.
+	publicHost string
 }
 
 // BackofficeAuthParams holds the wiring for the back-office auth router.
@@ -250,6 +257,11 @@ type BackofficeAuthParams struct {
 	RateLimiter                     services.AuthRateLimiter
 	AuditService                    services.AuditLogger
 	JWTSecret                       []byte
+	// PublicURL is the deployment's public base URL (e.g.
+	// https://app.example.com). When set, refresh() enforces that the
+	// request's Origin/Referer host matches it (issue #2113, L-1). Empty
+	// leaves the check off — the cookie's SameSite=Strict still applies.
+	PublicURL string
 }
 
 // BackofficeAuth mounts the back-office auth routes. The login, refresh,
@@ -271,6 +283,7 @@ func BackofficeAuth(params BackofficeAuthParams) func(r chi.Router) {
 		rateLimiter:            params.RateLimiter,
 		auditService:           params.AuditService,
 		jwtSecret:              params.JWTSecret,
+		publicHost:             publicHostFromURL(params.PublicURL),
 	}
 
 	requireBackofficeAuth := RequireBackofficeAuth(
@@ -290,7 +303,9 @@ func BackofficeAuth(params BackofficeAuthParams) func(r chi.Router) {
 		r.Post("/logout", api.logout)
 		// /me is the only route that requires a back-office bearer
 		// token — every other route is unauthenticated by design (login
-		// runs before authentication, refresh runs on cookie + Bearer).
+		// runs before authentication; refresh runs on the refresh cookie
+		// alone, with an Origin/Referer CSRF check when the public host is
+		// configured — see refresh()).
 		r.With(requireBackofficeAuth).Get("/me", api.handleGetCurrentUser)
 	}
 }
@@ -599,6 +614,21 @@ func (api *BackofficeAuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 	if api.refreshTokenRegistry == nil {
 		http.Error(w, "Refresh tokens not supported", http.StatusNotImplemented)
 		return
+	}
+
+	// CSRF defence-in-depth (issue #2113, L-1): /backoffice/auth/refresh is
+	// a state-changing POST that runs on the refresh cookie alone — it never
+	// sees the CSRF token middleware (which gates bearer-authenticated
+	// routes). The cookie is already SameSite=Strict, but when the public
+	// host is configured we additionally reject any request whose
+	// Origin/Referer host doesn't match it. Skipped when publicHost is empty
+	// (dev / tests) so the cookie's SameSite=Strict remains the sole guard.
+	if api.publicHost != "" {
+		if err := validateBackofficeRefreshOrigin(r, api.publicHost); err != nil {
+			slog.Warn("Backoffice refresh: Origin/Referer validation failed", "error", err)
+			http.Error(w, "Invalid origin", http.StatusForbidden)
+			return
+		}
 	}
 
 	cookie, err := r.Cookie(backofficeRefreshTokenCookieName)
@@ -997,6 +1027,50 @@ func (api *BackofficeAuthAPI) maybeRecordFailedLogin(ctx context.Context, email 
 // -----------------------------------------------------------------------
 // Free-function helpers
 // -----------------------------------------------------------------------
+
+// publicHostFromURL extracts the host[:port] component of a configured
+// public base URL (e.g. "https://app.example.com:8443" → "app.example.com:8443").
+// Returns "" for an empty or unparseable URL so the caller treats the
+// Origin/Referer check as disabled rather than enforcing against a bogus host.
+func publicHostFromURL(publicURL string) string {
+	publicURL = strings.TrimSpace(publicURL)
+	if publicURL == "" {
+		return ""
+	}
+	u, err := url.Parse(publicURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// validateBackofficeRefreshOrigin checks that the request's Origin (preferred)
+// or Referer (fallback) header host matches the configured public host. Used
+// on POST /backoffice/auth/refresh (issue #2113, L-1) to defend the
+// cookie-only, state-changing endpoint against cross-origin replay. A request
+// with neither header, or whose host doesn't match, is rejected.
+func validateBackofficeRefreshOrigin(r *http.Request, publicHost string) error {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		referer := r.Header.Get("Referer")
+		if referer == "" {
+			return errors.New("Origin or Referer header required")
+		}
+		origin = referer
+	}
+
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid Origin/Referer %q: %w", origin, err)
+	}
+	if originURL.Host == "" {
+		return fmt.Errorf("Origin/Referer %q has no host", origin)
+	}
+	if originURL.Host != publicHost {
+		return fmt.Errorf("origin mismatch: got %q, expected %q", originURL.Host, publicHost)
+	}
+	return nil
+}
 
 // generateBackofficeRefreshToken mints a fresh cryptographically-random
 // refresh token + its SHA-256 hash. Mirrors models.GenerateRefreshToken

--- a/go/apiserver/backoffice_auth_l1_test.go
+++ b/go/apiserver/backoffice_auth_l1_test.go
@@ -1,0 +1,118 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// POST /backoffice/auth/refresh runs on the refresh cookie alone and bypasses
+// the bearer-authenticated CSRF middleware. When the public host is configured
+// it must reject cross-origin requests (issue #2113, L-1) as defence-in-depth
+// on top of the cookie's SameSite=Strict attribute.
+
+const backofficeL1PublicURL = "https://admin.example.com"
+
+// newBackofficeAuthRouterWithPublicURL wires a back-office auth router with
+// PublicURL set so the L-1 Origin/Referer check is active, and returns the
+// router plus a valid refresh cookie obtained via login.
+func newBackofficeAuthRouterWithPublicURL(t *testing.T) (http.Handler, *http.Cookie) {
+	t.Helper()
+	c := qt.New(t)
+
+	bo := memory.NewBackofficeUserRegistry()
+	rt := memory.NewBackofficeRefreshTokenRegistry()
+	auditSvc := services.NewAuditService(memory.NewAuditLogRegistry())
+
+	r := chi.NewRouter()
+	r.Route("/", apiserver.BackofficeAuth(apiserver.BackofficeAuthParams{
+		BackofficeUserRegistry:         bo,
+		BackofficeRefreshTokenRegistry: rt,
+		BlacklistService:               services.NewInMemoryTokenBlacklister(),
+		RateLimiter:                    services.NewNoOpAuthRateLimiter(),
+		AuditService:                   auditSvc,
+		JWTSecret:                      backofficeTestSecret,
+		PublicURL:                      backofficeL1PublicURL,
+	}))
+
+	seedBackofficeUser(t, bo, "ops@example.com", "S3cretPass!")
+
+	body, _ := json.Marshal(apiserver.BackofficeLoginRequest{Email: "ops@example.com", Password: "S3cretPass!"})
+	loginReq := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader(body))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	r.ServeHTTP(loginRec, loginReq)
+	c.Assert(loginRec.Code, qt.Equals, http.StatusOK)
+
+	var refreshCookie *http.Cookie
+	for _, cookie := range loginRec.Result().Cookies() {
+		if cookie.Name == "backoffice_refresh_token" {
+			refreshCookie = cookie
+			break
+		}
+	}
+	c.Assert(refreshCookie, qt.IsNotNil)
+	return r, refreshCookie
+}
+
+func TestBackofficeAuth_Refresh_RejectsMissingOrigin(t *testing.T) {
+	c := qt.New(t)
+	router, cookie := newBackofficeAuthRouterWithPublicURL(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/refresh", nil)
+	req.AddCookie(cookie)
+	// No Origin and no Referer header.
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	c.Assert(rec.Code, qt.Equals, http.StatusForbidden)
+}
+
+func TestBackofficeAuth_Refresh_RejectsForeignOrigin(t *testing.T) {
+	c := qt.New(t)
+	router, cookie := newBackofficeAuthRouterWithPublicURL(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/refresh", nil)
+	req.AddCookie(cookie)
+	req.Header.Set("Origin", "https://evil.example.net")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	c.Assert(rec.Code, qt.Equals, http.StatusForbidden)
+}
+
+func TestBackofficeAuth_Refresh_AcceptsMatchingOrigin(t *testing.T) {
+	c := qt.New(t)
+	router, cookie := newBackofficeAuthRouterWithPublicURL(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/refresh", nil)
+	req.AddCookie(cookie)
+	req.Header.Set("Origin", backofficeL1PublicURL)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+}
+
+func TestBackofficeAuth_Refresh_AcceptsMatchingRefererFallback(t *testing.T) {
+	c := qt.New(t)
+	router, cookie := newBackofficeAuthRouterWithPublicURL(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/refresh", nil)
+	req.AddCookie(cookie)
+	// No Origin — the handler falls back to Referer.
+	req.Header.Set("Referer", backofficeL1PublicURL+"/admin/dashboard")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+}

--- a/go/apiserver/csrf_middleware.go
+++ b/go/apiserver/csrf_middleware.go
@@ -23,9 +23,14 @@ const (
 // Passing a nil csrfService disables CSRF validation entirely; this is
 // intended only for test environments.
 //
-// On backend errors the middleware fails open: a Redis/storage outage must
-// not take down the API. Operators should monitor CSRF service errors and
-// ensure backend availability.
+// On backend errors the middleware fails CLOSED for state-changing requests
+// (issue #2113, L-6): a Redis/storage outage must not silently bypass CSRF
+// validation on POST/PUT/PATCH/DELETE — that would expose every mutating
+// endpoint to forgery while the backend is degraded. Safe methods
+// (GET/HEAD/OPTIONS) are short-circuited above and never reach the validation
+// call, so the fail-closed path only ever affects mutating requests.
+// Operators should monitor CSRF service errors and ensure backend
+// availability.
 func CSRFMiddleware(csrfService csrf.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,14 +68,18 @@ func CSRFMiddleware(csrfService csrf.Service) func(http.Handler) http.Handler {
 
 			valid, err := csrfService.ValidateToken(r.Context(), user.ID, tokenFromHeader)
 			if err != nil {
-				// Fail-open: a storage outage must not block all writes.
-				slog.Error("CSRF service error; allowing request (fail-open)",
+				// Fail-closed (issue #2113, L-6): a CSRF store outage must
+				// not silently bypass validation on a state-changing request.
+				// Only mutating methods reach this point — the safe-method
+				// switch above already returned — so rejecting here cannot
+				// block reads.
+				slog.Error("CSRF service error; rejecting state-changing request (fail-closed)",
 					"error", err,
 					"user_id", user.ID,
 					"method", r.Method,
 					"path", r.URL.Path,
 				)
-				next.ServeHTTP(w, r)
+				http.Error(w, "CSRF validation unavailable", http.StatusForbidden)
 				return
 			}
 

--- a/go/apiserver/csrf_middleware_test.go
+++ b/go/apiserver/csrf_middleware_test.go
@@ -18,7 +18,8 @@ import (
 	"github.com/denisvmedia/inventario/registry"
 )
 
-// errCSRFService is a CSRFService that always returns an error (to test fail-open behaviour).
+// errCSRFService is a CSRFService that always returns an error (to test the
+// fail-closed behaviour on state-changing requests, issue #2113 L-6).
 type errCSRFService struct{}
 
 func (errCSRFService) GenerateToken(_ context.Context, _ string) (string, error) {
@@ -225,8 +226,11 @@ func TestCSRFMiddleware_NilServiceDisablesCSRF(t *testing.T) {
 	c.Assert(w.Code, qt.Equals, http.StatusOK)
 }
 
-func TestCSRFMiddleware_ServiceErrorFailsOpen(t *testing.T) {
-	c := qt.New(t)
+// TestCSRFMiddleware_ServiceErrorFailsClosedOnMutatingMethods verifies that
+// a CSRF backend outage rejects every state-changing request with 403 rather
+// than silently bypassing validation (issue #2113, L-6). A fail-open store
+// outage would expose every mutating endpoint to forgery while degraded.
+func TestCSRFMiddleware_ServiceErrorFailsClosedOnMutatingMethods(t *testing.T) {
 	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
 	user, tokenString := makeCSRFTestUser(t, jwtSecret)
 
@@ -234,17 +238,50 @@ func TestCSRFMiddleware_ServiceErrorFailsOpen(t *testing.T) {
 		users: map[string]*models.User{user.ID: user},
 	}
 
-	// Use the error service — GetToken will always return an error.
+	// ValidateToken always errors → the middleware must fail closed.
 	router := makeCSRFRouter(jwtSecret, userReg, errCSRFService{})
 
-	req := httptest.NewRequest(http.MethodPost, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+tokenString)
-	req.Header.Set("X-CSRF-Token", "some-token")
-	w := httptest.NewRecorder()
+	mutatingMethods := []string{
+		http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete,
+	}
+	for _, method := range mutatingMethods {
+		t.Run(method, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(method, "/test", nil)
+			req.Header.Set("Authorization", "Bearer "+tokenString)
+			req.Header.Set("X-CSRF-Token", "some-token")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			c.Assert(w.Code, qt.Equals, http.StatusForbidden)
+		})
+	}
+}
 
-	router.ServeHTTP(w, req)
-	// Fail-open: backend errors must not block valid requests.
-	c.Assert(w.Code, qt.Equals, http.StatusOK)
+// TestCSRFMiddleware_ServiceErrorAllowsSafeMethods verifies that a CSRF
+// backend outage does NOT block safe reads (issue #2113, L-6): GET/HEAD/OPTIONS
+// short-circuit before the validation call, so a degraded store never affects
+// them.
+func TestCSRFMiddleware_ServiceErrorAllowsSafeMethods(t *testing.T) {
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	user, tokenString := makeCSRFTestUser(t, jwtSecret)
+
+	userReg := &mockUserRegistryForSecurityTests{
+		users: map[string]*models.User{user.ID: user},
+	}
+
+	router := makeCSRFRouter(jwtSecret, userReg, errCSRFService{})
+
+	safeMethods := []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+	for _, method := range safeMethods {
+		t.Run(method, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(method, "/test", nil)
+			req.Header.Set("Authorization", "Bearer "+tokenString)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			c.Assert(w.Code, qt.Equals, http.StatusOK)
+		})
+	}
 }
 
 // TestCSRFMiddleware_MultipleSessionsShareUser verifies that multiple tokens

--- a/go/apiserver/debug.go
+++ b/go/apiserver/debug.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/denisvmedia/inventario/debug"
 )
 
@@ -14,13 +12,19 @@ type debugAPI struct {
 }
 
 // getDebugInfo returns debug information about the application configuration.
+//
+// Moved behind the back-office auth plane at /admin/debug (issue #2113, L-4):
+// the response leaks operational config (file-storage driver, database driver,
+// OS) that must not be readable by an ordinary tenant user. Registered in
+// apiserver/admin_routes.go under RequireBackofficeAuth.
 // @Summary Get debug information
-// @Description get debug information about file storage, database driver, and operating system
-// @Tags debug
+// @Description get debug information about file storage, database driver, and operating system (back-office only)
+// @Tags admin
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} debug.Info "OK"
-// @Router /debug [get]
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Router /admin/debug [get]
 func (api *debugAPI) getDebugInfo(w http.ResponseWriter, _r *http.Request) { //revive:disable-line:get-return
 	// Set the content type to application/json
 	w.Header().Set("Content-Type", "application/json")
@@ -29,16 +33,5 @@ func (api *debugAPI) getDebugInfo(w http.ResponseWriter, _r *http.Request) { //r
 	if err := json.NewEncoder(w).Encode(api.debugInfo); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	}
-}
-
-// Debug returns a handler for debug information.
-func Debug(params Params) func(r chi.Router) {
-	api := &debugAPI{
-		debugInfo: params.DebugInfo,
-	}
-
-	return func(r chi.Router) {
-		r.Get("/", api.getDebugInfo) // GET /debug
 	}
 }

--- a/go/apiserver/debug_test.go
+++ b/go/apiserver/debug_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/denisvmedia/inventario/registry/memory"
 )
 
+// GET /debug moved to /admin/debug behind the back-office auth plane
+// (issue #2113, L-4). The endpoint leaks operational config (storage/db
+// driver, OS) and must not be readable by an ordinary tenant user.
+
 func TestDebugAPI(t *testing.T) {
 	c := qt.New(t)
 
@@ -51,21 +55,21 @@ func TestDebugAPI(t *testing.T) {
 			c := qt.New(t)
 
 			// Create API server with test parameters
-			params, testUser, _ := newParams()
+			params, _, _ := newParams()
 			params.UploadLocation = tc.uploadLocation
 			params.DebugInfo = tc.debugInfo
 
-			// Mock workers for testing
+			// A back-office admin is required to read /admin/debug.
+			_, token := WithBackofficeAdmin(t, params)
+
 			mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
 			server := apiserver.APIServer(params, mockRestoreWorker)
 
-			// Create test request
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/debug", nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/debug", nil)
 			req = req.WithContext(context.Background())
-			addTestUserAuthHeader(req, testUser.ID)
+			addBackofficeAuthHeader(req, token)
 			w := httptest.NewRecorder()
 
-			// Execute request
 			server.ServeHTTP(w, req)
 
 			// Check response status
@@ -95,21 +99,20 @@ func TestDebugAPI_InvalidURLs(t *testing.T) {
 	c.Assert(factorySet, qt.IsNotNil)
 
 	// Test with invalid URLs
-	params, testUser, _ := newParams()
+	params, _, _ := newParams()
 	params.UploadLocation = "://invalid-url"
 	params.DebugInfo = debug.NewInfo("://invalid-dsn", "://invalid-url")
 
-	// Mock workers for testing
+	_, token := WithBackofficeAdmin(t, params)
+
 	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
 	server := apiserver.APIServer(params, mockRestoreWorker)
 
-	// Create test request
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/debug", nil)
 	req = req.WithContext(context.Background())
-	addTestUserAuthHeader(req, testUser.ID)
+	addBackofficeAuthHeader(req, token)
 	w := httptest.NewRecorder()
 
-	// Execute request
 	server.ServeHTTP(w, req)
 
 	// Check response status
@@ -125,4 +128,39 @@ func TestDebugAPI_InvalidURLs(t *testing.T) {
 	c.Assert(debugInfo.DatabaseDriver, qt.Equals, "")
 	c.Assert(debugInfo.OperatingSystem, qt.Equals, runtime.GOOS)
 	c.Assert(debugInfo.Error, qt.IsNotNil)
+}
+
+// TestDebugAPI_DeniesTenantUser asserts a plain tenant JWT cannot reach the
+// back-office-gated debug endpoint (issue #2113, L-4).
+func TestDebugAPI_DeniesTenantUser(t *testing.T) {
+	c := qt.New(t)
+
+	params, user, _ := newParams()
+	params.DebugInfo = debug.NewInfo("memory://", uploadLocation)
+	server := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/debug", nil)
+	// Tenant JWT — RequireBackofficeAuth rejects it (audience mismatch /
+	// missing admin_id).
+	addTestUserAuthHeader(req, user.ID)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+// TestDebugAPI_DeniesUnauthenticated asserts an anonymous caller cannot reach
+// the debug endpoint.
+func TestDebugAPI_DeniesUnauthenticated(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.DebugInfo = debug.NewInfo("memory://", uploadLocation)
+	server := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/debug", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
 }

--- a/go/apiserver/invites_rate_limit_test.go
+++ b/go/apiserver/invites_rate_limit_test.go
@@ -1,0 +1,51 @@
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// GET /api/v1/invites/{token} is public (the invitee is usually
+// unauthenticated). Issue #2113 (L-3) moved it inside the global per-IP
+// rate-limit group so the token-lookup leg is rate-limited as defence-in-depth
+// against invite-token enumeration.
+
+func TestAPIServer_InvitesGoThroughGlobalRateLimit(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParamsAreaRegistryOnly()
+
+	// Budget of 1 per hour: a single globally-limited request exhausts the IP.
+	limiter := services.NewInMemoryGlobalRateLimiter(1, time.Hour)
+	t.Cleanup(limiter.Stop)
+	params.GlobalRateLimiter = limiter
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	const clientIP = "203.0.113.77:1234"
+	get := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.RemoteAddr = clientIP
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	// First invites GET consumes the single-request budget. The token is
+	// unknown, so the handler returns a non-429 status (typically 404) — what
+	// matters is that it is NOT throttled yet.
+	first := get("/api/v1/invites/some-token")
+	c.Assert(first.Code, qt.Not(qt.Equals), http.StatusTooManyRequests)
+
+	// Second invites GET from the same IP: the global budget is exhausted, so
+	// it must be throttled — proving the route sits inside the global limiter.
+	second := get("/api/v1/invites/another-token")
+	c.Assert(second.Code, qt.Equals, http.StatusTooManyRequests)
+}

--- a/go/apiserver/metrics_guard_test.go
+++ b/go/apiserver/metrics_guard_test.go
@@ -1,0 +1,92 @@
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// The /metrics endpoint exposes installation-wide business gauges (#2102).
+// When params.MetricsToken is set it must require a bearer token; when unset
+// it stays open (legacy behaviour that keeps local dev frictionless).
+
+func TestMetricsGuard_OpenWhenTokenUnset(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	// MetricsToken left empty → open.
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}
+
+func TestMetricsGuard_RejectsMissingTokenWhenConfigured(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.MetricsToken = "s3cr3t-metrics-token-at-least-32-bytes!"
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestMetricsGuard_RejectsWrongTokenWhenConfigured(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.MetricsToken = "s3cr3t-metrics-token-at-least-32-bytes!"
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestMetricsGuard_AcceptsCorrectTokenWhenConfigured(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	const token = "s3cr3t-metrics-token-at-least-32-bytes!"
+	params.MetricsToken = token
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}
+
+func TestMetricsTokenMiddleware_NoOpWhenEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := apiserver.MetricsTokenMiddleware("")(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	c.Assert(called, qt.IsTrue)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -149,6 +149,32 @@ type Config struct {
 	// to curl /seed.
 	SeedEndpointEnabled bool `yaml:"enable_seed_endpoint" env:"ENABLE_SEED_ENDPOINT" env-default:"false"`
 
+	// MetricsToken is the optional shared-secret bearer token that gates
+	// GET /metrics (issue #2102). When set (≥ 32 bytes recommended), the
+	// endpoint requires the header "Authorization: Bearer <token>",
+	// compared with crypto/subtle.ConstantTimeCompare. When empty (the
+	// default) /metrics stays open — the legacy behaviour that keeps local
+	// dev working — and the server logs a one-time startup warning so an
+	// operator knows the installation-wide business gauges
+	// (inventario_tenants/users/commodities/file_storage_bytes) are exposed.
+	// Wired via env INVENTARIO_RUN_METRICS_TOKEN / --metrics-token. Keep
+	// /metrics off the public internet regardless; this is defence-in-depth
+	// for the in-cluster scrape path. NEVER ship production without setting
+	// this to a strong random value (e.g. openssl rand -hex 32).
+	MetricsToken string `yaml:"metrics_token" env:"METRICS_TOKEN" env-default:""`
+
+	// EnableAPIDocs gates the GET /swagger/* Swagger UI + doc.json endpoints
+	// (issue #2102 / L-5). Default TRUE so dev / e2e keep the interactive
+	// docs; production deployments set it false (env
+	// INVENTARIO_RUN_ENABLE_API_DOCS=false / --enable-api-docs=false) so the
+	// API surface (endpoint signatures, parameter names, error codes) is not
+	// served publicly for reconnaissance. When false the /swagger routes are
+	// not mounted and return 404. NOTE: a bool defaulting true that is
+	// omitted from a YAML config reads as false (cleanenv applies env-default
+	// only on env reads) — mirrors MagicLinkLoginEnabled / the operator must
+	// set the key explicitly in a YAML deploy to keep docs on.
+	EnableAPIDocs bool `yaml:"enable_api_docs" env:"ENABLE_API_DOCS" env-default:"true"`
+
 	// WorkersOnly / WorkersExclude restrict which background workers run in
 	// `inventario run workers`. See the run/workers package for the accepted
 	// syntax and mutual-exclusion rules. Both fields default to empty, meaning

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -106,6 +106,8 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.IntVar(&cfg.AIVisionMaxTokens, "ai-vision-max-tokens", cfg.AIVisionMaxTokens, "Cap on the vision model's structured output (must hold a multi-line invoice; 0 = provider default 4096)")
 	flags.BoolVar(&cfg.PublicAIVisionScanEnabled, "public-ai-vision-scan-enabled", cfg.PublicAIVisionScanEnabled, "Enable the unauthenticated public photo-scan endpoint for the landing-page CTA (#1988). Default false; spends vendor tokens.")
 	flags.BoolVar(&cfg.SeedEndpointEnabled, "enable-seed-endpoint", cfg.SeedEndpointEnabled, "Mount the public, unauthenticated POST /api/v1/seed route (#2039). Default false; runs a privileged RLS-bypassing op — keep off in prod.")
+	flags.StringVar(&cfg.MetricsToken, "metrics-token", cfg.MetricsToken, "Bearer token gating GET /metrics (#2102; minimum 32 bytes recommended). Empty = open + one-time startup warning.")
+	flags.BoolVar(&cfg.EnableAPIDocs, "enable-api-docs", cfg.EnableAPIDocs, "Mount the GET /swagger/* API documentation UI (#2102). Default true for dev/e2e; set false in production to hide the API surface.")
 
 	// OAuth third-party sign-in (issue #1394). Each provider requires
 	// BOTH a client id AND a client secret to be enabled; the redirect

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -187,6 +187,13 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 	// off in production and is opted into only on dev / e2e / the init-data
 	// seed server.
 	params.SeedEndpointEnabled = cfg.SeedEndpointEnabled
+	// /metrics bearer-token gate (#2102). Empty leaves /metrics open and the
+	// apiserver logs a one-time startup warning; a non-empty token requires
+	// "Authorization: Bearer <token>" on every scrape.
+	params.MetricsToken = cfg.MetricsToken
+	// /swagger docs gate (#2102 / L-5). Default true so dev/e2e keep the
+	// interactive docs; production flips it off to hide the API surface.
+	params.EnableAPIDocs = cfg.EnableAPIDocs
 
 	emailLifecycle, err := buildEmailService(cfg)
 	if err != nil {

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -55,6 +55,12 @@ import (
 	"github.com/denisvmedia/inventario/registry"
 )
 
+// testOrgTenantSlug is the well-known sentinel slug for the seed's own
+// throwaway test tenant. The seed treats it as the ONLY slug it is allowed to
+// (re)seed into when the row already exists — every other pre-existing slug is
+// presumed to be real (production) data and is refused (issue #2113, L-2).
+const testOrgTenantSlug = "test-org"
+
 // SeedOptions contains optional parameters for seeding.
 type SeedOptions struct {
 	UserEmail  string // Optional: email of user to seed for
@@ -120,8 +126,10 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 	ctx := context.Background()
 	registrySet := factorySet.CreateServiceRegistrySet()
 
-	// Find or create tenant.
-	tenant, err := findOrCreateTenant(ctx, registrySet, opts)
+	// Find or create tenant. tenantPreExisted reports whether the row was
+	// already present before this call — the L-2 fresh-seed guard below uses
+	// it to refuse the first seed into an unrelated production tenant.
+	tenant, tenantPreExisted, err := findOrCreateTenant(ctx, registrySet, opts)
 	if err != nil {
 		return false, err
 	}
@@ -130,6 +138,16 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 	users, err := registrySet.UserRegistry.List(ctx)
 	if err != nil {
 		return false, err
+	}
+
+	// Fail-closed (issue #2113, L-2): refuse the first seed into a
+	// pre-existing tenant the seed doesn't own. Runs before any rows are
+	// created, so a rejected call is a clean no-op. Only pre-existing tenants
+	// can be polluted this way; a tenant the seed just created is always fine.
+	if tenantPreExisted {
+		if err := guardPreExistingTenant(ctx, registrySet, tenant, opts); err != nil {
+			return false, err
+		}
 	}
 
 	user1, user2, err := findOrCreateUsers(ctx, registrySet, tenant, users, opts.UserEmail)
@@ -307,6 +325,40 @@ func seedTestOrgFixtures(ctx context.Context, registrySet *registry.Set, tenant 
 	return nil
 }
 
+// guardPreExistingTenant enforces the #2113 L-2 fail-closed rule for a tenant
+// that already existed before this seed call: the public, unauthenticated
+// /api/v1/seed endpoint must not be coaxed into seeding the demo dataset into a
+// tenant it doesn't own — that would let any caller pollute real production
+// data via /api/v1/seed?tenant_slug=<theirs>. It returns an error (the caller
+// aborts before creating any rows) unless one of the exemptions holds:
+//   - the slug is the well-known `test-org` sentinel the seed owns;
+//   - the explicit env-gated opt-in (CreateTenantIfMissing, from
+//     INVENTARIO_SEED_ALLOW_CREATE_TENANT) is set; or
+//   - the tenant already owns users — the idempotent reconcile/reseed path
+//     (#1931), which must keep working to backfill blobs on a later run.
+//
+// The tenant-scoped ListByTenant is used deliberately: the service-registry
+// UserRegistry.List is GLOBAL (RLS-bypassed, all tenants) and so cannot tell
+// whether THIS tenant has users — using it would defeat the guard in a real
+// multi-tenant deployment.
+func guardPreExistingTenant(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, opts SeedOptions) error {
+	if tenant.Slug == testOrgTenantSlug || opts.CreateTenantIfMissing {
+		return nil
+	}
+	tenantUsers, err := registrySet.UserRegistry.ListByTenant(ctx, tenant.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check existing users for tenant '%s': %w", tenant.Slug, err)
+	}
+	if len(tenantUsers) > 0 {
+		// Already-seeded tenant: the reconcile/reseed path is allowed.
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to seed into pre-existing tenant '%s': the demo dataset is only seeded into the '%s' sentinel, a freshly created tenant, or one already seeded (set INVENTARIO_SEED_ALLOW_CREATE_TENANT to override for trusted fixtures)",
+		tenant.Slug, testOrgTenantSlug,
+	)
+}
+
 // findOrCreateTenant finds an existing tenant by slug or creates a new
 // test tenant. When opts.TenantSlug is non-empty and the row is
 // missing, opts.CreateTenantIfMissing decides whether to fail-closed
@@ -314,11 +366,16 @@ func seedTestOrgFixtures(ctx context.Context, registrySet *registry.Set, tenant 
 // create-then-seed (e2e cross-tenant fixture path, #1851; the seed
 // handler binds opts.CreateTenantIfMissing to
 // INVENTARIO_SEED_ALLOW_CREATE_TENANT).
-func findOrCreateTenant(ctx context.Context, registrySet *registry.Set, opts SeedOptions) (*models.Tenant, error) {
+//
+// The second return value (preExisted) reports whether the resolved tenant
+// row already existed before this call — the L-2 fresh-seed guard in SeedData
+// uses it to refuse the FIRST seed into an unrelated pre-existing tenant while
+// still allowing idempotent reconcile reseeds.
+func findOrCreateTenant(ctx context.Context, registrySet *registry.Set, opts SeedOptions) (_ *models.Tenant, preExisted bool, _ error) {
 	if opts.TenantSlug != "" {
 		tenant, err := registrySet.TenantRegistry.GetBySlug(ctx, opts.TenantSlug)
 		if err == nil {
-			return tenant, nil
+			return tenant, true, nil
 		}
 		// Only fall through to create-if-missing on the explicit "not
 		// found" sentinel. Any other lookup error (DB down, RLS
@@ -328,10 +385,10 @@ func findOrCreateTenant(ctx context.Context, registrySet *registry.Set, opts See
 		// the row already exists but the read failed for a transient
 		// reason.
 		if !errors.Is(err, registry.ErrNotFound) {
-			return nil, fmt.Errorf("tenant lookup for slug '%s' failed: %w", opts.TenantSlug, err)
+			return nil, false, fmt.Errorf("tenant lookup for slug '%s' failed: %w", opts.TenantSlug, err)
 		}
 		if !opts.CreateTenantIfMissing {
-			return nil, fmt.Errorf("tenant with slug '%s' not found: %w", opts.TenantSlug, err)
+			return nil, false, fmt.Errorf("tenant with slug '%s' not found: %w", opts.TenantSlug, err)
 		}
 		// Create-if-missing: provision a new active tenant with a
 		// human-friendly name derived from the slug. Slug stays as
@@ -344,22 +401,23 @@ func findOrCreateTenant(ctx context.Context, registrySet *registry.Set, opts See
 		}
 		created, createErr := registrySet.TenantRegistry.Create(ctx, newTenant)
 		if createErr != nil {
-			return nil, fmt.Errorf("create tenant '%s': %w", opts.TenantSlug, createErr)
+			return nil, false, fmt.Errorf("create tenant '%s': %w", opts.TenantSlug, createErr)
 		}
-		return created, nil
+		return created, false, nil
 	}
 
 	existingTenants, err := registrySet.TenantRegistry.List(ctx)
 	if err == nil && len(existingTenants) > 0 {
-		return existingTenants[0], nil
+		return existingTenants[0], true, nil
 	}
 
 	testTenant := models.Tenant{
 		Name:   "Test Organization",
-		Slug:   "test-org",
+		Slug:   testOrgTenantSlug,
 		Status: models.TenantStatusActive,
 	}
-	return registrySet.TenantRegistry.Create(ctx, testTenant)
+	created, createErr := registrySet.TenantRegistry.Create(ctx, testTenant)
+	return created, false, createErr
 }
 
 // findOrCreateUsers finds existing users or creates test users based on options.

--- a/go/debug/seeddata/seeddata_l2_test.go
+++ b/go/debug/seeddata/seeddata_l2_test.go
@@ -1,0 +1,77 @@
+package seeddata_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/debug/seeddata"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// The public, unauthenticated /api/v1/seed endpoint must not be coaxed into
+// seeding into a pre-existing production tenant matched by slug (#2113, L-2).
+// The refusal itself is asserted by
+// TestSeedDataRefusesFreshSeedIntoPreExistingNonTestTenant in seeddata_test.go;
+// the cases below pin the EXEMPTIONS that must keep working.
+
+func TestSeedData_AllowsPreExistingTestOrgTenant(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+	registrySet := factorySet.CreateServiceRegistrySet()
+
+	_, err := registrySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Test Organization",
+		Slug:   "test-org",
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Seeding into the well-known sentinel is allowed and idempotent.
+	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{TenantSlug: "test-org"})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestSeedData_CreateTenantIfMissingOverridesGuardForExistingTenant(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+	registrySet := factorySet.CreateServiceRegistrySet()
+
+	// A pre-existing non-test-org tenant the trusted e2e fixture targets.
+	_, err := registrySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Tenant B",
+		Slug:   "tenant-b",
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// CreateTenantIfMissing is the explicit env-gated opt-in (#1851); with it
+	// set, re-seeding an already-created fixture tenant is allowed.
+	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "tenant-b",
+		CreateTenantIfMissing: true,
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestSeedData_CreateTenantIfMissingCreatesNewTenant(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	// The slug does not exist yet; CreateTenantIfMissing provisions it.
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "fresh-tenant",
+		CreateTenantIfMissing: true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	registrySet := factorySet.CreateServiceRegistrySet()
+	created, err := registrySet.TenantRegistry.GetBySlug(context.Background(), "fresh-tenant")
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.Slug, qt.Equals, "fresh-tenant")
+}

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -360,7 +360,14 @@ func TestSeedDataIdempotent(t *testing.T) {
 // security gate on the well-known-password fixture users: orphan,
 // user2 (when planted via the email path), and family. They must
 // never land outside the test-org tenant.
-func TestSeedDataDoesNotCreateFixturesInNonTestTenant(t *testing.T) {
+// TestSeedDataRefusesFreshSeedIntoPreExistingNonTestTenant pins the #2113 L-2
+// hardening: the first seed of a PRE-EXISTING non-test-org tenant (no opt-in)
+// is refused outright. Previously the seed merely withheld the privileged
+// fixtures (sysadmin / blob uploads) but still populated the tenant — which
+// let an unauthenticated /api/v1/seed?tenant_slug=<real-tenant> call pollute
+// production data. The refusal is strictly stronger than the old "no fixtures
+// leak" guarantee.
+func TestSeedDataRefusesFreshSeedIntoPreExistingNonTestTenant(t *testing.T) {
 	c := qt.New(t)
 
 	factorySet := memory.NewFactorySet()
@@ -373,25 +380,17 @@ func TestSeedDataDoesNotCreateFixturesInNonTestTenant(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	// SeedSystemAdmin is opted in here on purpose: the tenant.Slug gate
-	// must still keep the sysadmin fixture (and every other well-known
-	// fixture) out of a non-test-org tenant even when the flag is set.
+	// SeedSystemAdmin is opted in on purpose: the L-2 refusal fires
+	// regardless, so a misconfigured opt-in cannot smuggle the dataset in.
 	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{TenantSlug: "acme", SeedSystemAdmin: true})
-	c.Assert(err, qt.IsNil)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "refusing to seed into pre-existing tenant 'acme'")
 
+	// No users were minted in the pre-existing tenant.
 	ctx := context.Background()
 	users, err := registrySet.UserRegistry.List(ctx)
 	c.Assert(err, qt.IsNil)
-	for _, u := range users {
-		c.Assert(u.Email, qt.Not(qt.Equals), "orphan@test-org.com")
-		c.Assert(u.Email, qt.Not(qt.Equals), "family@test-org.com")
-		c.Assert(u.Email, qt.Not(qt.Equals), "teammate@test-org.com")
-		c.Assert(u.Email, qt.Not(qt.Equals), "sysadmin@test-org.com")
-		c.Assert(u.Email, qt.Not(qt.Equals), "blocktarget@test-org.com")
-		isAdmin, err := registrySet.SystemAdminGrantRegistry.Exists(ctx, u.ID)
-		c.Assert(err, qt.IsNil)
-		c.Assert(isAdmin, qt.IsFalse)
-	}
+	c.Assert(users, qt.HasLen, 0)
 }
 
 // TestSeedDataSystemAdminGate asserts the sysadmin fixture is NOT

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -54,6 +54,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/debug": {
+            "get": {
+                "description": "get debug information about file storage, database driver, and operating system (back-office only)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get debug information",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/debug.Info"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/groups": {
             "get": {
                 "description": "Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page\u0026per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.",
@@ -2185,29 +2214,6 @@ const docTemplate = `{
                             "items": {
                                 "type": "string"
                             }
-                        }
-                    }
-                }
-            }
-        },
-        "/debug": {
-            "get": {
-                "description": "get debug information about file storage, database driver, and operating system",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "debug"
-                ],
-                "summary": "Get debug information",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/debug.Info"
                         }
                     }
                 }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -47,6 +47,35 @@
                 }
             }
         },
+        "/admin/debug": {
+            "get": {
+                "description": "get debug information about file storage, database driver, and operating system (back-office only)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get debug information",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/debug.Info"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/groups": {
             "get": {
                 "description": "Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page\u0026per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.",
@@ -2178,29 +2207,6 @@
                             "items": {
                                 "type": "string"
                             }
-                        }
-                    }
-                }
-            }
-        },
-        "/debug": {
-            "get": {
-                "description": "get debug information about file storage, database driver, and operating system",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "debug"
-                ],
-                "summary": "Get debug information",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/debug.Info"
                         }
                     }
                 }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4562,6 +4562,26 @@ paths:
       summary: Back-office ping
       tags:
       - admin
+  /admin/debug:
+    get:
+      consumes:
+      - application/json
+      description: get debug information about file storage, database driver, and
+        operating system (back-office only)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/debug.Info'
+        "401":
+          description: Unauthorized - back-office authentication required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get debug information
+      tags:
+      - admin
   /admin/groups:
     get:
       description: Returns every location group with computed member_count and an
@@ -6073,22 +6093,6 @@ paths:
       summary: Get supported currencies
       tags:
       - currencies
-  /debug:
-    get:
-      consumes:
-      - application/json
-      description: get debug information about file storage, database driver, and
-        operating system
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/debug.Info'
-      summary: Get debug information
-      tags:
-      - debug
   /feature-flags:
     get:
       description: Returns the deployment-scoped feature-flag state. Public (no auth)

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -153,6 +153,7 @@ Expected secret keys when using `secrets.existingSecret`:
 - `INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL`, `INVENTARIO_RUN_AUTH_RATE_LIMIT_REDIS_URL`, `INVENTARIO_RUN_GLOBAL_RATE_LIMIT_REDIS_URL`, `INVENTARIO_RUN_CSRF_REDIS_URL`, `INVENTARIO_RUN_EMAIL_QUEUE_REDIS_URL` (optional)
 - `INVENTARIO_RUN_SMTP_PASSWORD`, `INVENTARIO_RUN_SENDGRID_API_KEY`, `INVENTARIO_RUN_MANDRILL_API_KEY` (provider-specific)
 - `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY` (required when `aivision.provider=anthropic`), `INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY` (required when `aivision.provider=openai`)
+- `INVENTARIO_RUN_METRICS_TOKEN` (optional; bearer token for `GET /metrics` — strongly recommended in production. When present, the ServiceMonitor `authorization` stanza is wired automatically.)
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (required for `s3://` upload targets)
 
 Example existing Secret install:
@@ -340,12 +341,15 @@ Run `helm template ... --debug | grep -E 'replicas|resources|nodeSelector|tolera
 
 ## Metrics & scraping
 
-Inventario always serves Prometheus metrics at `/metrics` — on the API HTTP port (`:3333`, served by `run.all` and `run.apiserver`) and on each worker's probe port (`:3334`, alongside `/healthz` and `/readyz`). The endpoint is unconditional; the `metrics.*` values only control how an external Prometheus *discovers* the pods. Everything below is **OFF by default** and does not change rendered output unless explicitly enabled.
+Inventario always serves Prometheus metrics at `/metrics` — on the API HTTP port (`:3333`, served by `run.all` and `run.apiserver`) and on each worker's probe port (`:3334`, alongside `/healthz` and `/readyz`). The endpoint is unconditional; the `metrics.*` discovery values only control how an external Prometheus *discovers* the pods. Everything below is **OFF by default** and does not change rendered output unless explicitly enabled.
+
+⚠️ **`/metrics` leaks installation-wide gauges** (tenant/user/commodity counts, storage bytes). Gate it with `metrics.token` (#2102) and do not route it through the public ingress — see [PRODUCTION.md §B10a](../../PRODUCTION.md). When the token is unset the endpoint is **open** and the app logs a one-time startup warning.
 
 | Value | Default | Effect |
 | ----- | ------- | ------ |
-| `metrics.podAnnotations.enabled` | `false` | Adds `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path=/metrics` annotations to the API and worker pods. Use this for a vanilla, **operator-less** Prometheus running a `kubernetes_sd_configs` (role: pod) discovery job. The port is role-aware: `3333` on API/combined pods, the worker's probe port (`3334`) on worker pods. |
-| `metrics.serviceMonitor.enabled` | `false` | Renders a `monitoring.coreos.com/v1` ServiceMonitor selecting the API Service's `http` port at `/metrics`. **Requires the Prometheus Operator** — the template is additionally guarded by a CRD-capability check (`.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`), so enabling it on a cluster without the operator is a no-op rather than a render error. Tune `interval`, `scrapeTimeout`, and `labels` (e.g. `release: kube-prometheus-stack` so the operator selects it). |
+| `metrics.token` | `""` | Bearer token for `GET /metrics`. When set, the app requires `Authorization: Bearer <token>` (HTTP 401 on mismatch). Injected as `INVENTARIO_RUN_METRICS_TOKEN` via the chart-managed Secret on every workload, and — when `serviceMonitor.enabled` — wired into the ServiceMonitor's `authorization` stanza automatically. With `secrets.existingSecret`, leave this empty and supply the `INVENTARIO_RUN_METRICS_TOKEN` key in that Secret instead. Generate: `openssl rand -hex 32`. |
+| `metrics.podAnnotations.enabled` | `false` | Adds `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path=/metrics` annotations to the API and worker pods. Use this for a vanilla, **operator-less** Prometheus running a `kubernetes_sd_configs` (role: pod) discovery job. The port is role-aware: `3333` on API/combined pods, the worker's probe port (`3334`) on worker pods. Pod annotations cannot carry the bearer token — add `authorization` to the scrape job out of band when `metrics.token` is set. |
+| `metrics.serviceMonitor.enabled` | `false` | Renders a `monitoring.coreos.com/v1` ServiceMonitor selecting the API Service's `http` port at `/metrics`. **Requires the Prometheus Operator** — the template is additionally guarded by a CRD-capability check (`.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`), so enabling it on a cluster without the operator is a no-op rather than a render error. Tune `interval`, `scrapeTimeout`, and `labels` (e.g. `release: kube-prometheus-stack` so the operator selects it). When a metrics token is configured, an `authorization` stanza referencing the runtime Secret is added so the operator sends the token. |
 
 ```bash
 # Operator-less discovery: annotate API + worker pods.

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -255,6 +255,31 @@ whichever Deployment (all or apiserver) is currently enabled.
 {{- default (printf "%s-secret" (include "inventario.fullname" .)) .Values.secrets.existingSecret -}}
 {{- end -}}
 
+{{/*
+Effective metrics bearer token (#2102). metrics.token is the primary knob;
+secrets.metricsToken is an explicit alias/override. Empty when neither is set,
+which means /metrics stays open (the app logs a one-time warning). Ignored when
+secrets.existingSecret is used — the operator supplies INVENTARIO_RUN_METRICS_TOKEN
+in that Secret instead.
+*/}}
+{{- define "inventario.metricsToken" -}}
+{{- default .Values.metrics.token .Values.secrets.metricsToken -}}
+{{- end -}}
+
+{{/*
+Whether a bearer token guards /metrics. True when secrets.existingSecret is set
+(we cannot read its contents, so we assume the operator provided
+INVENTARIO_RUN_METRICS_TOKEN and wire the ServiceMonitor's authorization stanza),
+or when an inline metrics token resolves to a non-empty value.
+*/}}
+{{- define "inventario.metricsTokenEnabled" -}}
+{{- if .Values.secrets.existingSecret -}}
+true
+{{- else if (include "inventario.metricsToken" .) -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "inventario.demoPostgresName" -}}
 {{- printf "%s-demo-postgres" (include "inventario.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -11,6 +11,12 @@ data:
   # os.Getenv("INVENTARIO_DEBUG_UI") (NOT an INVENTARIO_RUN_ config key).
   # Off by default; the preview/demo overlay sets app.debugUI=true.
   INVENTARIO_DEBUG_UI: {{ .Values.app.debugUI | default false | quote }}
+  # Swagger/OpenAPI docs UI toggle (#2113 L-5). Off by default so production does
+  # not expose the interactive /swagger surface. The Go config reader (cleanenv)
+  # reads `run` config under the INVENTARIO_RUN_ prefix, so the `ENABLE_API_DOCS`
+  # env tag in cmd/inventario/run/bootstrap/config.go resolves at runtime to
+  # INVENTARIO_RUN_ENABLE_API_DOCS.
+  INVENTARIO_RUN_ENABLE_API_DOCS: {{ .Values.app.enableApiDocs | default false | quote }}
   INVENTARIO_RUN_UPLOAD_LOCATION: {{ include "inventario.uploadLocation" . | quote }}
   INVENTARIO_RUN_FILE_URL_EXPIRATION: {{ .Values.app.fileUrlExpiration | quote }}
   INVENTARIO_RUN_MAX_CONCURRENT_EXPORTS: {{ .Values.app.maxConcurrentExports | quote }}

--- a/helm/inventario/templates/ingress.yaml
+++ b/helm/inventario/templates/ingress.yaml
@@ -1,3 +1,24 @@
+{{- /*
+SECURITY NOTE (#2102): /metrics leaks installation-wide gauges (tenant/user/
+commodity counts, storage bytes). It is gated at the APP layer by the bearer
+token (metrics.token → INVENTARIO_RUN_METRICS_TOKEN); when that token is unset the
+endpoint is OPEN. For defense-in-depth, do NOT route /metrics through the public
+ingress. This chart's default rule is `path: /` (Prefix), which would otherwise
+forward /metrics to the backend — block it at the ingress controller:
+
+  ingress-nginx:
+    ingress.annotations:
+      nginx.ingress.kubernetes.io/server-snippet: |
+        location = /metrics { return 401; }
+
+  Traefik: attach a Middleware that rejects the /metrics path (or scope the
+  rule's `path` away from /metrics).
+
+  GCE: add a URL-map rule blocking /metrics.
+
+Scrape /metrics only from the in-cluster Prometheus (ServiceMonitor / pod
+discovery), which targets the Service directly and never traverses this ingress.
+*/ -}}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm/inventario/templates/secret.yaml
+++ b/helm/inventario/templates/secret.yaml
@@ -23,6 +23,12 @@ data:
   INVENTARIO_RUN_MANDRILL_API_KEY: {{ .Values.secrets.mandrillApiKey | b64enc | quote }}
   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: {{ .Values.secrets.aiVisionAnthropicApiKey | b64enc | quote }}
   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: {{ .Values.secrets.aiVisionOpenaiApiKey | b64enc | quote }}
+  {{- $metricsToken := include "inventario.metricsToken" . }}
+  {{- if $metricsToken }}
+  # Bearer token for GET /metrics (#2102). Present only when metrics.token (or
+  # secrets.metricsToken) is set; otherwise /metrics is open and the app warns.
+  INVENTARIO_RUN_METRICS_TOKEN: {{ $metricsToken | b64enc | quote }}
+  {{- end }}
   AWS_ACCESS_KEY_ID: {{ ternary .Values.demo.minio.rootUser .Values.secrets.awsAccessKeyId .Values.demo.minio.enabled | b64enc | quote }}
   AWS_SECRET_ACCESS_KEY: {{ ternary .Values.demo.minio.rootPassword .Values.secrets.awsSecretAccessKey .Values.demo.minio.enabled | b64enc | quote }}
   SETUP_ADMIN_PASSWORD: {{ .Values.setupJob.initData.adminPassword | b64enc | quote }}

--- a/helm/inventario/templates/servicemonitor.yaml
+++ b/helm/inventario/templates/servicemonitor.yaml
@@ -38,6 +38,17 @@ spec:
       path: /metrics
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- if (include "inventario.metricsTokenEnabled" .) }}
+      # Bearer token wiring (#2102): the operator reads INVENTARIO_RUN_METRICS_TOKEN
+      # from the runtime Secret and sends `Authorization: Bearer <token>`. The
+      # Secret must live in the SAME namespace as this ServiceMonitor. When
+      # secrets.existingSecret is set we assume that Secret carries the key.
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "inventario.secretName" . }}
+          key: INVENTARIO_RUN_METRICS_TOKEN
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- /*

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -256,17 +256,40 @@ run:
 # ============================================================
 # Metrics / scraping (#843)
 # ============================================================
-# Prometheus metrics / scraping (#843). The app always serves /metrics on the
-# API port (3333) and each worker's probe port (3334); these toggles only
-# control how an external Prometheus discovers the pods. Both default OFF.
+# Prometheus metrics / scraping (#843, hardened in #2102). The app always serves
+# /metrics on the API port (3333) and each worker's probe port (3334); the
+# discovery toggles below only control how an external Prometheus finds the pods.
+# Discovery is OFF by default. The `token` field gates the endpoint itself.
 metrics:
+  # Optional shared-secret bearer token for GET /metrics (#2102). When set, the
+  # app requires the header `Authorization: Bearer <token>` on every /metrics
+  # request (API :3333 and worker :3334) and rejects mismatches with HTTP 401.
+  # The chart injects it as the INVENTARIO_RUN_METRICS_TOKEN env var (via the runtime
+  # Secret) on every workload and, when serviceMonitor.enabled, wires the
+  # Prometheus Operator to send it automatically.
+  #
+  # Leave empty to keep the legacy OPEN behaviour (the app logs a one-time
+  # startup warning). STRONGLY recommended for production: when empty, anyone with
+  # network access to the HTTP port can read installation-wide gauges
+  # (inventario_tenants / _users / _commodities / _file_storage_bytes).
+  # Generate a strong value (>= 32 bytes): openssl rand -hex 32
+  #
+  # When secrets.existingSecret is set, leave this empty and instead provide the
+  # key INVENTARIO_RUN_METRICS_TOKEN in that Secret.
+  token: ""
+
   # Add prometheus.io/* scrape annotations to API + worker pods so a vanilla
-  # (operator-less) Prometheus kubernetes_sd job can discover them.
+  # (operator-less) Prometheus kubernetes_sd job can discover them. NOTE: pod
+  # annotations cannot carry a bearer token — a vanilla Prometheus pod-discovery
+  # job must add `authorization` to its scrape_config out of band (see
+  # PRODUCTION.md §B10a) when metrics.token is set.
   podAnnotations:
     enabled: false
   # ServiceMonitor for the Prometheus Operator. OFF by default and additionally
   # guarded by a CRD-capability check, so enabling it without the operator is a
-  # no-op rather than a render error.
+  # no-op rather than a render error. When metrics.token is set (inline OR via the
+  # existing Secret's INVENTARIO_RUN_METRICS_TOKEN key), the ServiceMonitor is wired
+  # with an `authorization` stanza so the operator sends the bearer token.
   serviceMonitor:
     enabled: false
     interval: 15s
@@ -333,6 +356,14 @@ app:
   # (NOT under the INVENTARIO_RUN_ prefix).
   # Env: INVENTARIO_DEBUG_UI
   debugUI: false
+
+  # Expose the interactive Swagger/OpenAPI docs UI at /swagger (#2113 L-5).
+  # OFF by default so production installs do not advertise the full API surface
+  # to anonymous callers. Flip to true on dev/preview overlays if you want the
+  # docs UI. Read by the app as a `run`-section bool, so cleanenv resolves the
+  # `ENABLE_API_DOCS` env tag under the INVENTARIO_RUN_ prefix.
+  # Env: INVENTARIO_RUN_ENABLE_API_DOCS
+  enableApiDocs: false
 
   # File upload storage location. Supports:
   #   file:///app/uploads?create_dir=1  (local; requires persistence.enabled=true)
@@ -579,6 +610,7 @@ secrets:
   #   INVENTARIO_RUN_MANDRILL_API_KEY            (required for mandrill/mailchimp provider)
   #   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY (required when aivision.provider=anthropic)
   #   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY    (required when aivision.provider=openai)
+  #   INVENTARIO_RUN_METRICS_TOKEN                   (optional; bearer token for GET /metrics — strongly recommended in production, see metrics.token)
   #   SETUP_ADMIN_PASSWORD                       (required by job-setup if setupJob.enabled)
   #   BACKOFFICE_USER_PASSWORD                   (required by setup/init-data Job when backofficeUser.enabled; maps to setupJob.initData.backofficeUserPassword; min 8 chars + upper + lower + digit)
   #   BACKOFFICE_USER_EMAIL                      (optional; when backofficeUser.enabled, overrides backofficeUser.email so the operator login identity comes from the Secret/sops bundle instead of the overlay; falls back to backofficeUser.email when absent)
@@ -629,6 +661,14 @@ secrets:
   # aivision.provider; empty otherwise. See the `aivision:` block above.
   aiVisionAnthropicApiKey: ""    # Env: INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY
   aiVisionOpenaiApiKey: ""       # Env: INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY
+
+  # Metrics bearer token (#2102). Convenience alias for metrics.token: when
+  # metrics.token is set it is mirrored into the chart-managed Secret as
+  # INVENTARIO_RUN_METRICS_TOKEN automatically, so you normally do NOT set this
+  # directly. Provided for completeness / explicit overrides. Ignored when
+  # secrets.existingSecret is set (supply INVENTARIO_RUN_METRICS_TOKEN there instead).
+  # Env: INVENTARIO_RUN_METRICS_TOKEN
+  metricsToken: ""
 
   # S3/MinIO credentials (required when app.uploadLocation uses s3://)
   # Automatically set from demo.minio.* when demo.minio.enabled=true.

--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,18 @@
   ],
   "packageRules": [
     {
-      "description": "Auto-merge patch and minor updates",
-      "matchUpdateTypes": ["patch", "minor"],
+      "description": "Auto-merge patch updates only (#2097). Minor and major are held for manual review. Auto-merge waits for branch-protection required checks (go-govulncheck, dependency-review, image scan) via platformAutomerge — those checks are the real gate, not Renovate. minimumReleaseAge adds a soak buffer against freshly-published-and-yanked patches.",
+      "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash"
+      "automergeStrategy": "squash",
+      "platformAutomerge": true,
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Never auto-merge minor or major updates (#2097) — review the changelog and CI results manually.",
+      "matchUpdateTypes": ["minor", "major"],
+      "automerge": false
     },
     {
       "description": "Group Cloud SDKs updates",


### PR DESCRIPTION
## Summary

Defense-in-depth security batch tracked under #2087, bundled into one PR. None of these are exploitable today; they close low-severity gaps before alpha.

Closes #2102 · Closes #2097 · Closes #2113

> Scope note: the original list also named #2099 (SECURITY.md — already **closed/done**) and #967 (refresh-token rotation — already **merged via #2165**), so both are excluded here.

---

### 🔐 #2102 — `GET /metrics` was unauthenticated (leaks installation-wide gauges)

- New `MetricsTokenMiddleware` gates `/metrics` behind an **optional** bearer token, compared with `crypto/subtle.ConstantTimeCompare`.
  - Token **unset** → no-op (legacy open behaviour) + a **one-time startup warning**, so local dev / e2e are unaffected.
  - Token **set** → `401` when the `Authorization: Bearer <token>` header is missing/wrong.
- Wired through the existing `run`-section config as `INVENTARIO_RUN_METRICS_TOKEN` / `--metrics-token`.
- **Helm:** a chart-managed `Secret` injects the token on every workload, the default Ingress no longer routes `/metrics`, and the `ServiceMonitor` sends the bearer automatically. `PRODUCTION.md` documents the posture.

### 🔐 #2097 — no dependency-vuln scanning in CI; patch+minor auto-merged on green

- New **blocking** `go-govulncheck.yml` and `dependency-review.yml` on PRs.
- **Trivy** image scan (SARIF, fail on HIGH/CRITICAL, `.trivyignore` allowlist) + **SBOM + provenance** enabled in `docker.yml`.
- Dependabot **and** Renovate auto-merge restricted to **patch-only** (fail-safe: anything not unambiguously a patch is held for review).
- `alpine:latest` base pinned to a digest (`alpine:3.22@sha256:310c62…`).

### 🔐 #2113 — authorization hardening backlog (L-1…L-6)

| Item | Change |
|---|---|
| **L-1** | `POST /backoffice/auth/refresh`: Origin/Referer check vs the configured public host (defence-in-depth on top of `SameSite=Strict`); corrected the inaccurate "cookie + bearer" route note. |
| **L-2** | `POST /seed`: **fail-closed** — refuse the first seed into a pre-existing non-`test-org` tenant, using a **tenant-scoped** user check (not the RLS-bypassed global list). Idempotent reseed of an already-seeded tenant still works. |
| **L-3** | `GET /invites/{token}`: moved **inside** the global per-IP rate-limit group. |
| **L-4** | `GET /debug`: moved off the tenant plane to **`/admin/debug` behind `RequireBackofficeAuth`** (it leaked storage/db driver + OS). |
| **L-5** | `GET /swagger/*`: gated behind `INVENTARIO_RUN_ENABLE_API_DOCS` (app default **on** for dev/e2e; the chart sets it **false** for prod). |
| **L-6** | CSRF middleware: **fail-closed** (`403`) on store errors for state-changing methods. Safe methods short-circuit earlier, so reads are never blocked during a CSRF-store outage. |

Swagger spec + frontend `api.d.ts` codegen regenerated for the `/debug → /admin/debug` move.

---

## How this was built / reviewed

Implemented via a survey → implement → verify → review agent workflow, then a human pass. The review phase **caught a real cross-domain bug**, now fixed in this PR: the Go `run` config reads env vars under the `INVENTARIO_RUN_` prefix (cleanenv), but the chart initially injected the **un-prefixed** `INVENTARIO_METRICS_TOKEN` / `INVENTARIO_ENABLE_API_DOCS` — which would have left `/metrics` open and `/swagger` on in production **silently**. The chart + docs now use the `RUN`-prefixed names, verified against the rendered template.

## Verification

- `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test` for changed packages — all green.
- New tests: metrics guard (open/401/200), `/admin/debug` access, `/swagger` gated off, `/invites` rate-limited, backoffice Origin reject, seed fail-closed, CSRF fail-closed.
- `actionlint` on changed workflows · `helm lint` + `helm template` render valid YAML · `helm template` confirms the env names match what the app reads.
- Frontend `codegen:check` up-to-date + `tsc` typecheck clean.

## ⚠️ Required manual follow-up

The patch-only auto-merge only **gates** on the new scans if branch protection **requires** them. Add `go-govulncheck`, `dependency-review`, and the docker image-scan checks to the `master` required-status-checks (the GitHub UI bit this action can't set). Ties into #1819.

## Known / deferred (non-blocking)

- L-1 Origin check is host-only (scheme-agnostic) — intentional, on top of `SameSite=Strict`. Noted as a `LOW` in review, not changed here to avoid breaking http-PublicURL dev setups.