### PR TITLE
example: setup.sh with image|source modes + deployment-kit refresh

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -3,8 +3,9 @@
 #
 # Usage:
 #   cp .env.example .env
-#   # Edit .env with your values
-#   docker-compose up -d
+#   # REQUIRED before first boot: set ADMIN_PASSWORD and replace the
+#   # JWT_SECRET / FILE_SIGNING_KEY placeholders (then: chmod 600 .env)
+#   docker compose up -d
 
 # Application Configuration
 INVENTARIO_HOST_PORT=3333
@@ -24,6 +25,9 @@ THUMBNAIL_MAX_CONCURRENT_PER_USER=5
 THUMBNAIL_RATE_LIMIT_PER_MINUTE=50
 THUMBNAIL_SLOT_DURATION=30m
 
+# Token blacklist (Redis)
+TOKEN_BLACKLIST_REDIS_URL=redis://redis:6379
+
 TZ=UTC
 
 # Build Configuration (optional - will be auto-detected if not set)
@@ -42,10 +46,14 @@ POSTGRES_MIGRATOR_PASSWORD=inventario_migrator_password
 DEFAULT_TENANT_NAME=Default Organization
 DEFAULT_TENANT_SLUG=default
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=Admin123
+# REQUIRED: set a strong admin password before first boot. Must be >= 8 chars
+# with an upper-case letter, a lower-case letter, and a digit. The base compose
+# fails closed (refuses to start) if this is empty, so a deployment can never
+# seed a public default admin password. `setup.sh` generates one for you.
+ADMIN_PASSWORD=
 ADMIN_NAME=System Administrator
 
 # Security Note:
-# - Change all default passwords before production deployment
-# - Generate JWT_SECRET with: openssl rand -hex 32
-# - Use strong, unique passwords for database users
+# - This file holds CLEARTEXT secrets — chmod 600 .env and keep it private.
+# - Set a strong, unique ADMIN_PASSWORD (and database passwords) before deploying.
+# - Generate JWT_SECRET and FILE_SIGNING_KEY with: openssl rand -hex 32

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -11,3 +11,7 @@ docker-compose.override.yaml
 *.sql
 *.tar.gz
 backup-*
+
+# Ignore setup.sh backups of .env / override (may contain secrets)
+.env.bak.*
+docker-compose.override.yaml.bak.*

--- a/example/README.md
+++ b/example/README.md
@@ -1,118 +1,231 @@
 # Inventario Production Docker Deployment
 
-This directory contains a production-ready Docker Compose configuration for deploying Inventario with PostgreSQL database and proper initialization handling.
+A production-ready Docker Compose stack for Inventario with PostgreSQL, Redis, and automatic database initialization — runnable from a prebuilt image (no local compilation) or built from source.
 
 ## Quick Start
 
-1. **Copy and customize the override file:**
+The fastest way to get going is the bundled setup script. It asks whether you want to run the **prebuilt image** or **build from source**, generates secrets, writes your `.env` and `docker-compose.override.yaml`, validates the configuration, and (optionally) starts the stack. You do not need to read through all the settings below to get a working deployment.
+
+```bash
+./setup.sh
+```
+
+Or skip the prompts with one of the two fastest paths:
+
+```bash
+# Prebuilt image, no compilation (RECOMMENDED for trying it out).
+# Pulls ghcr.io/denisvmedia/inventario:edge and starts the stack.
+./setup.sh --mode image -y --start
+
+# Build from local source (for development / customization).
+./setup.sh --mode source -y --start
+```
+
+When the stack is up, the script prints the access URL, the Swagger location, and the admin credentials. A generated admin password is printed once at the end and is also saved to `.env` as `ADMIN_PASSWORD` (recover it with `grep '^ADMIN_PASSWORD=' .env`). By default the app is published on `http://localhost:3333` (change with `--port`).
+
+> The script is safe to re-run. It never clobbers an existing `.env` (re-run with `--force` to regenerate). It always regenerates the override for the mode you pick, backing up any previous one.
+
+## Deployment modes
+
+| Mode | What it does | Use it for |
+|------|--------------|------------|
+| **image** (default) | Runs the public prebuilt image `ghcr.io/denisvmedia/inventario`. No toolchain, no compile — just pulls the image. Multi-arch (`linux/amd64` + `linux/arm64`). | Trying Inventario, fast deploys, servers without a Go/Node toolchain. |
+| **source** | Builds the image locally from the repository `Dockerfile` (`production` target — includes the frontend build and version injection). | Development, customization, running un-released changes. |
+
+In **image** mode the override sets `image:` and removes the `build:` section from all four `inventario*` services (using `build: !reset null`), so a plain `docker compose up` can never trigger a local build. Available image tags: `edge` (latest `master`), `latest` (newest release), and pinned versions like `vX.Y.Z`. The prebuilt image is identical to the `Dockerfile` `production` target: it ships `curl`, `tzdata`, and `ca-certificates`, runs as non-root uid `1001`, and has the `inventario` binary on `PATH`, so the bootstrap/migrate/init-data scripts run unmodified.
+
+## setup.sh options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mode <image\|source>` | interactive prompt (`image` preselected); `image` with `-y` | Choose the prebuilt image or a local source build. |
+| `--image-tag <tag>` | `edge` | Image tag for image mode (`edge`, `latest`, `vX.Y.Z`, `sha-…`). Ignored in source mode. |
+| `--port <port>` | `3333` | Host port to publish the app on. |
+| `--admin-email <email>` | `admin@example.com` | Initial admin email. |
+| `--admin-password <pw>` | generated | Initial admin password. If omitted, a strong random password is generated and printed once at the end. |
+| `--tenant-name <name>` | `Default Organization` | Initial organization (tenant) name. |
+| `--tenant-slug <slug>` | `default` | Initial tenant slug. |
+| `--ephemeral-secrets` | off | Do **not** persist `JWT_SECRET` / `FILE_SIGNING_KEY`. They are left empty, so the app auto-generates throwaway keys per restart (fine for local testing, not for production). |
+| `--start` / `--no-start` | interactive prompt; `--no-start` with `-y` | Bring the stack up after preparing the files. |
+| `-y`, `--yes` | off | Non-interactive; accept all defaults (mode `image`, no start). |
+| `--force` | off | Overwrite an existing `.env`/override. The old file is backed up to `<file>.bak.<n>` first. |
+| `-h`, `--help` | — | Show usage. |
+
+By default the script generates 64-hex secrets (`openssl rand -hex 32`, with a `/dev/urandom` fallback) for `JWT_SECRET` and `FILE_SIGNING_KEY` and writes them to `.env`. With `--ephemeral-secrets` those keys are left empty.
+
+## Manual setup (advanced)
+
+If you want full control instead of the script, configure the two files by hand.
+
+1. **Create your environment file.** `.env` drives the variable substitution in the base compose file (`${JWT_SECRET}`, `${POSTGRES_*}`, etc.).
+
    ```bash
-   cp docker-compose.override.yaml.example docker-compose.override.yaml
-   # Edit docker-compose.override.yaml with your production values
+   cp .env.example .env
+   chmod 600 .env          # it will hold cleartext secrets
    ```
 
-2. **Generate a secure JWT secret:**
+2. **Generate both secrets** and put them in `.env`. The placeholder values in `.env.example` are rejected at startup (the app refuses to boot on a public example secret), so you must replace them. Leaving a secret unset/commented makes the app auto-generate an ephemeral key per restart — fine for local testing, not for production.
+
    ```bash
-   openssl rand -hex 32
-   # Add this to JWT_SECRET in docker-compose.override.yaml
+   openssl rand -hex 32   # -> JWT_SECRET
+   openssl rand -hex 32   # -> FILE_SIGNING_KEY
    ```
 
