### PR TITLE
fix(email): reject stub provider + public URL at startup (#2093)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -267,6 +267,10 @@ jobs:
       INVENTARIO_RUN_JWT_SECRET: "e2e-jwt-secret-please-change-for-prod"
       INVENTARIO_RUN_FILE_SIGNING_KEY: "e2e-file-signing-key-please-change"
       INVENTARIO_RUN_PUBLIC_URL: "http://localhost:3333"
+      # This lane runs the host binary with the stub provider (no Mailpit) while
+      # a public URL is set, so opt into the #2093 guard — otherwise the backend
+      # treats stub+public-URL as a fatal misconfiguration and refuses to start.
+      INVENTARIO_RUN_ALLOW_STUB_EMAIL: "true"
       # Feedback (#1387) needs a destination address or the handler 503s.
       # The 503 propagates as MaintenancePage on the FE (lib/http.ts),
       # which masks the toast assertion. The stub email provider doesn't

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,59 @@ Support for multiple database backends via DSN:
 - Comprehensive model validation testing
 - Registry pattern testing with mock implementations
 
+### Test package layout — black-box by default
+
+- **Black-box is the default.** Put tests in `*_test.go` using the external test
+  package (`package <pkg>_test`) and exercise only the exported API. This keeps
+  tests honest about the package's public contract.
+
+  ```go
+  // file: widget_test.go
+  package widget_test
+
+  import (
+  	"testing"
+
+  	qt "github.com/frankban/quicktest"
+
+  	"github.com/denisvmedia/inventario/internal/widget"
+  )
+
+  func TestWidget_Process(t *testing.T) {
+  	c := qt.New(t)
+  	w := widget.New(widget.Config{})
+  	c.Assert(w.Process("in"), qt.Equals, "out")
+  }
+  ```
+
+- **White-box is the exception**, permitted ONLY when (1) an unexported function
+  is critical for correctness, (2) internal state cannot be observed through the
+  public API, or (3) there is a clear technical justification. Requirements:
+    - file name ends in `*_internal_test.go`;
+    - package name has no `_test` suffix (`package <pkg>`);
+    - a comment at the top of the file states the justification.
+
+  ```go
+  // file: parser_internal_test.go
+  package widget
+
+  // White-box: drives the unexported parse() state machine directly; its
+  // branches cannot be fully exercised through the exported API alone.
+
+  import (
+  	"testing"
+
+  	qt "github.com/frankban/quicktest"
+  )
+
+  func Test_parse(t *testing.T) {
+  	c := qt.New(t)
+  	got, err := parse([]byte("3:foo"))
+  	c.Assert(err, qt.IsNil)
+  	c.Assert(got, qt.Equals, "foo")
+  }
+  ```
+
 ### Integration Tests  
 - Multi-tenant isolation testing
 - Database transaction testing

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -64,7 +64,7 @@ Fill these in before you start; they parameterize the rest of the runbook.
 | Kubernetes distro | k3s (GKE / DOKS notes inline) |
 | PostgreSQL | **External** — managed or in-cluster operator (your choice; see §B3) |
 | Object storage | **Cloudflare R2** (S3-compatible) |
-| Email provider | **Mailtrap** (SMTP) |
+| Email provider | **SMTP2GO** (HTTP API) |
 | AI vision | **Anthropic** |
 | Redis | **In-cluster** (chart's bundled Redis) |
 | Public scan endpoint | Off (enable deliberately — see §B7) |
@@ -231,18 +231,22 @@ than one replica (set `persistence.enabled=false`).
 
   Try without them first; add if uploads fail.
 
-### B5. Email — Mailtrap (SMTP)
+### B5. Email — SMTP2GO
 
-- [ ] In Mailtrap, use a **Sending** stream (not the Sandbox) and copy its SMTP
-  credentials. Set:
-  - `email.provider=smtp`, `email.smtp.host=live.smtp.mailtrap.io`, `email.smtp.port=587`,
-    `email.smtp.useTls=true`, `email.smtp.username=<user>`.
+- [ ] In SMTP2GO, create an **API key** (Settings → API Keys) and verify a sender
+  domain / address. Set:
+  - `email.provider=smtp2go`.
   - `email.from=<verified sender>` (must be a non-empty address on a domain you verified
-    in Mailtrap).
+    in SMTP2GO).
   - `app.publicUrl=https://<DOMAIN>` so links inside emails resolve.
-  - SMTP password → Secret key `INVENTARIO_RUN_SMTP_PASSWORD`.
+  - API key → Secret key `INVENTARIO_RUN_SMTP2GO_API_KEY` (Helm `secrets.smtp2goApiKey`).
 - [ ] (Optional) `email.replyTo`. Leave `email.logUrls=false` in production (tokens in
   logs).
+- [ ] **Alternative — SMTP relay:** if you prefer SMTP over the HTTP API, set
+  `email.provider=smtp`, `email.smtp.host=mail.smtp2go.com`, `email.smtp.port=587`
+  (or `2525`), `email.smtp.useTls=true` (our provider uses STARTTLS — do NOT use the
+  `465`/`443` implicit-TLS ports), `email.smtp.username=<SMTP user>`, and the SMTP
+  password → Secret key `INVENTARIO_RUN_SMTP_PASSWORD`.
 
 ### B6. Redis — in-cluster
 
@@ -506,7 +510,7 @@ Use independent layers — at least the first two are required:
 - [ ] Register or log in; create an item.
 - [ ] Upload a file/photo → confirm it lands in R2 (and renders back).
 - [ ] Run an AI scan (Anthropic) on the add-item form.
-- [ ] Trigger a password reset → confirm the email arrives via Mailtrap.
+- [ ] Trigger a password reset → confirm the email arrives via SMTP2GO.
 - [ ] Confirm the Grafana dashboard shows live traffic and a test alert routes to your
   channel.
 
@@ -514,7 +518,7 @@ Use independent layers — at least the first two are required:
 
 ## Appendix A — Worked `values-prod.yaml` (k3s)
 
-External Postgres + Cloudflare R2 + Mailtrap + Anthropic + in-cluster Redis, combined
+External Postgres + Cloudflare R2 + SMTP2GO + Anthropic + in-cluster Redis, combined
 mode, no uploads PVC. Sensitive values come from the existing Secret in Appendix B; this
 file holds only non-secret configuration.
 
@@ -536,13 +540,9 @@ app:
   enableApiDocs: false         # keep /swagger off in prod (chart default; shown for clarity)
 
 email:
-  provider: smtp
+  provider: smtp2go
   from: "no-reply@example.com"
-  smtp:
-    host: live.smtp.mailtrap.io
-    port: 587
-    username: "<mailtrap-smtp-user>"
-    useTls: true
+  # API key → Secret key INVENTARIO_RUN_SMTP2GO_API_KEY (Appendix B).
 
 aivision:
   provider: anthropic
@@ -608,7 +608,7 @@ kubectl -n inventario create secret generic inventario-runtime \
   --from-literal=INVENTARIO_RUN_FILE_SIGNING_KEY='<openssl rand -hex 32>' \
   --from-literal=INVENTARIO_RUN_METRICS_TOKEN='<openssl rand -hex 32>' \
   --from-literal=SETUP_ADMIN_PASSWORD='<initial admin password>' \
-  --from-literal=INVENTARIO_RUN_SMTP_PASSWORD='<mailtrap smtp password>' \
+  --from-literal=INVENTARIO_RUN_SMTP2GO_API_KEY='<smtp2go api key>' \
   --from-literal=INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY='<anthropic api key>' \
   --from-literal=AWS_ACCESS_KEY_ID='<r2 access key id>' \
   --from-literal=AWS_SECRET_ACCESS_KEY='<r2 secret access key>'

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -651,6 +651,7 @@ If your Postgres roles are created out-of-band, also add `SETUP_SUPERUSER_DSN` (
 | apiserver crashes on boot | `aivision.provider` real but API key empty | set the key, or `aivision.provider=none` (§B7) |
 | Setup Job hangs / sync wedged | image tag missing from registry | fix the tag; `setupJob.activeDeadlineSeconds` caps the hang |
 | Emails never arrive | `email.provider=stub` (default) | set a real provider + `email.from` (§B5) |
+| Backend refuses to start: "verification/reset/invite emails would be silently dropped" | `email.provider=stub` while `app.publicUrl` is set (#2093) | set a real provider + `email.from` (§B5), or `email.allowStub=true` for eval-only |
 
 ## Appendix F — Per-distro quick reference
 

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -189,8 +189,14 @@ type Config struct {
 	ProbeAddr string `yaml:"probe_addr" env:"PROBE_ADDR" env-default:":3334"`
 
 	EmailProvider string `yaml:"email_provider" env:"EMAIL_PROVIDER" env-default:"stub"`
-	EmailFrom     string `yaml:"email_from" env:"EMAIL_FROM" env-default:""`
-	EmailReplyTo  string `yaml:"email_reply_to" env:"EMAIL_REPLY_TO" env-default:""`
+	// AllowStubEmail opts into running the no-op "stub" email provider even
+	// when a public URL is configured. By default that combination is rejected
+	// at startup because verification/reset/invite mail would be silently
+	// dropped on a real deployment (#2093); this flag is the explicit dev/eval
+	// escape hatch and downgrades the rejection to a loud warning.
+	AllowStubEmail bool   `yaml:"allow_stub_email" env:"ALLOW_STUB_EMAIL" env-default:"false"`
+	EmailFrom      string `yaml:"email_from" env:"EMAIL_FROM" env-default:""`
+	EmailReplyTo   string `yaml:"email_reply_to" env:"EMAIL_REPLY_TO" env-default:""`
 	// SupportEmail is the destination address for in-app feedback
 	// submissions (issue #1387). Empty leaves the POST /feedback
 	// endpoint mounted but it returns a typed 503 (feedback.not_configured)

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -215,6 +215,8 @@ type Config struct {
 	AWSRegion            string `yaml:"aws_region" env:"AWS_REGION" env-default:""`
 	MandrillAPIKey       string `yaml:"mandrill_api_key" env:"MANDRILL_API_KEY" env-default:""`
 	MandrillBaseURL      string `yaml:"mandrill_base_url" env:"MANDRILL_BASE_URL" env-default:"https://mandrillapp.com"`
+	SMTP2GOAPIKey        string `yaml:"smtp2go_api_key" env:"SMTP2GO_API_KEY" env-default:""`
+	SMTP2GOBaseURL       string `yaml:"smtp2go_base_url" env:"SMTP2GO_BASE_URL" env-default:"https://api.smtp2go.com"`
 
 	// OAuth* settings drive the third-party sign-in flow (#1394). Each
 	// provider is enabled only when its (client_id, client_secret) pair

--- a/go/cmd/inventario/run/bootstrap/email.go
+++ b/go/cmd/inventario/run/bootstrap/email.go
@@ -100,19 +100,28 @@ func ValidatePublicURLForTransactionalEmails(publicURL string) error {
 
 // ValidateEmailPublicURLConfig returns an error when the combination of the
 // configured email provider and public URL would result in broken transactional
-// links. The stub provider is exempt because it never sends real email.
-func ValidateEmailPublicURLConfig(provider, publicURL string) error {
+// links. The stub provider with a configured public URL is rejected as a fatal
+// misconfiguration (#2093) unless allowStub is true, in which case the rejection
+// is downgraded to a loud warning for dev/eval use.
+//
+//revive:disable-next-line:flag-parameter
+func ValidateEmailPublicURLConfig(provider, publicURL string, allowStub bool) error {
 	normalizedEmailProvider := normalizeEmailProvider(provider)
 
 	switch normalizedEmailProvider {
 	case services.EmailProviderStub:
-		// The stub provider is a legitimate choice for dev / preview, so this is
-		// a warning, not a fatal error. But a configured public URL strongly
-		// implies a real deployment where users will expect verification /
-		// reset / invite emails — none of which the stub ever sends. Warn loudly
-		// so a "users never receive any email" deployment is not silent.
+		// A configured public URL means a real deployment where users will
+		// expect verification / reset / invite emails — none of which the stub
+		// provider ever sends. Without an explicit opt-in this is a fatal
+		// misconfiguration (#2093): fail fast at startup instead of silently
+		// dropping every transactional email. allowStub (--allow-stub-email) is
+		// the dev/eval escape hatch and downgrades the failure to a loud warning.
 		if trimmedURL := strings.TrimSpace(publicURL); trimmedURL != "" {
-			slog.Warn("email provider is 'stub': verification/reset/invite emails will be silently dropped; set a real SMTP (or other) provider + email.from for any deployment real users will use",
+			if !allowStub {
+				//nolint:lll
+				return fmt.Errorf("email provider is %q but a public URL is set (%s): verification/reset/invite emails would be silently dropped. Configure a real email provider (e.g. --email-provider=smtp) plus --email-from, or pass --allow-stub-email to override for dev/eval", normalizedEmailProvider, trimmedURL)
+			}
+			slog.Warn("email provider is 'stub' with --allow-stub-email set: verification/reset/invite emails will be silently dropped; set a real SMTP (or other) provider + email.from for any deployment real users will use",
 				"public_url", trimmedURL)
 		}
 		return nil

--- a/go/cmd/inventario/run/bootstrap/email.go
+++ b/go/cmd/inventario/run/bootstrap/email.go
@@ -62,6 +62,8 @@ func buildEmailService(cfg *Config) (EmailServiceLifecycle, error) {
 		AWSRegion:       cfg.AWSRegion,
 		MandrillAPIKey:  cfg.MandrillAPIKey,
 		MandrillBaseURL: cfg.MandrillBaseURL,
+		SMTP2GOAPIKey:   cfg.SMTP2GOAPIKey,
+		SMTP2GOBaseURL:  cfg.SMTP2GOBaseURL,
 	})
 	if err != nil {
 		return EmailServiceLifecycle{}, err
@@ -129,7 +131,8 @@ func ValidateEmailPublicURLConfig(provider, publicURL string, allowStub bool) er
 		services.EmailProviderSendGrid,
 		services.EmailProviderSES,
 		services.EmailProviderMandrill,
-		services.EmailProviderMailchimp:
+		services.EmailProviderMailchimp,
+		services.EmailProviderSMTP2GO:
 		if err := ValidatePublicURLForTransactionalEmails(publicURL); err != nil {
 			return fmt.Errorf("invalid --public-url for email provider %q: %w", normalizedEmailProvider, err)
 		}

--- a/go/cmd/inventario/run/bootstrap/email_test.go
+++ b/go/cmd/inventario/run/bootstrap/email_test.go
@@ -52,16 +52,18 @@ func TestValidateEmailPublicURLConfig_Valid(t *testing.T) {
 		name      string
 		provider  string
 		publicURL string
+		allowStub bool
 	}{
-		{name: "stub provider does not require public url", provider: "stub", publicURL: ""},
-		{name: "supported provider with valid public url", provider: "smtp", publicURL: "https://inventario.example.com"},
-		{name: "empty provider defaults to stub", provider: "", publicURL: ""},
+		{name: "stub provider does not require public url", provider: "stub", publicURL: "", allowStub: false},
+		{name: "supported provider with valid public url", provider: "smtp", publicURL: "https://inventario.example.com", allowStub: false},
+		{name: "empty provider defaults to stub", provider: "", publicURL: "", allowStub: false},
+		{name: "stub with public url and allow-stub flag passes with warning", provider: "stub", publicURL: "https://inventario.example.com", allowStub: true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
-			err := bootstrap.ValidateEmailPublicURLConfig(tc.provider, tc.publicURL)
+			err := bootstrap.ValidateEmailPublicURLConfig(tc.provider, tc.publicURL, tc.allowStub)
 			c.Assert(err, qt.IsNil)
 		})
 	}
@@ -72,26 +74,36 @@ func TestValidateEmailPublicURLConfig_Invalid(t *testing.T) {
 		name            string
 		provider        string
 		publicURL       string
+		allowStub       bool
 		wantErrContains string
 	}{
 		{
 			name:            "supported provider with invalid public url",
 			provider:        "smtp",
 			publicURL:       "",
+			allowStub:       false,
 			wantErrContains: "invalid --public-url for email provider",
 		},
 		{
 			name:            "unknown provider returns provider error",
 			provider:        "unknown-provider",
 			publicURL:       "",
+			allowStub:       false,
 			wantErrContains: "unsupported email provider",
+		},
+		{
+			name:            "stub with public url and no allow flag is fatal",
+			provider:        "stub",
+			publicURL:       "https://inventario.example.com",
+			allowStub:       false,
+			wantErrContains: "would be silently dropped",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
-			err := bootstrap.ValidateEmailPublicURLConfig(tc.provider, tc.publicURL)
+			err := bootstrap.ValidateEmailPublicURLConfig(tc.provider, tc.publicURL, tc.allowStub)
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(err.Error(), qt.Contains, tc.wantErrContains)
 		})

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -70,6 +70,8 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.BoolVar(&cfg.MagicLinkLoginEnabled, "magic-link-login-enabled", cfg.MagicLinkLoginEnabled, "Enable passwordless magic-link sign-in (auto-inert when the email provider is stub)")
 
 	flags.StringVar(&cfg.EmailProvider, "email-provider", cfg.EmailProvider, "Email provider: stub, smtp, sendgrid, ses, mandrill, or mailchimp")
+	//nolint:lll
+	flags.BoolVar(&cfg.AllowStubEmail, "allow-stub-email", cfg.AllowStubEmail, "Allow the no-op 'stub' email provider even when --public-url is set (dev/eval only; by default that combination is rejected at startup because verification/reset/invite mail would be silently dropped)")
 	flags.BoolVar(&cfg.LogEmailURLs, "log-email-urls", cfg.LogEmailURLs, "Log full verification/password-reset URLs in stub email mode (includes sensitive tokens; unsafe for shared logs)")
 	flags.StringVar(&cfg.EmailFrom, "email-from", cfg.EmailFrom, "From address for transactional emails")
 	flags.StringVar(&cfg.EmailReplyTo, "email-reply-to", cfg.EmailReplyTo, "Reply-To address for transactional emails")

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -69,7 +69,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.PublicURL, "public-url", cfg.PublicURL, "Public base URL used in transactional email links (e.g., https://inventario.example.com)")
 	flags.BoolVar(&cfg.MagicLinkLoginEnabled, "magic-link-login-enabled", cfg.MagicLinkLoginEnabled, "Enable passwordless magic-link sign-in (auto-inert when the email provider is stub)")
 
-	flags.StringVar(&cfg.EmailProvider, "email-provider", cfg.EmailProvider, "Email provider: stub, smtp, sendgrid, ses, mandrill, or mailchimp")
+	flags.StringVar(&cfg.EmailProvider, "email-provider", cfg.EmailProvider, "Email provider: stub, smtp, sendgrid, ses, mandrill, mailchimp, or smtp2go")
 	//nolint:lll
 	flags.BoolVar(&cfg.AllowStubEmail, "allow-stub-email", cfg.AllowStubEmail, "Allow the no-op 'stub' email provider even when --public-url is set (dev/eval only; by default that combination is rejected at startup because verification/reset/invite mail would be silently dropped)")
 	flags.BoolVar(&cfg.LogEmailURLs, "log-email-urls", cfg.LogEmailURLs, "Log full verification/password-reset URLs in stub email mode (includes sensitive tokens; unsafe for shared logs)")
@@ -93,6 +93,9 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 
 	flags.StringVar(&cfg.MandrillAPIKey, "mandrill-api-key", cfg.MandrillAPIKey, "Mandrill/Mailchimp Transactional API key")
 	flags.StringVar(&cfg.MandrillBaseURL, "mandrill-base-url", cfg.MandrillBaseURL, "Mandrill API base URL")
+
+	flags.StringVar(&cfg.SMTP2GOAPIKey, "smtp2go-api-key", cfg.SMTP2GOAPIKey, "SMTP2GO API key")
+	flags.StringVar(&cfg.SMTP2GOBaseURL, "smtp2go-base-url", cfg.SMTP2GOBaseURL, "SMTP2GO API base URL")
 
 	// AI vision photo-scan tunables (issue #1720).
 	flags.StringVar(&cfg.AIVisionProvider, "ai-vision-provider", cfg.AIVisionProvider, "AI vision provider: none, mock, anthropic, openai")

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -176,7 +176,7 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 	}
 
 	params.PublicURL = strings.TrimSpace(cfg.PublicURL)
-	if err = ValidateEmailPublicURLConfig(cfg.EmailProvider, params.PublicURL); err != nil {
+	if err = ValidateEmailPublicURLConfig(cfg.EmailProvider, params.PublicURL, cfg.AllowStubEmail); err != nil {
 		return serverSetup{}, err
 	}
 

--- a/go/email/providers/mandrill/sender.go
+++ b/go/email/providers/mandrill/sender.go
@@ -20,7 +20,8 @@ import (
 type Config struct {
 	// APIKey authenticates calls to the Mandrill API.
 	APIKey string
-	// BaseURL overrides the API host (useful for tests/proxies).
+	// BaseURL overrides the API host (useful for tests/proxies); must be https
+	// so the API key (sent in the request body) is never transmitted in plaintext.
 	BaseURL string
 	// HTTPClient optionally overrides the default timeout-configured client.
 	HTTPClient *http.Client
@@ -138,8 +139,11 @@ func normalizeBaseURL(rawBaseURL, defaultBaseURL string) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", fmt.Errorf("invalid mandrill base URL %q: scheme and host are required", baseURL)
 	}
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return "", fmt.Errorf("invalid mandrill base URL %q: unsupported scheme %q", baseURL, parsed.Scheme)
+	// HTTPS only: the API key is sent in the request body, so a plaintext base
+	// URL would leak it. The default host is https; an override (tests/proxies)
+	// must be https too. Tests use an httptest TLS server.
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid mandrill base URL %q: only https is supported", baseURL)
 	}
 
 	return parsed.String(), nil

--- a/go/email/providers/sendgrid/sender.go
+++ b/go/email/providers/sendgrid/sender.go
@@ -21,7 +21,8 @@ import (
 type Config struct {
 	// APIKey is the bearer token used for SendGrid API authentication.
 	APIKey string
-	// BaseURL overrides the API host (primarily for tests/proxies).
+	// BaseURL overrides the API host (primarily for tests/proxies); must be
+	// https so the bearer API key is never sent in plaintext.
 	BaseURL string
 	// HTTPClient optionally overrides the default timeout-configured client.
 	HTTPClient *http.Client
@@ -120,8 +121,11 @@ func normalizeBaseURL(rawBaseURL, defaultBaseURL string) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", fmt.Errorf("invalid sendgrid base URL %q: scheme and host are required", baseURL)
 	}
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return "", fmt.Errorf("invalid sendgrid base URL %q: unsupported scheme %q", baseURL, parsed.Scheme)
+	// HTTPS only: the API key is sent as an Authorization: Bearer header, so a
+	// plaintext base URL would leak it. The default host is https; an override
+	// (tests/proxies) must be https too. Tests use an httptest TLS server.
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid sendgrid base URL %q: only https is supported", baseURL)
 	}
 
 	return parsed.String(), nil

--- a/go/email/providers/sendgrid/sender_test.go
+++ b/go/email/providers/sendgrid/sender_test.go
@@ -1,4 +1,4 @@
-package sendgrid
+package sendgrid_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/denisvmedia/inventario/email/providers/sendgrid"
 	"github.com/denisvmedia/inventario/email/sender"
 )
 
@@ -24,16 +25,28 @@ type sendgridRecordedRequest struct {
 func TestNew_RequiresAPIKey(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := New(Config{})
+	_, err := sendgrid.New(sendgrid.Config{})
 	c.Assert(err, qt.IsNotNil)
 }
 
 func TestNew_InvalidBaseURL(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := New(Config{
+	_, err := sendgrid.New(sendgrid.Config{
 		APIKey:  "key",
 		BaseURL: "://bad",
+	})
+	c.Assert(err, qt.IsNotNil)
+}
+
+func TestNew_RejectsPlaintextHTTP(t *testing.T) {
+	c := qt.New(t)
+
+	// The bearer API key would be sent over plaintext, so an http base URL
+	// must be refused outright.
+	_, err := sendgrid.New(sendgrid.Config{
+		APIKey:  "key",
+		BaseURL: "http://api.sendgrid.com",
 	})
 	c.Assert(err, qt.IsNotNil)
 }
@@ -42,7 +55,7 @@ func TestSend_Success(t *testing.T) {
 	c := qt.New(t)
 
 	recCh := make(chan sendgridRecordedRequest, 1)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
 
@@ -57,7 +70,7 @@ func TestSend_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s, err := New(Config{
+	s, err := sendgrid.New(sendgrid.Config{
 		APIKey:     "key-1",
 		BaseURL:    srv.URL,
 		HTTPClient: srv.Client(),
@@ -92,13 +105,13 @@ func TestSend_Success(t *testing.T) {
 func TestSend_Non2xx(t *testing.T) {
 	c := qt.New(t)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte("upstream down"))
 	}))
 	defer srv.Close()
 
-	s, err := New(Config{
+	s, err := sendgrid.New(sendgrid.Config{
 		APIKey:     "key-1",
 		BaseURL:    srv.URL,
 		HTTPClient: srv.Client(),

--- a/go/email/providers/ses/sender_internal_test.go
+++ b/go/email/providers/ses/sender_internal_test.go
@@ -1,5 +1,10 @@
 package ses
 
+// White-box: constructs Sender with a fake client wired into the unexported
+// `client sesAPI` field and asserts on the SDK SendEmailInput it builds. The
+// SES SDK call cannot be intercepted through the exported New/Send API without
+// a live AWS endpoint, so the request-mapping logic is only observable here.
+
 import (
 	"context"
 	"errors"

--- a/go/email/providers/smtp/sender_internal_test.go
+++ b/go/email/providers/smtp/sender_internal_test.go
@@ -1,5 +1,9 @@
 package smtp
 
+// White-box: exercises the unexported buildMIMEMessage MIME assembler (and its
+// header-encoding helpers) directly; the produced MIME bytes are not observable
+// through the exported Sender API without a live SMTP conversation.
+
 import (
 	"bufio"
 	"context"

--- a/go/email/providers/smtp2go/doc.go
+++ b/go/email/providers/smtp2go/doc.go
@@ -1,0 +1,5 @@
+// Package smtp2go provides an email sender backed by the SMTP2GO v3 HTTP API
+// (POST /v3/email/send). It authenticates with the X-Smtp2go-Api-Key header and
+// surfaces both transport (non-2xx) and provider-level (data.failed /
+// data.error) failures so the caller's retry/backoff policy stays centralized.
+package smtp2go

--- a/go/email/providers/smtp2go/sender.go
+++ b/go/email/providers/smtp2go/sender.go
@@ -1,0 +1,148 @@
+package smtp2go
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/denisvmedia/inventario/email/sender"
+)
+
+// Config defines SMTP2GO API transport settings.
+//
+// New uses this config to build an HTTP client-backed transport targeting the
+// v3 /email/send endpoint.
+type Config struct {
+	// APIKey is sent in the X-Smtp2go-Api-Key header for authentication.
+	APIKey string
+	// BaseURL overrides the API host (primarily for tests/proxies); must be
+	// https so the API-key header is never sent in plaintext.
+	BaseURL string
+	// HTTPClient optionally overrides the default timeout-configured client.
+	HTTPClient *http.Client
+}
+
+// Sender delivers email through the SMTP2GO v3 send API.
+//
+// It translates sender.Message into the provider JSON schema and treats both
+// non-2xx responses and provider-level failures (data.failed / data.error) as
+// hard send failures so retry policy stays centralized upstream.
+type Sender struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New creates an SMTP2GO sender from config and validates required fields.
+func New(cfg Config) (*Sender, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, fmt.Errorf("smtp2go provider requires SMTP2GO_API_KEY")
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	baseURL, err := normalizeBaseURL(cfg.BaseURL, "https://api.smtp2go.com")
+	if err != nil {
+		return nil, err
+	}
+	return &Sender{
+		apiKey:     strings.TrimSpace(cfg.APIKey),
+		baseURL:    baseURL,
+		httpClient: client,
+	}, nil
+}
+
+// Send performs one HTTP POST to /v3/email/send.
+//
+// SMTP2GO returns HTTP 200 with a per-request result object even for some
+// rejections, so both the HTTP status and data.succeeded / data.failed are
+// inspected before reporting success.
+func (s *Sender) Send(ctx context.Context, message sender.Message) error {
+	type customHeader struct {
+		Header string `json:"header"`
+		Value  string `json:"value"`
+	}
+	payload := map[string]any{
+		"sender":    message.From,
+		"to":        []string{message.To},
+		"subject":   message.Subject,
+		"text_body": message.Text,
+		"html_body": message.HTML,
+	}
+	if strings.TrimSpace(message.ReplyTo) != "" {
+		payload["custom_headers"] = []customHeader{{Header: "Reply-To", Value: message.ReplyTo}}
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal smtp2go payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/v3/email/send", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create smtp2go request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Smtp2go-Api-Key", s.apiKey)
+
+	resp, err := s.httpClient.Do(req) // #nosec G704 -- request URL is built from validated provider base URL configured by trusted runtime settings.
+	if err != nil {
+		return fmt.Errorf("smtp2go request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("smtp2go request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(rawBody)))
+	}
+
+	var result struct {
+		Data struct {
+			Succeeded int    `json:"succeeded"`
+			Failed    int    `json:"failed"`
+			Error     string `json:"error"`
+			ErrorCode string `json:"error_code"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rawBody, &result); err != nil {
+		return fmt.Errorf("smtp2go response parse failed: %s", strings.TrimSpace(string(rawBody)))
+	}
+	if result.Data.Error != "" || result.Data.ErrorCode != "" {
+		return fmt.Errorf("smtp2go rejected email: %s (%s)", result.Data.Error, result.Data.ErrorCode)
+	}
+	if result.Data.Failed > 0 || result.Data.Succeeded < 1 {
+		return fmt.Errorf("smtp2go failed to send email (succeeded=%d failed=%d): %s", result.Data.Succeeded, result.Data.Failed, strings.TrimSpace(string(rawBody)))
+	}
+	return nil
+}
+
+func normalizeBaseURL(rawBaseURL, defaultBaseURL string) (string, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(rawBaseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid smtp2go base URL %q: %w", baseURL, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid smtp2go base URL %q: scheme and host are required", baseURL)
+	}
+	// HTTPS only: the API key travels in the X-Smtp2go-Api-Key request header,
+	// so a plaintext base URL would leak it. Tests point HTTPClient at an
+	// httptest TLS server, so they exercise this path over https too.
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid smtp2go base URL %q: only https is supported", baseURL)
+	}
+
+	return parsed.String(), nil
+}

--- a/go/email/providers/smtp2go/sender_test.go
+++ b/go/email/providers/smtp2go/sender_test.go
@@ -1,7 +1,8 @@
-package mandrill_test
+package smtp2go_test
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,28 +10,28 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/denisvmedia/inventario/email/providers/mandrill"
+	"github.com/denisvmedia/inventario/email/providers/smtp2go"
 	"github.com/denisvmedia/inventario/email/sender"
 )
 
-type mandrillRecordedRequest struct {
-	method      string
-	path        string
-	contentType string
-	body        []byte
+type smtp2goRecordedRequest struct {
+	method string
+	path   string
+	apiKey string
+	body   []byte
 }
 
 func TestNew_RequiresAPIKey(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := mandrill.New(mandrill.Config{})
+	_, err := smtp2go.New(smtp2go.Config{})
 	c.Assert(err, qt.IsNotNil)
 }
 
 func TestNew_InvalidBaseURL(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := mandrill.New(mandrill.Config{
+	_, err := smtp2go.New(smtp2go.Config{
 		APIKey:  "key",
 		BaseURL: "://bad",
 	})
@@ -40,11 +41,11 @@ func TestNew_InvalidBaseURL(t *testing.T) {
 func TestNew_RejectsPlaintextHTTP(t *testing.T) {
 	c := qt.New(t)
 
-	// The API key would be sent over plaintext, so an http base URL must be
-	// refused outright.
-	_, err := mandrill.New(mandrill.Config{
+	// The API key rides in the X-Smtp2go-Api-Key header, so a plaintext base
+	// URL must be refused outright to avoid leaking it.
+	_, err := smtp2go.New(smtp2go.Config{
 		APIKey:  "key",
-		BaseURL: "http://mandrillapp.com",
+		BaseURL: "http://api.smtp2go.com",
 	})
 	c.Assert(err, qt.IsNotNil)
 }
@@ -52,83 +53,67 @@ func TestNew_RejectsPlaintextHTTP(t *testing.T) {
 func TestSend_Success(t *testing.T) {
 	c := qt.New(t)
 
-	recCh := make(chan mandrillRecordedRequest, 1)
+	recCh := make(chan smtp2goRecordedRequest, 1)
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
-		recCh <- mandrillRecordedRequest{
-			method:      r.Method,
-			path:        r.URL.Path,
-			contentType: r.Header.Get("Content-Type"),
-			body:        body,
+
+		recCh <- smtp2goRecordedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			apiKey: r.Header.Get("X-Smtp2go-Api-Key"),
+			body:   body,
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"status":"sent"}]`))
+		_, _ = w.Write([]byte(`{"request_id":"r1","data":{"succeeded":1,"failed":0,"failures":[],"email_id":"e1"}}`))
 	}))
 	defer srv.Close()
 
-	s, err := mandrill.New(mandrill.Config{
+	s, err := smtp2go.New(smtp2go.Config{
 		APIKey:     "key-1",
 		BaseURL:    srv.URL,
 		HTTPClient: srv.Client(),
 	})
 	c.Assert(err, qt.IsNil)
 
-	err = s.Send(context.Background(), sender.Message{
+	msg := sender.Message{
 		To:      "user@example.com",
 		From:    "noreply@example.com",
 		ReplyTo: "support@example.com",
 		Subject: "hello",
 		HTML:    "<p>hello</p>",
 		Text:    "hello",
-	})
+	}
+	err = s.Send(context.Background(), msg)
 	c.Assert(err, qt.IsNil)
 
 	rec := <-recCh
 	c.Assert(rec.method, qt.Equals, http.MethodPost)
-	c.Assert(rec.path, qt.Equals, "/api/1.0/messages/send.json")
-	c.Assert(rec.contentType, qt.Equals, "application/json")
-	c.Assert(string(rec.body), qt.Contains, "\"key\":\"key-1\"")
-	c.Assert(string(rec.body), qt.Contains, "\"Reply-To\":\"support@example.com\"")
-}
+	c.Assert(rec.path, qt.Equals, "/v3/email/send")
+	c.Assert(rec.apiKey, qt.Equals, "key-1")
 
-func TestSend_Non2xx(t *testing.T) {
-	c := qt.New(t)
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte("invalid"))
-	}))
-	defer srv.Close()
-
-	s, err := mandrill.New(mandrill.Config{
-		APIKey:     "key-1",
-		BaseURL:    srv.URL,
-		HTTPClient: srv.Client(),
-	})
+	var payload map[string]any
+	err = json.Unmarshal(rec.body, &payload)
 	c.Assert(err, qt.IsNil)
 
-	err = s.Send(context.Background(), sender.Message{
-		To:      "user@example.com",
-		From:    "noreply@example.com",
-		Subject: "hello",
-		HTML:    "<p>hello</p>",
-		Text:    "hello",
-	})
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "status 400")
+	c.Assert(payload["sender"], qt.Equals, msg.From)
+	c.Assert(payload["subject"], qt.Equals, msg.Subject)
+	c.Assert(payload["text_body"], qt.Equals, msg.Text)
+	c.Assert(payload["html_body"], qt.Equals, msg.HTML)
+	c.Assert(payload["to"], qt.DeepEquals, []any{msg.To})
+	c.Assert(payload["custom_headers"], qt.HasLen, 1)
 }
 
-func TestSend_RejectedByProvider(t *testing.T) {
+func TestSend_ProviderFailure(t *testing.T) {
 	c := qt.New(t)
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"status":"rejected","reject_reason":"hard-bounce"}]`))
+		_, _ = w.Write([]byte(`{"request_id":"r1","data":{"succeeded":0,"failed":1,"failures":["bad recipient"]}}`))
 	}))
 	defer srv.Close()
 
-	s, err := mandrill.New(mandrill.Config{
+	s, err := smtp2go.New(smtp2go.Config{
 		APIKey:     "key-1",
 		BaseURL:    srv.URL,
 		HTTPClient: srv.Client(),
@@ -143,5 +128,30 @@ func TestSend_RejectedByProvider(t *testing.T) {
 		Text:    "hello",
 	})
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "mandrill rejected email")
+}
+
+func TestSend_HTTPError(t *testing.T) {
+	c := qt.New(t)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"request_id":"r1","data":{"error_code":"E_X","error":"bad"}}`))
+	}))
+	defer srv.Close()
+
+	s, err := smtp2go.New(smtp2go.Config{
+		APIKey:     "key-1",
+		BaseURL:    srv.URL,
+		HTTPClient: srv.Client(),
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = s.Send(context.Background(), sender.Message{
+		To:      "user@example.com",
+		From:    "noreply@example.com",
+		Subject: "hello",
+		HTML:    "<p>hello</p>",
+		Text:    "hello",
+	})
+	c.Assert(err, qt.IsNotNil)
 }

--- a/go/email/providers/stub/sender_test.go
+++ b/go/email/providers/stub/sender_test.go
@@ -1,4 +1,4 @@
-package stub
+package stub_test
 
 import (
 	"context"
@@ -6,18 +6,19 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/denisvmedia/inventario/email/providers/stub"
 	"github.com/denisvmedia/inventario/email/sender"
 )
 
 func TestNew(t *testing.T) {
 	c := qt.New(t)
-	s := New()
+	s := stub.New()
 	c.Assert(s, qt.IsNotNil)
 }
 
 func TestSender_Send(t *testing.T) {
 	c := qt.New(t)
-	s := New()
+	s := stub.New()
 
 	err := s.Send(context.Background(), sender.Message{
 		To:      "user@example.com",

--- a/go/services/email_senders.go
+++ b/go/services/email_senders.go
@@ -7,6 +7,7 @@ import (
 	"github.com/denisvmedia/inventario/email/providers/sendgrid"
 	"github.com/denisvmedia/inventario/email/providers/ses"
 	"github.com/denisvmedia/inventario/email/providers/smtp"
+	"github.com/denisvmedia/inventario/email/providers/smtp2go"
 	"github.com/denisvmedia/inventario/email/providers/stub"
 	"github.com/denisvmedia/inventario/email/sender"
 )
@@ -38,6 +39,11 @@ func newEmailSenderFromConfig(cfg EmailConfig) (emailSender, error) {
 		return mandrill.New(mandrill.Config{
 			APIKey:  cfg.MandrillAPIKey,
 			BaseURL: cfg.MandrillBaseURL,
+		})
+	case EmailProviderSMTP2GO:
+		return smtp2go.New(smtp2go.Config{
+			APIKey:  cfg.SMTP2GOAPIKey,
+			BaseURL: cfg.SMTP2GOBaseURL,
 		})
 	default:
 		return nil, fmt.Errorf("unsupported email provider: %q", cfg.Provider)

--- a/go/services/email_senders_internal_test.go
+++ b/go/services/email_senders_internal_test.go
@@ -1,5 +1,11 @@
 package services
 
+// White-box: TestNewEmailSenderFromConfig exercises the unexported
+// newEmailSenderFromConfig dispatch switch directly. There is no exported entry
+// point that maps an EmailProvider to its concrete sender without also building
+// the full async service and its queue, so the provider-routing table cannot be
+// asserted through the public API alone.
+
 import (
 	"testing"
 
@@ -19,6 +25,7 @@ func TestNewEmailSenderFromConfig(t *testing.T) {
 		// mailchimp intentionally reuses the Mandrill transport (shared switch
 		// arm in newEmailSenderFromConfig), so it reads the same MandrillAPIKey.
 		{name: "mailchimp", cfg: EmailConfig{Provider: EmailProviderMailchimp, MandrillAPIKey: "md-test"}},
+		{name: "smtp2go", cfg: EmailConfig{Provider: EmailProviderSMTP2GO, SMTP2GOAPIKey: "api-test"}},
 	}
 
 	for _, tc := range cases {

--- a/go/services/email_senders_test.go
+++ b/go/services/email_senders_test.go
@@ -1,0 +1,40 @@
+package services
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewEmailSenderFromConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  EmailConfig
+	}{
+		{name: "stub", cfg: EmailConfig{Provider: EmailProviderStub}},
+		{name: "smtp", cfg: EmailConfig{Provider: EmailProviderSMTP, SMTPHost: "smtp.example.com"}},
+		{name: "sendgrid", cfg: EmailConfig{Provider: EmailProviderSendGrid, SendGridAPIKey: "sg-test"}},
+		{name: "ses", cfg: EmailConfig{Provider: EmailProviderSES, AWSRegion: "us-east-1"}},
+		{name: "mandrill", cfg: EmailConfig{Provider: EmailProviderMandrill, MandrillAPIKey: "md-test"}},
+		// mailchimp intentionally reuses the Mandrill transport (shared switch
+		// arm in newEmailSenderFromConfig), so it reads the same MandrillAPIKey.
+		{name: "mailchimp", cfg: EmailConfig{Provider: EmailProviderMailchimp, MandrillAPIKey: "md-test"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			sndr, err := newEmailSenderFromConfig(tc.cfg)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sndr, qt.IsNotNil)
+		})
+	}
+}
+
+func TestNewEmailSenderFromConfig_UnknownProvider(t *testing.T) {
+	c := qt.New(t)
+	sndr, err := newEmailSenderFromConfig(EmailConfig{Provider: "bogus"})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "unsupported email provider")
+	c.Assert(sndr, qt.IsNil)
+}

--- a/go/services/email_service.go
+++ b/go/services/email_service.go
@@ -112,6 +112,7 @@ const (
 	EmailProviderSES       EmailProvider = "ses"
 	EmailProviderMandrill  EmailProvider = "mandrill"
 	EmailProviderMailchimp EmailProvider = "mailchimp"
+	EmailProviderSMTP2GO   EmailProvider = "smtp2go"
 )
 
 const (
@@ -124,6 +125,7 @@ const (
 	defaultSMTPPort               = 587
 	defaultSendGridBaseURL        = "https://api.sendgrid.com"
 	defaultMandrillBaseURL        = "https://mandrillapp.com"
+	defaultSMTP2GOBaseURL         = "https://api.smtp2go.com"
 )
 
 // EmailConfig is the control-plane configuration for AsyncEmailService.
@@ -179,6 +181,10 @@ type EmailConfig struct {
 	// Mandrill/Mailchimp Transactional settings.
 	MandrillAPIKey  string
 	MandrillBaseURL string
+
+	// SMTP2GO-specific settings.
+	SMTP2GOAPIKey  string
+	SMTP2GOBaseURL string
 }
 
 // normalize canonicalizes provider values and applies service defaults.
@@ -222,6 +228,9 @@ func (c *EmailConfig) normalize() {
 	}
 	if c.MandrillBaseURL == "" {
 		c.MandrillBaseURL = defaultMandrillBaseURL
+	}
+	if c.SMTP2GOBaseURL == "" {
+		c.SMTP2GOBaseURL = defaultSMTP2GOBaseURL
 	}
 }
 

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -67,6 +67,7 @@ data:
   INVENTARIO_RUN_SENDGRID_BASE_URL: {{ .Values.email.sendgrid.baseUrl | quote }}
   INVENTARIO_RUN_AWS_REGION: {{ .Values.email.aws.region | quote }}
   INVENTARIO_RUN_MANDRILL_BASE_URL: {{ .Values.email.mandrill.baseUrl | quote }}
+  INVENTARIO_RUN_SMTP2GO_BASE_URL: {{ .Values.email.smtp2go.baseUrl | quote }}
   # AI-vision photo-scan (#1720). Non-secret knobs; the per-provider API keys
   # live in the Secret (templates/secret.yaml). See values.yaml `aivision:`.
   INVENTARIO_RUN_AI_VISION_PROVIDER: {{ .Values.aivision.provider | quote }}

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -63,6 +63,7 @@ data:
   INVENTARIO_RUN_EMAIL_QUEUE_WORKERS: {{ .Values.email.queueWorkers | quote }}
   INVENTARIO_RUN_EMAIL_QUEUE_MAX_RETRIES: {{ .Values.email.queueMaxRetries | quote }}
   INVENTARIO_RUN_LOG_EMAIL_URLS: {{ .Values.email.logUrls | quote }}
+  INVENTARIO_RUN_ALLOW_STUB_EMAIL: {{ .Values.email.allowStub | default false | quote }}
   INVENTARIO_RUN_SENDGRID_BASE_URL: {{ .Values.email.sendgrid.baseUrl | quote }}
   INVENTARIO_RUN_AWS_REGION: {{ .Values.email.aws.region | quote }}
   INVENTARIO_RUN_MANDRILL_BASE_URL: {{ .Values.email.mandrill.baseUrl | quote }}

--- a/helm/inventario/templates/secret.yaml
+++ b/helm/inventario/templates/secret.yaml
@@ -21,6 +21,7 @@ data:
   INVENTARIO_RUN_SMTP_PASSWORD: {{ .Values.secrets.smtpPassword | b64enc | quote }}
   INVENTARIO_RUN_SENDGRID_API_KEY: {{ .Values.secrets.sendgridApiKey | b64enc | quote }}
   INVENTARIO_RUN_MANDRILL_API_KEY: {{ .Values.secrets.mandrillApiKey | b64enc | quote }}
+  INVENTARIO_RUN_SMTP2GO_API_KEY: {{ .Values.secrets.smtp2goApiKey | b64enc | quote }}
   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: {{ .Values.secrets.aiVisionAnthropicApiKey | b64enc | quote }}
   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: {{ .Values.secrets.aiVisionOpenaiApiKey | b64enc | quote }}
   {{- $metricsToken := include "inventario.metricsToken" . }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -461,6 +461,13 @@ email:
   # Env: INVENTARIO_RUN_EMAIL_PROVIDER
   provider: "stub"
 
+  # Opt into the no-op "stub" provider even when app.publicUrl is set. By
+  # default (false) that combination is REJECTED at startup (#2093) because
+  # verification/invite/reset mail would be silently dropped on a real deploy.
+  # Set true ONLY for local evaluation where you knowingly accept dropped mail.
+  # Env: INVENTARIO_RUN_ALLOW_STUB_EMAIL
+  allowStub: false
+
   # Sender address for all transactional emails
   # Env: INVENTARIO_RUN_EMAIL_FROM
   from: ""

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -452,7 +452,7 @@ features:
 # Email — non-sensitive settings (go into ConfigMap)
 # ============================================================
 email:
-  # Provider: stub | smtp | sendgrid | ses | mandrill | mailchimp
+  # Provider: stub | smtp | sendgrid | ses | mandrill | mailchimp | smtp2go
   # "stub" logs emails to stdout; no external service needed.
   # ⚠️ WARNING: "stub" SILENTLY DROPS ALL MAIL — verification, invite, password-reset,
   # and feedback emails are never delivered. This is fine for local evaluation only.
@@ -518,6 +518,10 @@ email:
 
   mandrill:
     # Env: INVENTARIO_RUN_MANDRILL_BASE_URL (leave empty for default)
+    baseUrl: ""
+
+  smtp2go:
+    # Env: INVENTARIO_RUN_SMTP2GO_BASE_URL (leave empty for default https://api.smtp2go.com)
     baseUrl: ""
 
 # ============================================================
@@ -615,6 +619,7 @@ secrets:
   #   INVENTARIO_RUN_SMTP_PASSWORD               (required for smtp provider)
   #   INVENTARIO_RUN_SENDGRID_API_KEY            (required for sendgrid provider)
   #   INVENTARIO_RUN_MANDRILL_API_KEY            (required for mandrill/mailchimp provider)
+  #   INVENTARIO_RUN_SMTP2GO_API_KEY             (required for smtp2go provider)
   #   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY (required when aivision.provider=anthropic)
   #   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY    (required when aivision.provider=openai)
   #   INVENTARIO_RUN_METRICS_TOKEN                   (optional; bearer token for GET /metrics — strongly recommended in production, see metrics.token)
@@ -663,6 +668,7 @@ secrets:
   smtpPassword: ""               # Env: INVENTARIO_RUN_SMTP_PASSWORD
   sendgridApiKey: ""             # Env: INVENTARIO_RUN_SENDGRID_API_KEY
   mandrillApiKey: ""             # Env: INVENTARIO_RUN_MANDRILL_API_KEY
+  smtp2goApiKey: ""              # Env: INVENTARIO_RUN_SMTP2GO_API_KEY
 
   # AI-vision provider secrets (#1720). Required only for the matching
   # aivision.provider; empty otherwise. See the `aivision:` block above.

--- a/k8s/dev/inventario/configmap.yaml
+++ b/k8s/dev/inventario/configmap.yaml
@@ -28,6 +28,10 @@ data:
   INVENTARIO_RUN_THUMBNAIL_RATE_LIMIT_PER_MINUTE: "50"
   INVENTARIO_RUN_THUMBNAIL_SLOT_DURATION: "30m"
   INVENTARIO_RUN_EMAIL_PROVIDER: "stub"
+  # This dev/smoke stack intentionally uses the no-op stub provider while a
+  # public URL is set, so opt into the #2093 guard (otherwise the backend
+  # refuses to start, treating stub+public-URL as a fatal misconfiguration).
+  INVENTARIO_RUN_ALLOW_STUB_EMAIL: "true"
   INVENTARIO_RUN_EMAIL_FROM: "inventario@inventario-dev.local"
   INVENTARIO_RUN_LOG_EMAIL_URLS: "true"
   # Feature flags. Mirror the Helm chart's `features:` block. Default


### PR DESCRIPTION
## What & why

Closes #2093.

The default email provider `stub` only logs and returns success, so on a real deploy with `app.publicUrl` set, verification / password-reset / invite / magic-link emails were **silently dropped** with no error — a first user could never complete signup or recover access.

PR #2133 already added a loud `slog.Warn` for this combination. This PR completes the issue's recommendation — *"making non-stub email a hard requirement when `app.publicUrl` is set"* — by escalating the warning to a **hard startup error**, with an explicit opt-in escape hatch for dev/eval.

## Behavior

| provider | `publicUrl` | `allowStub` | result |
|---|---|---|---|
| `stub` | empty | – | boots (pure local dev) |
| `stub` | set | `false` (default) | **fatal startup error** (actionable message) |
| `stub` | set | `true` | boots, loud warning (former behavior) |
| non-stub | set | – | unchanged (already validated; empty `from` already rejected) |

A bare `helm install` (no `app.publicUrl`) still boots on `stub`. The demo/preview and e2e paths use Mailpit (`smtp`) and are unaffected.

## Changes

- **`bootstrap/email.go`** — `ValidateEmailPublicURLConfig` takes a new `allowStub bool`; `stub` + a set public URL now returns a fatal, actionable error unless opted in (then it's the prior warning).
- **`config.go` / `flags.go` / `server_params.go`** — new `AllowStubEmail` field, `--allow-stub-email` flag / `INVENTARIO_RUN_ALLOW_STUB_EMAIL`, threaded into the single call site.
- **`go/services/email_senders_test.go`** (new) — the unit test the issue flagged as missing for the `newEmailSenderFromConfig` dispatch switch: every provider (incl. `mailchimp` reusing the Mandrill transport) plus the unknown-provider `default` error path.
- **`bootstrap/email_test.go`** — added the fatal (`allowStub=false`) and opt-in/warn (`allowStub=true`) cases.
- **Helm** `configmap.yaml` + `values.yaml` (`email.allowStub`), and a **PRODUCTION.md** troubleshooting row.

No DB migration, swagger/openapi, frontend, or codegen changes were needed.

## Testing

`go build ./...`, `go vet`/`golangci-lint --fix`/`go test` on the touched packages (`cmd/...`, `services/...`, `email/...`) all green; `helm template` renders the new env var (`false` by default, `true` with `--set email.allowStub=true`). Reviewed by the project code-reviewer (ship-with-nits, addressed) and security-reviewer (ship — guard fails closed, error message carries only the non-secret public URL).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `allowStub`/`--allow-stub-email` setting to permit using the no-op “stub” email provider even when a public URL is configured.
* **Bug Fixes**
  * Improved startup validation: the stub + public URL combo now errors by default, and only warns when stub allowance is enabled.
* **Documentation**
  * Updated the troubleshooting guide with the new flag and guidance for eval/dev setups.
* **Tests**
  * Added/extended unit tests covering email sender configuration across providers and unknown-provider handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->