### PR TITLE
fix(schema): add missing tenant/group FKs + export ON DELETE SET NULL via ptah bump

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   concurrency: 8
-  go: "1.26.0"
+  go: "1.26.4"
 
 linters:
   default: none

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -1,3 +1,3 @@
 module github.com/denisvmedia/inventario/frontend
 
-go 1.26.0
+go 1.26.4

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/denisvmedia/inventario
 
-go 1.26.3
+go 1.26.4
 
 tool (
 	github.com/go-extras/nolintguard/cmd/nolintguard
@@ -43,7 +43,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
-	github.com/stokaro/ptah v0.0.0-20260616125223-86a407bb5108
+	github.com/stokaro/ptah v0.0.0-20260622204233-3fac142ebf40
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.16.6
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/go/go.sum
+++ b/go/go.sum
@@ -479,8 +479,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spiffe/go-spiffe/v2 v2.7.0 h1:uXe1MflJoHw58wAUvxVlcM7WpKtijWG7I1UidcGh6g4=
 github.com/spiffe/go-spiffe/v2 v2.7.0/go.mod h1:47Q0Q9/AqGha8QLHp+kxpH4Wca7X7EnOtlIJy3mxZ3U=
-github.com/stokaro/ptah v0.0.0-20260616125223-86a407bb5108 h1:wfQUECnrWZeV4ir5i/nEu7DY9PpA6RAVaKnDz6ck0aE=
-github.com/stokaro/ptah v0.0.0-20260616125223-86a407bb5108/go.mod h1:agVdQjOXOb7wnIxgp0aR1j6rOg3gHlNOT4Xc86ce5OU=
+github.com/stokaro/ptah v0.0.0-20260622204233-3fac142ebf40 h1:urSRuRPSgVycaydZ5waz+fPwj+TE9Bb3rZaYbCkIp5U=
+github.com/stokaro/ptah v0.0.0-20260622204233-3fac142ebf40/go.mod h1:Id4FYM0nglazYyypIpbhKk0JKuaZ/KRLkaSed/xeoQM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go/models/currency_migration.go
+++ b/go/models/currency_migration.go
@@ -223,7 +223,7 @@ type CurrencyMigrationAuditRow struct {
 	//migrator:embedded mode="inline"
 	TenantGroupAwareEntityID
 
-	//migrator:schema:field name="migration_id" type="TEXT" not_null="true" foreign="currency_migrations(id)" foreign_key_name="fk_currency_migration_audit_migration"
+	//migrator:schema:field name="migration_id" type="TEXT" not_null="true" foreign="currency_migrations(id)" foreign_key_name="fk_currency_migration_audit_migration" on_delete="CASCADE"
 	MigrationID string `json:"migration_id" db:"migration_id"`
 
 	// CommodityID is nullable on purpose — see ON DELETE SET NULL on the

--- a/go/registry/postgres/tenant_purger.go
+++ b/go/registry/postgres/tenant_purger.go
@@ -79,8 +79,9 @@ func NewTenantPurgerWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *T
 // and no children, so their position within the data block is unconstrained.
 var tenantPurgeOrder = []func(t store.TableNames) string{
 	// Restore pipeline (deepest children first): steps -> operations ->
-	// exports. exports.file_id -> files is NO ACTION, so exports drop before
-	// files (which is later in this slice).
+	// exports. exports.file_id -> files is ON DELETE SET NULL (#2180); exports
+	// still drop before files here — the order is no longer FK-forced but is
+	// harmless and keeps the pipeline grouped.
 	func(t store.TableNames) string { return string(t.RestoreSteps()) },
 	func(t store.TableNames) string { return string(t.RestoreOperations()) },
 	func(t store.TableNames) string { return string(t.Exports()) },
@@ -92,8 +93,9 @@ var tenantPurgeOrder = []func(t store.TableNames) string{
 	func(t store.TableNames) string { return string(t.ThumbnailGenerationJobs()) },
 
 	// Generic polymorphic files (linked by entity_type/id, no FK chain). Must
-	// drop after exports + the thumbnail chain (both FK to files NO ACTION) and
-	// after commodities.cover_file_id (SET NULL — harmless either way).
+	// drop after the thumbnail chain (jobs.file_id -> files NO ACTION);
+	// exports.file_id (SET NULL, #2180) and commodities.cover_file_id (SET NULL)
+	// are harmless either way.
 	func(t store.TableNames) string { return string(t.Files()) },
 
 	// Commodity audit timelines (#1450). FK to commodities is CASCADE; explicit

--- a/go/schema/migrations/_sqldata/1782161136_fk_integrity_and_export_ondelete.down.sql
+++ b/go/schema/migrations/_sqldata/1782161136_fk_integrity_and_export_ondelete.down.sql
@@ -1,0 +1,57 @@
+-- Migration rollback
+-- Generated on: 2026-06-22T20:45:36Z
+-- Direction: DOWN
+
+-- Drop constraint fk_export_file (table resolved at runtime from information_schema)
+DO $ptah$
+DECLARE
+    target_table TEXT;
+BEGIN
+    SELECT table_name INTO target_table
+    FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_export_file'
+      AND table_schema = current_schema()
+    LIMIT 1;
+
+    IF target_table IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I', target_table, 'fk_export_file');
+        RAISE NOTICE 'Dropped constraint fk_export_file from table %', target_table;
+    ELSE
+        RAISE NOTICE 'Constraint fk_export_file not found in current schema';
+    END IF;
+END
+$ptah$;
+-- ALTER statements: --
+ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- ALTER statements: --
+ALTER TABLE commodities DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE locations DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE restore_operations DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE areas DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE restore_steps DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets DROP CONSTRAINT IF EXISTS fk_entity_tenant;
+-- ALTER statements: --
+ALTER TABLE areas DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE exports DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE restore_operations DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets DROP CONSTRAINT IF EXISTS fk_entity_user;
+-- ALTER statements: --
+ALTER TABLE restore_steps DROP CONSTRAINT IF EXISTS fk_entity_created_by;
+-- ALTER statements: --
+ALTER TABLE exports DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE commodities DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE files DROP CONSTRAINT IF EXISTS fk_entity_group;
+-- ALTER statements: --
+ALTER TABLE locations DROP CONSTRAINT IF EXISTS fk_entity_created_by;

--- a/go/schema/migrations/_sqldata/1782161136_fk_integrity_and_export_ondelete.up.sql
+++ b/go/schema/migrations/_sqldata/1782161136_fk_integrity_and_export_ondelete.up.sql
@@ -1,0 +1,57 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-06-22T20:45:36Z
+-- Direction: UP
+
+-- ALTER statements: --
+ALTER TABLE commodities ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE locations ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE restore_operations ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE areas ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE restore_steps ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+-- ALTER statements: --
+ALTER TABLE areas ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE exports ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE files ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE restore_operations ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE user_mfa_secrets ADD CONSTRAINT fk_entity_user FOREIGN KEY (user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE restore_steps ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE exports ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE commodities ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE files ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE locations ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- Drop constraint fk_export_file (table resolved at runtime from information_schema)
+DO $ptah$
+DECLARE
+    target_table TEXT;
+BEGIN
+    SELECT table_name INTO target_table
+    FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_export_file'
+      AND table_schema = current_schema()
+    LIMIT 1;
+
+    IF target_table IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I', target_table, 'fk_export_file');
+        RAISE NOTICE 'Dropped constraint fk_export_file from table %', target_table;
+    ELSE
+        RAISE NOTICE 'Constraint fk_export_file not found in current schema';
+    END IF;
+END
+$ptah$;
+-- ALTER statements: --
+ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Bumps `github.com/stokaro/ptah` to `v0.0.0-20260622204233-3fac142ebf40` and commits the migration that the corrected generator now produces. This surfaces and fixes **16 genuinely-missing foreign keys** across 8 tables (#2180) and rebuilds the `exports → files` FK with `ON DELETE SET NULL` (the residual F1 from #2122).

## The ptah bump

The previous ptah filtered field-level FKs out of the schema diff entirely, so the migration generator silently dropped declared `foreign=...` constraints. The upstream fix (stokaro/ptah **#189 / #190 / #197 / #198** — FK-on-delete-drift detection + embedded-mixin FK resolution) makes regeneration correctly emit them.

The newer ptah requires Go **>= 1.26.4**, so this PR also bumps the `go` directive and aligns the two version pins that were still lagging at `1.26.0` (the workflows and `Dockerfile` were already on `1.26.4`):

- `go/go.mod` `1.26.3 → 1.26.4`
- `.golangci.yml` analysis target `1.26.0 → 1.26.4`
- `frontend/go.mod` (standalone embed module) `1.26.0 → 1.26.4`

## The 16 missing FKs — Closes #2180

These tables embed the `TenantGroupAwareEntityID` / `TenantUserAwareEntityID` mixins, which declare `created_by_user_id`, `group_id`, `tenant_id`, `user_id` FKs. The mixin migrations changed over time **without a corresponding FK migration**, so the constraints lived in the Go model but never in Postgres. Regeneration against the fixed ptah surfaces all of them:

| Table | Added FK(s) |
|---|---|
| `commodities` | `fk_entity_created_by`, `fk_entity_group` |
| `locations` | `fk_entity_created_by`, `fk_entity_group` |
| `areas` | `fk_entity_created_by`, `fk_entity_group` |
| `files` | `fk_entity_created_by`, `fk_entity_group` |
| `exports` | `fk_entity_created_by`, `fk_entity_group` |
| `restore_operations` | `fk_entity_created_by`, `fk_entity_group` |
| `restore_steps` | `fk_entity_created_by`, `fk_entity_group` |
| `user_mfa_secrets` | `fk_entity_tenant`, `fk_entity_user` |

## The `fk_export_file` ON DELETE SET NULL — #2122 (F1)

`go/models/export.go` declares `on_delete=SET NULL` for `file_id`, but the original generated SQL emitted `NO ACTION`. The migration DROP-then-ADDs `fk_export_file` with `ON DELETE SET NULL`, so deleting a file nulls the export's `file_id` instead of blocking the delete.

## Currency-audit annotation alignment — #2122 (F2)

`fk_currency_migration_audit_migration` gets `on_delete="CASCADE"` added to the model annotation. The DB already had the CASCADE; this stops the regenerator from *stripping* it, keeping the generate-is-a-no-op invariant.

## Validation

Run on a live containerized Postgres (the same flow as `scripts/generate-migration.sh` / `inventool db migrations`):

- `up` applies cleanly to version `1782161136` (strictly greater than the prior max `1782048731` — no collision).
- `up → down → up` round-trips with no error (verified: `fk_export_file.confdeltype` toggles `n`↔`a`, the 16 `fk_entity_*` toggle present↔absent).
- `inventool db migrations generate --check` reports **"Schema is in sync — no pending migrations"** after applying — model ↔ DB fully aligned, so this is the CI `lint-migrations` gate passing.
- Full Go suite green: unit suite (142 pkgs) + the postgres registry suite (run against a CI-equivalent bootstrapped multi-role DB), `golangci-lint`/`nolintguard`/`qtlint` all clean.

## ⚠️ Data-safety for existing deployments (orphan audit)

`ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` **fails if existing rows violate the new constraint** — i.e. a non-null `created_by_user_id` / `group_id` / `tenant_id` / `user_id` that points at an already-deleted parent. Fresh and seed-data deployments are unaffected. Operators with existing data should run an orphan audit and clean up (or repair) any dangling rows **before** applying this migration:

```sql
SELECT 'commodities.created_by_user_id' AS fk, count(*) FROM commodities c
  LEFT JOIN users u ON u.id = c.created_by_user_id
  WHERE c.created_by_user_id IS NOT NULL AND u.id IS NULL
UNION ALL SELECT 'commodities.group_id', count(*) FROM commodities c
  LEFT JOIN location_groups g ON g.id = c.group_id
  WHERE c.group_id IS NOT NULL AND g.id IS NULL
-- … repeat per (table, fk) for the 8 tables above …
;
```

Any non-zero count must be resolved before the migration will apply. This caveat is intentionally kept out of the generated `.up.sql` (which stays exactly as the generator produced it) and documented here + in #2180.

Closes #2180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.4 across the project.
  * Updated a third-party dependency to the latest version.

* **Database Changes**
  * Enhanced foreign key constraints across multiple tables to ensure improved data integrity and proper cascade behavior on deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->