-3. **Start the services:**
-   ```bash
-   docker-compose up -d
+   Also set a strong **`ADMIN_PASSWORD`** in `.env` (≥8 chars with an upper-case letter, a lower-case letter, and a digit). `.env.example` ships it empty and the base compose **fails closed** — `docker compose config`/`up` errors until you set it. Change the default `POSTGRES_PASSWORD` / `POSTGRES_MIGRATOR_PASSWORD` too before production.
+
+3. **Create the override file.** This is where you make structural changes (host port, image vs. source, resource limits). Two things in the override are **mandatory** for a working deployment, because the base `docker-compose.yaml` provides neither:
+
+   - **A host port mapping.** The base compose publishes **no** host port for the main `inventario` service, so the app is unreachable from the host with the base file alone. The override must add:
+
+     ```yaml
+     services:
+       inventario:
+         ports:
+           - "${INVENTARIO_HOST_PORT:-3333}:3333"
+     ```
+
+   - **The file signing key.** The base compose does **not** wire `INVENTARIO_RUN_FILE_SIGNING_KEY` into the main service (only `INVENTARIO_RUN_JWT_SECRET`). Without it, signed file URLs are unavailable/insecure. The override must add:
+
+     ```yaml
+     services:
+       inventario:
+         environment:
+           INVENTARIO_RUN_FILE_SIGNING_KEY: ${FILE_SIGNING_KEY:-}
+           INVENTARIO_RUN_FILE_URL_EXPIRATION: ${FILE_URL_EXPIRATION:-15m}
+     ```
+
+   > The bundled `docker-compose.override.yaml.example` is an **illustrative reference** (resource limits, reverse-proxy labels, a fully custom production database) — **not** a drop-in for the bundled `.env`. It renames the database/user and ships placeholder secrets the app rejects at boot, so copying it verbatim yields a non-booting or mis-wired stack. Prefer `./setup.sh`, or hand-write the minimal blocks shown above and consult the `.example` only for the optional `deploy.resources` / labels snippets.
+
+4. **For image mode (no local build)**, point all four `inventario*` services at the prebuilt image and drop their `build:` section so `up` never compiles. Repeat this block for `inventario`, `inventario-bootstrap`, `inventario-migrate`, and `inventario-init-data` (swap `:edge` for any published tag — `latest`, `vX.Y.Z`, or a `sha-…` pin; this mirrors what `./setup.sh --mode image --image-tag <tag>` writes):
+
+   ```yaml
+   services:
+     inventario:
+       build: !reset null
+       image: ghcr.io/denisvmedia/inventario:edge
+       ports:
+         - "${INVENTARIO_HOST_PORT:-3333}:3333"
+       environment:
+         INVENTARIO_RUN_FILE_SIGNING_KEY: ${FILE_SIGNING_KEY:-}
+         INVENTARIO_RUN_FILE_URL_EXPIRATION: ${FILE_URL_EXPIRATION:-15m}
+     inventario-bootstrap:
+       build: !reset null
+       image: ghcr.io/denisvmedia/inventario:edge
+     inventario-migrate:
+       build: !reset null
+       image: ghcr.io/denisvmedia/inventario:edge
+     inventario-init-data:
+       build: !reset null
+       image: ghcr.io/denisvmedia/inventario:edge
    ```
 
-   **Note**: The Docker build process automatically includes the frontend and uses proper version injection matching the Makefile build process.
+   > `build: !reset null` requires Docker Compose v2.24.0 or newer. It removes the build context entirely from the resolved config (verify with `docker compose config --images`), so a bare `docker compose up` can never rebuild.
 
-4. **Access the application:**
-   - Web Interface: http://localhost:3333 (or your configured port)
-   - API Documentation: http://localhost:3333/swagger
-   - Liveness Check: http://localhost:3333/healthz
-   - Readiness Check: http://localhost:3333/readyz
+5. **Validate and start.**
+
+   ```bash
+   docker compose config -q              # exit 0 == valid
+
+   # Image mode (no build): --no-build is optional — `build: !reset null` already
+   # removes the build block, so a plain `up -d` can never compile.
+   docker compose pull
+   docker compose up -d                  # equivalent to: docker compose up -d --no-build
+
+   # Source mode (build locally):
+   docker compose up -d --build
+   ```
 
 ## Architecture Overview
 
 ### Services
 
-- **postgres**: PostgreSQL 18 database (internal only, no host port exposure)
-- **redis**: Redis cache for the token blacklist (internal only, no host port exposure)
-- **inventario-bootstrap**: Runs database bootstrap migrations (every startup - idempotent)
-- **inventario-migrate**: Runs schema migrations (every startup)
-- **inventario-init-data**: Sets up initial data (first run only)
-- **inventario**: Main application server
+- **postgres**: PostgreSQL 18 database (internal only, no host port exposure).
+- **redis**: Redis 8 cache backing the token blacklist (internal only, no host port exposure).
+- **inventario-bootstrap**: Runs database bootstrap (every startup — idempotent).
+- **inventario-migrate**: Runs schema migrations (every startup).
+- **inventario-init-data**: Sets up initial data (first run only).
+- **inventario**: Main application server.
 
 ### Initialization Flow
 
-1. **PostgreSQL starts** and creates necessary users via init script
-2. **Bootstrap service** runs `db bootstrap apply` to set up extensions and roles (idempotent - safe to run multiple times)
-3. **Migration service** runs `db migrate up` to apply schema changes
-4. **Init data service** runs `db migrate data` (only on first deployment)
-5. **Main application** starts and serves requests
+1. **PostgreSQL starts** and creates the migration user via the init script.
+2. **Bootstrap service** runs `db bootstrap apply` to set up extensions and roles (idempotent — safe to run repeatedly).
+3. **Migration service** runs `db migrate up` to apply schema changes.
+4. **Init data service** runs `db migrate data` — only on first deployment, gated by `./data/init-state/data-initialized`.
+5. **Main application** starts and serves requests.
 
 ### Data Persistence
 
 All data is stored in host-mounted directories for easy access:
 
-- **./data/postgres**: PostgreSQL database files
-- **./data/uploads**: Application file uploads
-- **./data/init-state**: Tracks initialization state to prevent data re-setup
+- **./data/postgres**: PostgreSQL database files.
+- **./data/redis**: Redis persistence (token-blacklist data).
+- **./data/uploads**: Application file uploads.
+- **./data/init-state**: Tracks initialization state to prevent data re-setup.
 
 **Directory Structure:**
+
 ```
 example/
 ├── data/
 │   ├── postgres/          # PostgreSQL data files
+│   ├── redis/             # Redis token-blacklist persistence
 │   ├── uploads/           # Application file uploads
 │   └── init-state/        # Initialization tracking
 ├── docker-compose.yaml
+├── docker-compose.override.yaml   # generated by setup.sh (the .example is a reference, not a drop-in)
+├── .env                           # generated by setup.sh (or copied from .env.example)
 └── ...
 ```
 
 ## Configuration
 
-### Required Configuration (docker-compose.override.yaml)
+### Where settings come from
 
-```yaml
-services:
-  inventario:
-    environment:
-      JWT_SECRET: "your-secure-32-byte-jwt-secret"
-    ports:
-      - "8080:3333"  # Customize host port
-  
-  postgres:
-    environment:
-      POSTGRES_PASSWORD: "secure-postgres-password"
-      POSTGRES_MIGRATOR_PASSWORD: "secure-migrator-password"
-  
-  inventario-init-data:
-    environment:
-      DEFAULT_TENANT_NAME: "Your Organization"
-      ADMIN_EMAIL: "admin@yourcompany.com"
-      ADMIN_PASSWORD: "secure-admin-password"
-```
+- **`.env`** supplies the shell variables the base `docker-compose.yaml` substitutes (e.g. `${JWT_SECRET}` → `INVENTARIO_RUN_JWT_SECRET`, `${POSTGRES_PASSWORD}`, `${ADMIN_EMAIL}` → `INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL`). This is the primary configuration entrypoint.
+- **`docker-compose.override.yaml`** is for structural changes: host port mapping, image-vs-source, resource limits, and wiring the file signing key.
+
+> Note: bare keys placed directly under a service's `environment:` (for example `JWT_SECRET:` under `inventario`) are inert — the container reads `INVENTARIO_RUN_JWT_SECRET`. Set values via `.env` (recommended) or, in the override, use the real container variable names (`INVENTARIO_RUN_*` on `inventario`, `POSTGRES_*` on `postgres`, `INVENTARIO_MIGRATE_DATA_*` on `inventario-init-data`).
 
 ### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INVENTARIO_HOST_PORT` | `3333` | Host port for application access |
-| `POSTGRES_DB` | `inventario` | PostgreSQL database name |
-| `POSTGRES_USER` | `inventario` | PostgreSQL application user |
-| `POSTGRES_PASSWORD` | `inventario_password` | PostgreSQL application password |
-| `POSTGRES_MIGRATOR_USER` | `inventario_migrator` | PostgreSQL migration user |
-| `POSTGRES_MIGRATOR_PASSWORD` | `inventario_migrator_password` | PostgreSQL migration password |
-| `JWT_SECRET` | (required) | JWT signing secret (32+ characters) |
-| `DEFAULT_TENANT_NAME` | `Default Organization` | Initial organization name |
-| `ADMIN_EMAIL` | `admin@example.com` | Initial admin user email |
-| `ADMIN_PASSWORD` | `Admin123` | Initial admin user password |
+| `INVENTARIO_HOST_PORT` | `3333` | Host port the override publishes the app on. Not consumed by the base compose — only by the `ports:` mapping the override adds. |
+| `JWT_SECRET` | (required) | JWT signing secret; generate with `openssl rand -hex 32`. The example placeholder is rejected at startup; leaving it unset auto-generates an ephemeral key per restart. |
+| `FILE_SIGNING_KEY` | (required) | Signing key for signed file URLs; generate with `openssl rand -hex 32`. Same placeholder-rejection / ephemeral behavior as `JWT_SECRET`. Wired into the app only via the override. |
+| `FILE_URL_EXPIRATION` | `15m` | Lifetime of signed file URLs. |
+| `MAX_CONCURRENT_EXPORTS` | `3` | Maximum concurrent export jobs. |
+| `MAX_CONCURRENT_IMPORTS` | `1` | Maximum concurrent import jobs. |
+| `THUMBNAIL_MAX_CONCURRENT_PER_USER` | `5` | Max concurrent thumbnail generations per user. |
+| `THUMBNAIL_RATE_LIMIT_PER_MINUTE` | `50` | Thumbnail generation requests allowed per minute. |
+| `THUMBNAIL_SLOT_DURATION` | `30m` | Thumbnail generation slot duration. |
+| `TOKEN_BLACKLIST_REDIS_URL` | `redis://redis:6379` | Redis URL backing the JWT token blacklist. |
+| `TZ` | `UTC` | Container timezone. |
+| `POSTGRES_DB` | `inventario` | PostgreSQL database name. |
+| `POSTGRES_USER` | `inventario` | PostgreSQL application user. |
+| `POSTGRES_PASSWORD` | `inventario_password` | PostgreSQL application password. |
+| `POSTGRES_MIGRATOR_USER` | `inventario_migrator` | PostgreSQL migration user. |
+| `POSTGRES_MIGRATOR_PASSWORD` | `inventario_migrator_password` | PostgreSQL migration password. |
+| `DEFAULT_TENANT_NAME` | `Default Organization` | Initial organization name (first run only). |
+| `DEFAULT_TENANT_SLUG` | `default` | Initial tenant slug (first run only). |
+| `ADMIN_EMAIL` | `admin@example.com` | Initial admin user email (first run only). |
+| `ADMIN_PASSWORD` | generated / **required** | Initial admin user password (first run only). `setup.sh` generates a strong random one unless you pass `--admin-password`. In the manual path `.env.example` ships it empty, so set a value before first run; the base compose fails closed (errors) while it is unset/empty. Must satisfy: ≥8 chars with upper, lower, and a digit. |
+| `ADMIN_NAME` | `System Administrator` | Initial admin user display name (first run only). |
+
+> Build-time only (source mode): `VERSION`, `COMMIT`, and `BUILD_DATE` are optional image-label build args (defaults `dev` / `unknown` / `unknown`, auto-detected if unset) — see the commented block in `.env.example`. They are ignored in image mode.
+
+> The `DEFAULT_TENANT_*` and `ADMIN_*` values seed initial data **once** (gated by `./data/init-state/data-initialized`). Changing them after the first boot has no effect — change the admin password in-app, or wipe `./data/init-state` to re-seed.
 
 ## Security Considerations
 
-1. **Change default passwords** in production
-2. **Use strong JWT secret** (32+ random characters)
-3. **PostgreSQL is internal only** (no host port exposure)
-4. **File uploads are persistent** but local (consider MinIO migration)
-5. **Use HTTPS reverse proxy** for production (nginx, Traefik, etc.)
+1. **Change default passwords** (database users and the admin account) before production.
+2. **Use a strong `JWT_SECRET`** (`openssl rand -hex 32`). The example placeholder is rejected at boot; an unset value auto-generates an ephemeral throwaway key per restart.
+3. **Set a strong `FILE_SIGNING_KEY`** (`openssl rand -hex 32`) and wire it via the override (`INVENTARIO_RUN_FILE_SIGNING_KEY`) — the base compose does not. Without it, signed file URLs are unavailable/insecure. `FILE_URL_EXPIRATION` (default `15m`) controls their lifetime.
+4. **PostgreSQL and Redis are internal only** (no host port exposure).
+5. **File uploads are persistent** but stored on the local filesystem (consider MinIO migration for scale).
+6. **Use an HTTPS reverse proxy** for production (nginx, Traefik, etc.).
+7. **Keep `.env` private.** `setup.sh` writes it mode `0600` (and its `.bak.*` backups too); it holds cleartext secrets (`JWT_SECRET`, `FILE_SIGNING_KEY`, DB and admin passwords). On a shared host, do not loosen its permissions. If you create `.env` by hand, `chmod 600 .env`.
 
 ## Maintenance
 
@@ -120,52 +233,60 @@ services:
 
 ```bash
 # All services
-docker-compose logs -f
+docker compose logs -f
 
 # Specific service
-docker-compose logs -f inventario
-docker-compose logs -f postgres
+docker compose logs -f inventario
+docker compose logs -f postgres
 ```
 
 ### Database Backup
 
 ```bash
-# Create backup using docker-compose
-docker-compose exec postgres pg_dump -U inventario inventario > backup.sql
+# Create a backup
+docker compose exec postgres pg_dump -U inventario inventario > backup.sql
 
-# Or access PostgreSQL data files directly (since they're host-mounted)
-# Data files are located in: ./data/postgres/
+# Or access the PostgreSQL data files directly (they are host-mounted under ./data/postgres/)
 
-# Restore backup
-docker-compose exec -T postgres psql -U inventario inventario < backup.sql
+# Restore a backup
+docker compose exec -T postgres psql -U inventario inventario < backup.sql
 
 # File-level backup (stop containers first)
-docker-compose down
+docker compose down
 cp -r ./data/postgres ./backup-postgres-$(date +%Y%m%d)
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Updates
 
 ```bash
 # Stop services
-docker-compose down
-
-# Pull latest images and rebuild
-docker-compose build --pull
-docker-compose pull
-
-# Start services (migrations run automatically)
-docker-compose up -d
+docker compose down
 ```
+
+**Image mode** — just pull the newer image, no build:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+**Source mode** — rebuild from the latest source:
+
+```bash
+docker compose build --pull
+docker compose up -d
+```
+
+Migrations run automatically on startup in either case.
 
 ### Reset Data (Development Only)
 
 ```bash
-# WARNING: This will delete all data
-docker-compose down
+# WARNING: this deletes all data
+docker compose down
 rm -rf ./data/
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Data Access
@@ -182,7 +303,7 @@ ls -la ./data/postgres/
 # Check initialization state
 cat ./data/init-state/data-initialized
 
-# Backup specific directories
+# Back up the whole data directory
 tar -czf backup-$(date +%Y%m%d).tar.gz ./data/
 ```
 
@@ -190,28 +311,31 @@ tar -czf backup-$(date +%Y%m%d).tar.gz ./data/
 
 ### Common Issues
 
-1. **Port already in use**: Change `INVENTARIO_HOST_PORT` in override file
-2. **Database connection failed**: Check PostgreSQL logs and credentials
-3. **Permission denied**: Ensure Docker has access to volume mount paths
-4. **JWT token errors**: Verify JWT_SECRET is set and consistent
+1. **Port already in use**: change `--port` (or `INVENTARIO_HOST_PORT` in `.env`) and re-run.
+2. **Database connection failed**: check PostgreSQL logs and credentials.
+3. **Permission denied**: ensure Docker has access to the volume mount paths.
+4. **JWT token errors**: verify `JWT_SECRET` is set and consistent (an ephemeral/unset secret invalidates tokens on every restart).
+5. **Signed file URLs fail**: ensure the override wires `INVENTARIO_RUN_FILE_SIGNING_KEY` from `FILE_SIGNING_KEY`.
 
 ### Health Checks
 
 ```bash
 # Check service status
-docker-compose ps
+docker compose ps
 
-# Test application readiness (dependencies reachable)
-curl http://localhost:3333/readyz
+# Test application readiness from the host (replace 3333 with your --port / INVENTARIO_HOST_PORT)
+curl -f http://localhost:3333/readyz
+# Note: the compose healthcheck runs the same probe INSIDE the container against
+# :3333 and is independent of the published host port.
 
 # Check database connectivity
-docker-compose exec postgres pg_isready -U inventario
+docker compose exec postgres pg_isready -U inventario
 ```
 
 ## Production Deployment Notes
 
-- Consider using external PostgreSQL for high availability
-- Implement proper backup strategy for persistent volumes
-- Use reverse proxy with SSL/TLS termination
-- Monitor resource usage and adjust limits accordingly
-- Consider migrating to MinIO for object storage scalability
+- Consider using an external PostgreSQL for high availability.
+- Implement a proper backup strategy for the persistent volumes.
+- Use a reverse proxy with SSL/TLS termination.
+- Monitor resource usage and adjust limits accordingly (see the override example for `deploy.resources`).
+- Consider migrating to MinIO for object storage scalability.

--- a/example/README.md
+++ b/example/README.md
@@ -119,7 +119,7 @@ If you want full control instead of the script, configure the two files by hand.
        image: ghcr.io/denisvmedia/inventario:edge
    ```
 
-   > `build: !reset null` requires Docker Compose v2.24.0 or newer. It removes the build context entirely from the resolved config (verify with `docker compose config --images`), so a bare `docker compose up` can never rebuild.
+   > `build: !reset null` requires Docker Compose v2.24.4 or newer. It removes the build context entirely from the resolved config (verify with `docker compose config --images`), so a bare `docker compose up` can never rebuild. `setup.sh` checks this and refuses image mode on an older/legacy Compose with a clear message.
 
 5. **Validate and start.**
 
@@ -303,8 +303,11 @@ ls -la ./data/postgres/
 # Check initialization state
 cat ./data/init-state/data-initialized
 
-# Back up the whole data directory
+# Back up the whole data directory (crash-consistent: stop services first, since
+# hot-copying the live PostgreSQL/Redis data dirs can produce a non-restorable snapshot)
+docker compose down
 tar -czf backup-$(date +%Y%m%d).tar.gz ./data/
+docker compose up -d
 ```
 
 ## Troubleshooting

--- a/example/docker-compose.override.yaml.example
+++ b/example/docker-compose.override.yaml.example
@@ -1,18 +1,21 @@
-# Docker Compose Override Example for Inventario Production Deployment
+# Docker Compose Override — ILLUSTRATIVE REFERENCE (advanced / custom production)
 #
-# Copy this file to docker-compose.override.yaml and customize the values
-# for your specific production environment.
+# This file demonstrates a fully customized production deployment: a renamed
+# database/user, resource limits, and reverse-proxy labels. It is NOT a drop-in
+# for the bundled .env — it renames the database and ships "your-secure-*"
+# placeholder secrets that the app REJECTS at boot, so copying it verbatim
+# yields a non-booting or mis-wired stack.
 #
-# Usage:
-#   cp docker-compose.override.yaml.example docker-compose.override.yaml
-#   # Edit docker-compose.override.yaml with your values
-#   docker-compose up -d --build
+# For a working deployment, prefer ./setup.sh (it generates a correct override),
+# or hand-write the minimal override documented in README.md "Manual setup".
+# Use the snippets here only as a reference for the optional pieces you want
+# (deploy.resources, reverse-proxy labels, a separate production database).
 #
-# IMPORTANT NOTES:
-# - All services use the same database DSN for consistency
-# - The default tenant ID is set to "test-tenant-id" to match the application code
-# - Environment variables for init-data use the INVENTARIO_MIGRATE_DATA_ prefix
-# - Make sure to change all "your-secure-*" placeholders with actual secure values
+# NOTES:
+# - init-data variables use the INVENTARIO_MIGRATE_DATA_ prefix.
+# - The app reads INVENTARIO_RUN_* / POSTGRES_* names; bare keys like
+#   MAX_CONCURRENT_EXPORTS placed directly under a service's environment are inert.
+# - Replace every "your-secure-*" placeholder with a real value before use.
 
 services:
   # Override Inventario application configuration
@@ -32,9 +35,12 @@ services:
       # Optional: Customize file URL expiration (default: 15m)
       INVENTARIO_RUN_FILE_URL_EXPIRATION: "15m"
 
-      # Optional: Customize worker limits based on your server capacity
-      MAX_CONCURRENT_EXPORTS: "5"
-      MAX_CONCURRENT_IMPORTS: "2"
+      # Optional: Customize worker limits based on your server capacity.
+      # Use the INVENTARIO_RUN_ prefix — the app reads the prefixed names, so a
+      # bare MAX_CONCURRENT_EXPORTS here would be inert. (Or set MAX_CONCURRENT_*
+      # in .env, which the base compose maps to these.)
+      INVENTARIO_RUN_MAX_CONCURRENT_EXPORTS: "5"
+      INVENTARIO_RUN_MAX_CONCURRENT_IMPORTS: "2"
 
       # Optional: Set timezone for your location
       TZ: "America/New_York"

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -115,7 +115,10 @@ services:
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME: ${DEFAULT_TENANT_NAME:-Default Organization}
       INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG: ${DEFAULT_TENANT_SLUG:-default}
       INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: ${ADMIN_PASSWORD:-Admin123}
+      # Fail closed: refuse to start rather than seed a public default admin
+      # password. setup.sh always writes a real value; the manual path must set
+      # ADMIN_PASSWORD in .env (see .env.example).
+      INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: "${ADMIN_PASSWORD:?set ADMIN_PASSWORD in .env before first run (see .env.example)}"
       INVENTARIO_MIGRATE_DATA_ADMIN_NAME: ${ADMIN_NAME:-System Administrator}
     volumes:
       # Track initialization state to prevent re-running (host mount for easy access)

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -347,6 +347,10 @@ write_env() {
   fi
 
   if [ -f "$ENV_FILE" ]; then
+    if [ -e "$SCRIPT_DIR/data/init-state/data-initialized" ]; then
+      warn "Stack already initialized: a regenerated ADMIN_PASSWORD will NOT replace the seeded admin,"
+      warn "and rotated JWT/FILE_SIGNING keys will invalidate existing sessions and signed file URLs."
+    fi
     backup_file "$ENV_FILE"
   fi
 
@@ -692,14 +696,38 @@ main() {
     esac
   fi
 
+  # Image mode's 'build: !reset null' needs Docker Compose >= v2.24.4. Reject an
+  # older / legacy v1 Compose up front, instead of failing later in validate_config
+  # with an opaque YAML merge error.
+  if [ "$MODE" = "image" ]; then
+    local cver rest cmaj cmin cpat cnum
+    cver="$("${COMPOSE[@]}" version --short 2>/dev/null | tr -dc '0-9.')"
+    cmaj="${cver%%.*}"; rest="${cver#*.}"
+    cmin="${rest%%.*}"; cpat="${rest#*.}"; cpat="${cpat%%.*}"
+    case "${cmaj:-x}" in
+      ''|*[!0-9]*)
+        warn "Could not parse the Docker Compose version; image mode needs >= v2.24.4 for 'build: !reset null'." ;;
+      *)
+        cnum=$(( cmaj * 1000000 + ${cmin:-0} * 1000 + ${cpat:-0} ))
+        if [ "$cnum" -lt 2024004 ]; then
+          die "Image mode needs Docker Compose >= v2.24.4 (for 'build: !reset null'); found v${cmaj}.${cmin:-0}.${cpat:-0}. Use --mode source, or upgrade Compose."
+        fi ;;
+    esac
+  fi
+
   # Resolve admin password (generate if omitted) — only matters when we (re)write .env.
   local will_write_env=0
   if [ ! -f "$ENV_FILE" ] || [ "$FORCE" -eq 1 ]; then
     will_write_env=1
   fi
-  if [ "$will_write_env" -eq 1 ] && [ -z "$ADMIN_PASSWORD" ]; then
-    ADMIN_PASSWORD="$(gen_password)"
-    ADMIN_PASSWORD_GENERATED=1
+  if [ "$will_write_env" -eq 1 ]; then
+    if [ -z "$ADMIN_PASSWORD" ]; then
+      ADMIN_PASSWORD="$(gen_password)"
+      ADMIN_PASSWORD_GENERATED=1
+    elif [ "${#ADMIN_PASSWORD}" -lt 8 ] || ! password_meets_policy "$ADMIN_PASSWORD"; then
+      # Fail fast on a weak --admin-password instead of aborting later in init-data.
+      die "--admin-password must be >= 8 chars with an upper-case letter, a lower-case letter, and a digit."
+    fi
   fi
 
   write_env

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -1,0 +1,745 @@
+#!/usr/bin/env bash
+#
+# setup.sh — one-command deployment preparer for the Inventario example stack.
+#
+# Generates secrets, writes .env and docker-compose.override.yaml for the
+# chosen run mode (prebuilt ghcr image, or build from local source), validates
+# the resulting Compose configuration, and optionally brings the stack up.
+#
+# Run it from anywhere; it resolves and operates in its own directory.
+#
+#   ./setup.sh --help
+#   ./setup.sh                       # interactive
+#   ./setup.sh --mode image -y       # non-interactive, prebuilt image, no start
+#   ./setup.sh --mode source --start # build from source and start
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve script directory and operate there.
+# ---------------------------------------------------------------------------
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do
+  dir="$(cd -P "$(dirname "$SCRIPT_SOURCE")" >/dev/null 2>&1 && pwd)"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ "$SCRIPT_SOURCE" != /* ]] && SCRIPT_SOURCE="$dir/$SCRIPT_SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_SOURCE")" >/dev/null 2>&1 && pwd)"
+cd "$SCRIPT_DIR"
+
+ENV_FILE="$SCRIPT_DIR/.env"
+OVERRIDE_FILE="$SCRIPT_DIR/docker-compose.override.yaml"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
+
+IMAGE_REPO="ghcr.io/denisvmedia/inventario"
+
+# Track temp files for guaranteed cleanup on any exit (set -u safe on bash 3.2).
+TMP_FILES=()
+cleanup() {
+  if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TMP_FILES[@]+"${TMP_FILES[@]}"}"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Colored logging (to stderr so stdout stays clean for any captured values).
+# ---------------------------------------------------------------------------
+if [ -t 2 ]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+  C_BLUE=$'\033[34m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'; C_CYAN=$'\033[36m'
+else
+  C_RESET=''; C_BOLD=''; C_BLUE=''; C_GREEN=''; C_YELLOW=''; C_RED=''; C_CYAN=''
+fi
+
+log()      { printf '%s\n' "${C_BLUE}==>${C_RESET} $*" >&2; }
+section()  { printf '\n%s\n' "${C_BOLD}${C_CYAN}== $* ==${C_RESET}" >&2; }
+info()     { printf '%s\n' "    $*" >&2; }
+success()  { printf '%s\n' "${C_GREEN}[ok]${C_RESET} $*" >&2; }
+warn()     { printf '%s\n' "${C_YELLOW}[warn]${C_RESET} $*" >&2; }
+err()      { printf '%s\n' "${C_RED}[error]${C_RESET} $*" >&2; }
+die()      { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via flags).
+# ---------------------------------------------------------------------------
+MODE=""                       # image | source ; empty => prompt/derive
+IMAGE_TAG="edge"
+PORT="3333"
+ADMIN_EMAIL="admin@example.com"
+ADMIN_PASSWORD=""             # empty => generate
+ADMIN_PASSWORD_GENERATED=0
+TENANT_NAME="Default Organization"
+TENANT_SLUG="default"
+EPHEMERAL_SECRETS=0
+START=""                      # "" => prompt ; 1 => start ; 0 => no-start
+ASSUME_YES=0
+FORCE=0
+ENV_FLAGS_SUPPLIED=0          # 1 if any .env-only value flag was passed
+
+usage() {
+  cat >&2 <<EOF
+${C_BOLD}Inventario deployment setup${C_RESET}
+
+Prepares this directory for a Docker Compose deployment: generates secrets,
+writes .env and docker-compose.override.yaml for the chosen run mode, validates
+the configuration, and optionally starts the stack.
+
+${C_BOLD}Usage:${C_RESET}
+  ./setup.sh [options]
+
+${C_BOLD}Options:${C_RESET}
+  --mode <image|source>     Run mode. 'image' runs the prebuilt ghcr image with
+                            no local compilation; 'source' builds from the local
+                            repository. Default: prompt ('image' preselected);
+                            with -y defaults to 'image'.
+  --image-tag <tag>         Image tag for image mode (edge|latest|vX.Y.Z|sha-...).
+                            Default: edge. Only meaningful in image mode.
+  --port <port>             Host port to publish. Default: 3333.
+  --admin-email <email>     Initial admin email. Default: admin@example.com.
+  --admin-password <pw>     Initial admin password. If omitted, a strong random
+                            password is generated and printed once at the end.
+  --tenant-name <name>      Default organization name. Default: "Default Organization".
+  --tenant-slug <slug>      Default tenant slug. Default: default.
+  --ephemeral-secrets       Do NOT persist JWT/file-signing secrets; leave them
+                            empty so the app auto-generates throwaway keys per
+                            restart (fine for local testing, not production).
+  --start                   Bring the stack up after preparing.
+  --no-start                Do not start the stack (just prepare files).
+                            Default: prompt; with -y defaults to --no-start.
+  -y, --yes                 Non-interactive; accept all defaults.
+  --force                   Overwrite existing .env/override, backing up the old
+                            file to <file>.bak.<n> first.
+  -h, --help                Show this help and exit.
+
+${C_BOLD}Examples:${C_RESET}
+  ./setup.sh
+  ./setup.sh --mode image -y
+  ./setup.sh --mode image --image-tag latest --port 8080 --start
+  ./setup.sh --mode source --admin-email me@example.com --start
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing — supports both "--flag value" and "--flag=value".
+# ---------------------------------------------------------------------------
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    local arg="$1"
+    local key="$arg" val="" has_val=0
+    if [[ "$arg" == --*=* ]]; then
+      key="${arg%%=*}"
+      val="${arg#*=}"
+      has_val=1
+    fi
+    case "$key" in
+      --mode)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        [ -n "$val" ] || die "--mode must not be empty (expected 'image' or 'source')."
+        MODE="$val" ;;
+      --image-tag)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        IMAGE_TAG="$val" ;;
+      --port)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        PORT="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --admin-email)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        ADMIN_EMAIL="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --admin-password)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        ADMIN_PASSWORD="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --tenant-name)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        TENANT_NAME="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --tenant-slug)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        TENANT_SLUG="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --ephemeral-secrets)
+        EPHEMERAL_SECRETS=1 ;;
+      --start)
+        START=1 ;;
+      --no-start)
+        START=0 ;;
+      -y|--yes)
+        ASSUME_YES=1 ;;
+      --force)
+        FORCE=1 ;;
+      -h|--help)
+        usage; exit 0 ;;
+      *)
+        die "Unknown option: $arg (try --help)" ;;
+    esac
+    shift
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Interactive prompts (skipped entirely with -y).
+# ---------------------------------------------------------------------------
+prompt_default() {
+  # $1 = prompt text, $2 = default ; echoes the answer
+  local text="$1" def="$2" ans=""
+  if [ "$ASSUME_YES" -eq 1 ] || [ ! -t 0 ]; then
+    printf '%s' "$def"
+    return 0
+  fi
+  read -r -p "$text [$def]: " ans </dev/tty || ans=""
+  printf '%s' "${ans:-$def}"
+}
+
+prompt_yes_no() {
+  # $1 = prompt text, $2 = default (y|n) ; returns 0 for yes, 1 for no
+  local text="$1" def="$2" ans=""
+  if [ "$ASSUME_YES" -eq 1 ] || [ ! -t 0 ]; then
+    [ "$def" = "y" ] && return 0 || return 1
+  fi
+  local hint="y/N"; [ "$def" = "y" ] && hint="Y/n"
+  read -r -p "$text [$hint]: " ans </dev/tty || ans=""
+  ans="${ans:-$def}"
+  case "$ans" in
+    y|Y|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Preflight: docker, docker compose v2, reachable daemon.
+# ---------------------------------------------------------------------------
+COMPOSE=()   # filled with the working compose invocation
+
+preflight() {
+  section "Preflight"
+
+  command -v docker >/dev/null 2>&1 || die "'docker' is not installed or not on PATH."
+  success "docker found: $(docker --version 2>/dev/null || echo unknown)"
+
+  # Prefer Compose v2 plugin ('docker compose'); fall back to legacy 'docker-compose'.
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+    warn "Using legacy 'docker-compose' (v1). Consider upgrading to the Compose v2 plugin."
+  else
+    die "Docker Compose v2 is required ('docker compose'). Neither it nor legacy 'docker-compose' was found."
+  fi
+  success "compose found: $("${COMPOSE[@]}" version 2>/dev/null | head -n1 || echo unknown)"
+
+  # Daemon must be reachable.
+  if ! docker info >/dev/null 2>&1; then
+    die "The Docker daemon is not reachable. Start Docker and try again."
+  fi
+  success "Docker daemon is reachable."
+}
+
+# ---------------------------------------------------------------------------
+# Secret generation: 64-hex chars. Prefer openssl; fall back to /dev/urandom.
+# ---------------------------------------------------------------------------
+gen_secret() {
+  local s=""
+  if command -v openssl >/dev/null 2>&1; then
+    s="$(openssl rand -hex 32 2>/dev/null || true)"
+  fi
+  if [ "${#s}" -ne 64 ]; then
+    s="$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 64 || true)"
+  fi
+  [ "${#s}" -eq 64 ] || die "Failed to generate a 64-hex secret (no openssl and /dev/urandom unavailable)."
+  printf '%s' "$s"
+}
+
+# Returns 0 only if the password has an upper, a lower, and a digit (the
+# backend's ValidatePassword policy). Used in an `if` so `set -e` is exempt.
+password_meets_policy() {
+  case "$1" in *[A-Z]*) ;; *) return 1 ;; esac
+  case "$1" in *[a-z]*) ;; *) return 1 ;; esac
+  case "$1" in *[0-9]*) ;; *) return 1 ;; esac
+  return 0
+}
+
+gen_password() {
+  # Strong, shell/URL-safe alphanumeric password (no special chars that need
+  # quoting). A uniform [A-Za-z0-9] draw can lack a required character class
+  # (~1.5% of the time), which the backend rejects and which would abort
+  # init-data — so retry until it satisfies the upper/lower/digit policy.
+  local p="" tries=0
+  while :; do
+    tries=$((tries + 1))
+    p=""
+    if command -v openssl >/dev/null 2>&1; then
+      p="$(openssl rand -base64 24 2>/dev/null | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 24 || true)"
+    fi
+    if [ "${#p}" -lt 20 ]; then
+      p="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c 24 || true)"
+    fi
+    [ "${#p}" -ge 20 ] || die "Failed to generate an admin password."
+    if password_meets_policy "$p" || [ "$tries" -ge 100 ]; then
+      break
+    fi
+  done
+  printf '%s' "$p"
+}
+
+# ---------------------------------------------------------------------------
+# Escape '$' -> '$$' for values written into .env. Docker Compose runs its own
+# ${VAR} interpolation over .env values, so an unescaped '$' is treated as a
+# variable reference and would silently corrupt the value (e.g. an admin
+# password). Compose un-escapes '$$' back to a literal '$' on substitution.
+# ---------------------------------------------------------------------------
+esc_env() {
+  local s="$1"
+  printf '%s' "${s//\$/\$\$}"
+}
+
+unesc_env() {
+  local s="$1"
+  printf '%s' "${s//\$\$/\$}"
+}
+
+# Reject newline/CR in operator-supplied values: a newline would write an extra
+# KEY=value line into .env and (Compose .env is last-wins) could override a
+# generated secret. esc_env neutralizes '$' but not newlines.
+reject_ctrl() {
+  case "$1" in
+    *$'\n'*|*$'\r'*) die "$2 must not contain newline or carriage-return characters." ;;
+  esac
+}
+
+# Read the last KEY=... value from the existing .env (empty if absent).
+read_env_value() {
+  local key="$1" line=""
+  [ -f "$ENV_FILE" ] || return 0
+  line="$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n1 || true)"
+  line="${line#*=}"
+  line="${line%$'\r'}"                        # strip trailing CR (CRLF .env)
+  line="${line#"${line%%[![:space:]]*}"}"     # strip leading whitespace
+  line="${line%"${line##*[![:space:]]}"}"     # strip trailing whitespace
+  printf '%s' "$line"
+}
+
+# ---------------------------------------------------------------------------
+# Back up an existing file to <file>.bak.<n> (lowest free n).
+# ---------------------------------------------------------------------------
+backup_file() {
+  local f="$1"
+  [ -e "$f" ] || return 0
+  local n=1
+  while [ -e "$f.bak.$n" ]; do
+    n=$((n + 1))
+  done
+  cp -p "$f" "$f.bak.$n"
+  chmod 600 "$f.bak.$n" 2>/dev/null || true
+  warn "Backed up existing $(basename "$f") -> $(basename "$f").bak.$n"
+}
+
+# ---------------------------------------------------------------------------
+# .env generation. Reuse an existing .env unless --force.
+# ---------------------------------------------------------------------------
+ENV_REUSED=0
+
+write_env() {
+  section "Environment file (.env)"
+
+  if [ -f "$ENV_FILE" ] && [ "$FORCE" -eq 0 ]; then
+    ENV_REUSED=1
+    success "Existing .env found — reusing it untouched (use --force to regenerate)."
+    info "Secrets, ports and credentials already in .env are preserved."
+    return 0
+  fi
+
+  if [ -f "$ENV_FILE" ]; then
+    backup_file "$ENV_FILE"
+  fi
+
+  local jwt_secret file_signing_key
+  if [ "$EPHEMERAL_SECRETS" -eq 1 ]; then
+    jwt_secret=""
+    file_signing_key=""
+    warn "Ephemeral secrets: JWT_SECRET and FILE_SIGNING_KEY left empty (auto-generated per restart)."
+  else
+    jwt_secret="$(gen_secret)"
+    file_signing_key="$(gen_secret)"
+    success "Generated JWT_SECRET and FILE_SIGNING_KEY (64-hex each)."
+  fi
+
+  # User-supplied values may contain '$'; escape them so Compose does not
+  # interpolate them away. Generated secrets/passwords are alnum/hex (no-op).
+  local env_tenant_name env_tenant_slug env_admin_email env_admin_password
+  env_tenant_name="$(esc_env "$TENANT_NAME")"
+  env_tenant_slug="$(esc_env "$TENANT_SLUG")"
+  env_admin_email="$(esc_env "$ADMIN_EMAIL")"
+  env_admin_password="$(esc_env "$ADMIN_PASSWORD")"
+
+  # Default DB credentials match .env.example (fine for a single-host example).
+  # Subshell with a tight umask so the secrets file is 0600 from the first byte
+  # (no world-readable window before the chmod below).
+  ( umask 077
+  cat > "$ENV_FILE" <<EOF
+# Inventario deployment environment — generated by setup.sh on $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+# This file is gitignored and written mode 0600. It holds CLEARTEXT secrets
+# (JWT/file-signing keys, DB and admin passwords) — keep it private.
+#
+# Run mode and image tag are wired through docker-compose.override.yaml.
+
+# Application Configuration
+INVENTARIO_HOST_PORT=${PORT}
+
+# Secrets. Generate each with: openssl rand -hex 32
+# Empty values cause the app to auto-generate throwaway keys per restart, which
+# invalidates existing sessions and previously-signed file URLs on every restart.
+JWT_SECRET=${jwt_secret}
+FILE_SIGNING_KEY=${file_signing_key}
+FILE_URL_EXPIRATION=15m
+
+# Worker limits
+MAX_CONCURRENT_EXPORTS=3
+MAX_CONCURRENT_IMPORTS=1
+
+# Thumbnail Generation Configuration
+THUMBNAIL_MAX_CONCURRENT_PER_USER=5
+THUMBNAIL_RATE_LIMIT_PER_MINUTE=50
+THUMBNAIL_SLOT_DURATION=30m
+
+# Token blacklist (Redis)
+TOKEN_BLACKLIST_REDIS_URL=redis://redis:6379
+
+# System
+TZ=UTC
+
+# Database Configuration (local defaults — fine for a single-host example)
+POSTGRES_DB=inventario
+POSTGRES_USER=inventario
+POSTGRES_PASSWORD=inventario_password
+POSTGRES_MIGRATOR_USER=inventario_migrator
+POSTGRES_MIGRATOR_PASSWORD=inventario_migrator_password
+
+# Initial Data Setup (runs only once)
+DEFAULT_TENANT_NAME=${env_tenant_name}
+DEFAULT_TENANT_SLUG=${env_tenant_slug}
+ADMIN_EMAIL=${env_admin_email}
+ADMIN_PASSWORD=${env_admin_password}
+ADMIN_NAME=System Administrator
+EOF
+  )
+
+  chmod 600 "$ENV_FILE"
+  success "Wrote .env (mode 0600)"
+}
+
+# ---------------------------------------------------------------------------
+# Override generation. Always (re)generate for the chosen mode.
+# ---------------------------------------------------------------------------
+write_override() {
+  section "Compose override (docker-compose.override.yaml)"
+
+  # Render to a temp file first; only back up + replace if the content actually
+  # changed, so repeated runs with identical inputs don't litter .bak.<n> files.
+  # No timestamp in the body, otherwise every run would differ.
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/inventario-override.XXXXXX")"
+  TMP_FILES+=("$tmp")
+
+  if [ "$MODE" = "image" ]; then
+    local image_ref="${IMAGE_REPO}:${IMAGE_TAG}"
+    # Image mode: for ALL FOUR inventario services, remove the build block with
+    # `build: !reset null` and pin `image:`. This guarantees a plain
+    # `docker compose up` can never trigger a local Node+Go compile (the build
+    # key is fully removed from the resolved config, not merely emptied).
+    # The main service also publishes the host port and wires the file signing key.
+    cat > "$tmp" <<EOF
+# Inventario Compose override — IMAGE mode — generated by setup.sh.
+#
+# Runs the prebuilt multi-arch image ${image_ref} with NO local compilation.
+# 'build: !reset null' fully removes the build block from the resolved config so
+# 'docker compose up' can never rebuild from source. Requires Compose >= v2.24.0.
+#
+# Re-generated by setup.sh on each run; edit setup.sh flags rather than this file.
+
+services:
+  inventario-bootstrap:
+    build: !reset null
+    image: ${image_ref}
+
+  inventario-migrate:
+    build: !reset null
+    image: ${image_ref}
+
+  inventario-init-data:
+    build: !reset null
+    image: ${image_ref}
+
+  inventario:
+    build: !reset null
+    image: ${image_ref}
+    # Base compose publishes NO host port; the override must add it for reachability.
+    ports:
+      - "\${INVENTARIO_HOST_PORT:-3333}:3333"
+    environment:
+      # Base compose does NOT wire the file signing key into the main service;
+      # supply it from .env so signed file URLs survive restarts.
+      INVENTARIO_RUN_FILE_SIGNING_KEY: \${FILE_SIGNING_KEY:-}
+      INVENTARIO_RUN_FILE_URL_EXPIRATION: \${FILE_URL_EXPIRATION:-15m}
+EOF
+  else
+    # Source mode: services keep building from the local repository. The override
+    # only adds the host port mapping and the file signing key wiring.
+    cat > "$tmp" <<EOF
+# Inventario Compose override — SOURCE mode — generated by setup.sh.
+#
+# Services keep building from the local repository (base compose 'build:' blocks).
+# This override only publishes the host port and wires the file signing key.
+#
+# Re-generated by setup.sh on each run; edit setup.sh flags rather than this file.
+
+services:
+  inventario:
+    # Base compose publishes NO host port; the override must add it for reachability.
+    ports:
+      - "\${INVENTARIO_HOST_PORT:-3333}:3333"
+    environment:
+      # Base compose does NOT wire the file signing key into the main service;
+      # supply it from .env so signed file URLs survive restarts.
+      INVENTARIO_RUN_FILE_SIGNING_KEY: \${FILE_SIGNING_KEY:-}
+      INVENTARIO_RUN_FILE_URL_EXPIRATION: \${FILE_URL_EXPIRATION:-15m}
+EOF
+  fi
+
+  if [ -f "$OVERRIDE_FILE" ] && cmp -s "$tmp" "$OVERRIDE_FILE"; then
+    rm -f "$tmp"
+    success "docker-compose.override.yaml already current (${MODE} mode) — left unchanged."
+    return 0
+  fi
+
+  backup_file "$OVERRIDE_FILE"
+  mv "$tmp" "$OVERRIDE_FILE"
+  chmod 600 "$OVERRIDE_FILE" 2>/dev/null || true
+  if [ "$MODE" = "image" ]; then
+    success "Wrote docker-compose.override.yaml (image mode -> ${IMAGE_REPO}:${IMAGE_TAG})"
+  else
+    success "Wrote docker-compose.override.yaml (source mode)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Validate the merged Compose configuration.
+# ---------------------------------------------------------------------------
+validate_config() {
+  section "Validate"
+  local errf
+  errf="$(mktemp "${TMPDIR:-/tmp}/inventario-compose.XXXXXX")"
+  TMP_FILES+=("$errf")
+  if "${COMPOSE[@]}" config -q 2>"$errf"; then
+    success "Compose configuration is valid ('${COMPOSE[*]} config -q' exited 0)."
+    rm -f "$errf"
+  else
+    err "Compose configuration is INVALID:"
+    cat "$errf" >&2 || true
+    rm -f "$errf"
+    die "Aborting — fix the configuration above and re-run."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Determine whether the compose 'up' supports --wait.
+# ---------------------------------------------------------------------------
+compose_supports_wait() {
+  "${COMPOSE[@]}" up --help 2>/dev/null | grep -q -- '--wait'
+}
+
+# ---------------------------------------------------------------------------
+# Pre-create host bind-mount dirs. On native Linux, Docker auto-creates missing
+# bind-mount dirs as root:root, which the non-root (uid 1001) app/init container
+# cannot write — init-data's `touch /app/state/data-initialized` then fails and
+# aborts the whole `up`. Pre-own the inventario-owned mounts to the image user.
+# ---------------------------------------------------------------------------
+prepare_data_dirs() {
+  mkdir -p data/postgres data/redis data/init-state data/uploads
+  if [ "$(uname -s)" = "Linux" ]; then
+    if ! chown -R 1001:1001 data/init-state data/uploads 2>/dev/null; then
+      warn "Could not chown data/init-state, data/uploads to uid 1001. If 'up' fails with"
+      warn "permission errors on native Linux, run: sudo chown -R 1001:1001 data/init-state data/uploads"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Start the stack.
+# ---------------------------------------------------------------------------
+start_stack() {
+  section "Start"
+  local wait_flag=()
+  if compose_supports_wait; then
+    wait_flag=(--wait)
+  fi
+
+  if [ "$MODE" = "image" ]; then
+    log "Pulling prebuilt image ${IMAGE_REPO}:${IMAGE_TAG} ..."
+    if ! "${COMPOSE[@]}" pull; then
+      die "Pull failed for ${IMAGE_REPO}:${IMAGE_TAG}. Verify the tag exists at ghcr.io (edge/latest/master/sha-*/vX.Y.Z) and is reachable; for a private tag run 'docker login ghcr.io'."
+    fi
+    log "Starting stack (no build) ..."
+    "${COMPOSE[@]}" up -d --no-build "${wait_flag[@]+"${wait_flag[@]}"}"
+  else
+    log "Building from source and starting stack ..."
+    "${COMPOSE[@]}" up -d --build "${wait_flag[@]+"${wait_flag[@]}"}"
+  fi
+  success "Stack is up."
+}
+
+# ---------------------------------------------------------------------------
+# Final summary / next steps.
+# ---------------------------------------------------------------------------
+print_access_info() {
+  local started="$1"   # 1 if started, 0 if not
+  local compose_str="${COMPOSE[*]}"
+
+  section "Summary"
+  info "Mode:        ${MODE}"
+  if [ "$MODE" = "image" ]; then
+    info "Image:       ${IMAGE_REPO}:${IMAGE_TAG}"
+  fi
+  info "Host port:   ${PORT}"
+  info "Admin email: ${ADMIN_EMAIL}"
+  if [ "$ADMIN_PASSWORD_GENERATED" -eq 1 ]; then
+    printf '%s\n' "    Admin password (generated, shown once): ${C_BOLD}${ADMIN_PASSWORD}${C_RESET}" >&2
+  elif [ "$ENV_REUSED" -eq 1 ]; then
+    info "Admin password: (unchanged — taken from existing .env)"
+    info "Recover it with: grep '^ADMIN_PASSWORD=' \"$ENV_FILE\""
+  else
+    info "Admin password: (as supplied via --admin-password)"
+  fi
+  info ".env:        $ENV_FILE"
+  info "override:    $OVERRIDE_FILE"
+
+  if [ "$started" -eq 1 ]; then
+    printf '\n%s\n' "${C_GREEN}${C_BOLD}Inventario is starting.${C_RESET}" >&2
+    info "Web UI:   http://localhost:${PORT}"
+    info "Swagger:  http://localhost:${PORT}/swagger  (if enabled by the app build)"
+    info "Readiness: http://localhost:${PORT}/readyz"
+    printf '\n%s\n' "    Follow logs:  ${compose_str} logs -f inventario" >&2
+    info "Stop:         ${compose_str} down"
+    info "Stop + wipe:  ${compose_str} down && rm -rf ./data"
+  else
+    printf '\n%s\n' "${C_GREEN}${C_BOLD}Preparation complete.${C_RESET} To start the stack, run:" >&2
+    if [ "$MODE" = "image" ]; then
+      printf '%s\n' "    ${C_BOLD}${compose_str} pull && ${compose_str} up -d --no-build${C_RESET}" >&2
+    else
+      printf '%s\n' "    ${C_BOLD}${compose_str} up -d --build${C_RESET}" >&2
+    fi
+    info "Then open: http://localhost:${PORT}"
+    info "Validate config any time: ${compose_str} config -q"
+    if [ "$ADMIN_PASSWORD_GENERATED" -eq 1 ]; then
+      printf '%s\n' "${C_YELLOW}Note:${C_RESET} the generated admin password above is also stored in .env (ADMIN_PASSWORD)." >&2
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+
+  # Operator-supplied strings must not inject extra .env lines via a newline.
+  reject_ctrl "$ADMIN_PASSWORD" "--admin-password"
+  reject_ctrl "$ADMIN_EMAIL" "--admin-email"
+  reject_ctrl "$TENANT_NAME" "--tenant-name"
+  reject_ctrl "$TENANT_SLUG" "--tenant-slug"
+
+  [ -f "$COMPOSE_FILE" ] || die "docker-compose.yaml not found in $SCRIPT_DIR — run this from the example directory."
+
+  section "Inventario setup"
+  info "Working directory: $SCRIPT_DIR"
+
+  preflight
+
+  # Resolve mode (prompt if not given).
+  if [ -z "$MODE" ]; then
+    if [ "$ASSUME_YES" -eq 1 ]; then
+      MODE="image"
+    else
+      local choice
+      choice="$(prompt_default "Run mode — 'image' (prebuilt, no compile) or 'source' (build locally)" "image")"
+      MODE="$choice"
+    fi
+  fi
+  case "$MODE" in
+    image|source) ;;
+    *) die "Invalid --mode '$MODE' (expected 'image' or 'source')." ;;
+  esac
+
+  # Interactive refinement of common settings (skipped with -y).
+  if [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ]; then
+    if [ "$MODE" = "image" ]; then
+      IMAGE_TAG="$(prompt_default "Image tag" "$IMAGE_TAG")"
+    fi
+    PORT="$(prompt_default "Host port" "$PORT")"
+    ADMIN_EMAIL="$(prompt_default "Admin email" "$ADMIN_EMAIL")"
+  fi
+
+  # Basic validation of port.
+  case "$PORT" in
+    ''|*[!0-9]*) die "Invalid --port '$PORT' (must be numeric)." ;;
+  esac
+  if [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+    die "Invalid --port '$PORT' (must be 1-65535)."
+  fi
+
+  # Validate the image tag (image mode only) for a clear message before we write.
+  if [ "$MODE" = "image" ]; then
+    case "$IMAGE_TAG" in
+      '') die "--image-tag must not be empty." ;;
+      *[!A-Za-z0-9._-]*) die "Invalid --image-tag '$IMAGE_TAG' (allowed: letters, digits, '.', '_', '-')." ;;
+    esac
+  fi
+
+  # Resolve admin password (generate if omitted) — only matters when we (re)write .env.
+  local will_write_env=0
+  if [ ! -f "$ENV_FILE" ] || [ "$FORCE" -eq 1 ]; then
+    will_write_env=1
+  fi
+  if [ "$will_write_env" -eq 1 ] && [ -z "$ADMIN_PASSWORD" ]; then
+    ADMIN_PASSWORD="$(gen_password)"
+    ADMIN_PASSWORD_GENERATED=1
+  fi
+
+  write_env
+
+  # When an existing .env is reused, .env-only flags (port/admin/tenant) are NOT
+  # applied. Report the values actually in effect and warn if flags were passed.
+  if [ "$ENV_REUSED" -eq 1 ]; then
+    local eff_port eff_email
+    eff_port="$(unesc_env "$(read_env_value INVENTARIO_HOST_PORT)")"
+    eff_email="$(unesc_env "$(read_env_value ADMIN_EMAIL)")"
+    [ -n "$eff_port" ] && PORT="$eff_port"
+    [ -n "$eff_email" ] && ADMIN_EMAIL="$eff_email"
+    if [ "$ENV_FLAGS_SUPPLIED" -eq 1 ]; then
+      warn "Existing .env reused — --port/--admin-email/--admin-password/--tenant-* were ignored. Re-run with --force to apply them."
+    fi
+  fi
+
+  write_override
+  validate_config
+  prepare_data_dirs
+
+  # Resolve start decision.
+  if [ -z "$START" ]; then
+    if [ "$ASSUME_YES" -eq 1 ]; then
+      START=0
+    elif prompt_yes_no "Start the stack now?" "n"; then
+      START=1
+    else
+      START=0
+    fi
+  fi
+
+  if [ "$START" -eq 1 ]; then
+    start_stack
+    print_access_info 1
+  else
+    print_access_info 0
+  fi
+
+  success "Done."
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds `example/setup.sh` — a one-command preparer for the Docker Compose example — and refreshes the surrounding kit so users get a clear **choice** without reading every setting.

### Run modes
- **image** (default): pull the prebuilt multi-arch image `ghcr.io/denisvmedia/inventario:edge` — no toolchain, no compile. `build: !reset null` removes the build block on all four `inventario*` services so `docker compose up` can never rebuild.
- **source**: build locally from the repo `Dockerfile` (`production` target).

`./setup.sh` is interactive; `./setup.sh --mode image -y --start` is the fast path. It generates secrets, writes `.env` (mode `0600`) and a mode-specific `docker-compose.override.yaml`, validates with `docker compose config -q`, and optionally starts the stack.

### Hardening / fixes to the kit
- **Fail-closed admin password**: the base compose now errors on an unset/empty `ADMIN_PASSWORD` instead of defaulting to the well-known `Admin123`; `setup.sh` always generates a strong one (guaranteed to satisfy the backend complexity policy).
- Both modes publish the host port (the base compose published **none**, so the app was unreachable) and wire `INVENTARIO_RUN_FILE_SIGNING_KEY`.
- `.env` and its backups are written `0600`; operator-supplied values are `$`-escaped and rejected if they contain newlines (no `.env` line injection).
- README rewritten around the mode choice; env-var table completed; `docker compose` (v2) throughout; `.env.example` and the override example corrected and reframed as an illustrative reference (it renames the DB and ships rejected placeholders — not a drop-in).
- `.gitignore` ignores secret-bearing `.env.bak.*` / override backups.

### Quality
- `setup.sh`: `set -euo pipefail`, bash 3.2 (macOS) safe, shellcheck-clean; both modes validated via `docker compose config`; prebuilt image confirmed multi-arch (amd64/arm64).
- Developed against a 3-round adversarial multi-agent self-review (confirmed findings 18 → 11 → 0 HIGH/medium).

### Follow-up (out of scope here)
- Backend: reject known-default admin passwords in `db migrate data` (mirroring the JWT/file-signing placeholder rejection), so the protection also holds outside this kit.

https://claude.ai/code/session_01NMehfFBUzKGTvKF1ZvG7a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated deployment setup script for Docker Compose with prebuilt image or build-from-source modes.

* **Documentation**
  * Comprehensive deployment guide with setup instructions, configuration details, and troubleshooting procedures.

* **Chores**
  * Enhanced security handling for credentials and secrets in example deployments; updated configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->