### PR TITLE
example: back-office auto-provision + seed prompt + postgres 18 fix + PR smoke CI

### DIFF
--- a/.github/workflows/example-smoke-test.yml
+++ b/.github/workflows/example-smoke-test.yml
@@ -69,21 +69,27 @@ jobs:
       - name: Smoke test — tenant login, backoffice login, seed, endpoint disabled
         run: |
           set -euo pipefail
+          # Read every value from the generated .env so the test never drifts from setup.sh defaults.
           PORT=$(grep '^INVENTARIO_HOST_PORT=' .env | cut -d= -f2-)
+          ADMIN_EMAIL=$(grep '^ADMIN_EMAIL=' .env | cut -d= -f2-)
           ADMIN_PW=$(grep '^ADMIN_PASSWORD=' .env | cut -d= -f2-)
+          BO_EMAIL=$(grep '^BACKOFFICE_EMAIL=' .env | cut -d= -f2-)
           BO_PW=$(grep '^BACKOFFICE_PASSWORD=' .env | cut -d= -f2-)
           BASE="http://localhost:${PORT}"
+
+          echo "--- postgres 18 data landed in the pgdata subdir (PGDATA fix) ---"
+          sudo test -f data/postgres/pgdata/PG_VERSION
 
           echo "--- tenant admin login (expect access_token) ---"
           curl -fsS -X POST "$BASE/api/v1/auth/login" \
             -H 'Content-Type: application/json' \
-            -d "{\"email\":\"admin@example.com\",\"password\":\"${ADMIN_PW}\"}" \
+            -d "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PW}\"}" \
             | jq -e '.access_token' >/dev/null
 
           echo "--- backoffice operator login (auto-provisioned; expect access_token) ---"
           curl -fsS -X POST "$BASE/api/v1/backoffice/auth/login" \
             -H 'Content-Type: application/json' \
-            -d "{\"email\":\"backoffice@example.com\",\"password\":\"${BO_PW}\"}" \
+            -d "{\"email\":\"${BO_EMAIL}\",\"password\":\"${BO_PW}\"}" \
             | jq -e '.access_token' >/dev/null
 
           echo "--- seed endpoint must be DISABLED again after seeding (expect 404) ---"

--- a/.github/workflows/example-smoke-test.yml
+++ b/.github/workflows/example-smoke-test.yml
@@ -1,0 +1,111 @@
+name: Example Smoke Test
+
+# Exercises example/setup.sh and the whole example/ deployment kit. Deliberately
+# PR-only and path-scoped: it runs ONLY on pull requests that touch example/** or
+# this workflow file, and never on master (no `push:` trigger) — the example is a
+# convenience kit, not a release gate, so master CI shouldn't pay for it.
+on:
+  pull_request:
+    paths:
+      - 'example/**'
+      - '.github/workflows/example-smoke-test.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  example-smoke:
+    name: setup.sh + example stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: example
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Lint setup.sh + init scripts
+        run: |
+          set -euo pipefail
+          bash -n setup.sh
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y shellcheck
+          fi
+          shellcheck -S warning setup.sh scripts/*.sh
+
+      - name: setup.sh --help
+        run: ./setup.sh --help
+
+      - name: Validate both modes (config only)
+        run: |
+          set -euo pipefail
+          # Source mode: keeps the 4 build blocks; wires BACKOFFICE_* into init-data.
+          ./setup.sh --mode source -y --no-start --force
+          docker compose config -q
+          test "$(docker compose config | grep -c 'build:')" = "4"
+          docker compose config | grep -q 'BACKOFFICE_PASSWORD'
+          # Image mode: drops build via `build: !reset null` (0 build keys, edge image).
+          ./setup.sh --mode image -y --no-start --force
+          docker compose config -q
+          test "$(docker compose config | grep -c 'build:')" = "0"
+          docker compose config --images | grep -q 'inventario:edge'
+
+      - name: Bring up the example stack with seeding (image mode)
+        run: |
+          set -euo pipefail
+          # The non-root (uid 1001) app/init containers write these bind mounts.
+          mkdir -p data/init-state data/uploads
+          chmod 777 data/init-state data/uploads
+          # image mode: pull edge, start, seed demo data, then disable the seed endpoint.
+          # NOTE: tests the kit wiring against the published edge image. Source-mode
+          # builds are covered by the root docker-compose-smoke-test workflow.
+          ./setup.sh --mode image -y --seed --force
+
+      - name: Smoke test — tenant login, backoffice login, seed, endpoint disabled
+        run: |
+          set -euo pipefail
+          PORT=$(grep '^INVENTARIO_HOST_PORT=' .env | cut -d= -f2-)
+          ADMIN_PW=$(grep '^ADMIN_PASSWORD=' .env | cut -d= -f2-)
+          BO_PW=$(grep '^BACKOFFICE_PASSWORD=' .env | cut -d= -f2-)
+          BASE="http://localhost:${PORT}"
+
+          echo "--- tenant admin login (expect access_token) ---"
+          curl -fsS -X POST "$BASE/api/v1/auth/login" \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"admin@example.com\",\"password\":\"${ADMIN_PW}\"}" \
+            | jq -e '.access_token' >/dev/null
+
+          echo "--- backoffice operator login (auto-provisioned; expect access_token) ---"
+          curl -fsS -X POST "$BASE/api/v1/backoffice/auth/login" \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"backoffice@example.com\",\"password\":\"${BO_PW}\"}" \
+            | jq -e '.access_token' >/dev/null
+
+          echo "--- seed endpoint must be DISABLED again after seeding (expect 404) ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v1/seed" \
+            -H 'Content-Type: application/json' -d '{}')
+          test "$code" = "404" || { echo "expected 404, got $code"; exit 1; }
+
+          echo "--- seeded demo data present (expect commodities > 0) ---"
+          n=$(docker compose exec -T postgres psql -U inventario -d inventario -tA \
+            -c 'select count(*) from commodities;')
+          echo "commodities=$n"
+          test "$n" -gt 0
+
+          echo "--- override left clean (no seed env in steady state) ---"
+          test "$(grep -c 'ENABLE_SEED_ENDPOINT' docker-compose.override.yaml)" = "0"
+
+          echo "=== all example smoke checks passed ==="
+
+      - name: Print service logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/example/.env.example
+++ b/example/.env.example
@@ -53,6 +53,17 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=
 ADMIN_NAME=System Administrator
 
+# Back-office (platform operator) — auto-provisioned on first run.
+# Authenticates at /backoffice/login, OUTSIDE the tenant model (no tenant_id).
+BACKOFFICE_EMAIL=backoffice@example.com
+BACKOFFICE_NAME=Platform Admin
+# REQUIRED: set a strong password before first boot — same policy as ADMIN_PASSWORD
+# (>= 8 chars with upper, lower, and a digit). The base compose fails closed if empty.
+BACKOFFICE_PASSWORD=
+# Demo default: password-only login. For production set BACKOFFICE_MFA_ENFORCED=true
+# and enrol TOTP via 'inventario backoffice mfa setup' before the first sign-in.
+BACKOFFICE_MFA_ENFORCED=false
+
 # Security Note:
 # - This file holds CLEARTEXT secrets — chmod 600 .env and keep it private.
 # - Set a strong, unique ADMIN_PASSWORD (and database passwords) before deploying.

--- a/example/.env.example
+++ b/example/.env.example
@@ -61,7 +61,7 @@ BACKOFFICE_NAME=Platform Admin
 # (>= 8 chars with upper, lower, and a digit). The base compose fails closed if empty.
 BACKOFFICE_PASSWORD=
 # Demo default: password-only login. For production set BACKOFFICE_MFA_ENFORCED=true
-# and enrol TOTP via 'inventario backoffice mfa setup' before the first sign-in.
+# and enroll TOTP via 'inventario backoffice mfa setup' before the first sign-in.
 BACKOFFICE_MFA_ENFORCED=false
 
 # Security Note:

--- a/example/README.md
+++ b/example/README.md
@@ -34,7 +34,7 @@ The first run auto-provisions two independent accounts (created by the `inventar
 | **Tenant admin** (the app) | `http://localhost:3333/` | `admin@example.com` | `ADMIN_PASSWORD` |
 | **Back-office operator** (platform admin) | `http://localhost:3333/backoffice/login` | `backoffice@example.com` | `BACKOFFICE_PASSWORD` |
 
-Back-office users live **outside** the tenant model (no tenant, no group scoping) and manage the platform. The example provisions the operator with **MFA disabled** (`BACKOFFICE_MFA_ENFORCED=false`) so you can sign in with just a password. For production, set `BACKOFFICE_MFA_ENFORCED=true` and enrol TOTP via `inventario backoffice mfa setup` before the first sign-in.
+Back-office users live **outside** the tenant model (no tenant, no group scoping) and manage the platform. The example provisions the operator with **MFA disabled** (`BACKOFFICE_MFA_ENFORCED=false`) so you can sign in with just a password. For production, set `BACKOFFICE_MFA_ENFORCED=true` and enroll TOTP via `inventario backoffice mfa setup` before the first sign-in.
 
 ### Seeding demo data
 
@@ -169,14 +169,14 @@ If you want full control instead of the script, configure the two files by hand.
 1. **PostgreSQL starts** and creates the migration user via the init script.
 2. **Bootstrap service** runs `db bootstrap apply` to set up extensions and roles (idempotent — safe to run repeatedly).
 3. **Migration service** runs `db migrate up` to apply schema changes.
-4. **Init data service** (first deployment only, gated by `./data/init-state/data-initialized`) seeds the default tenant + tenant admin (`db migrate data`) and provisions the back-office operator (`backoffice bootstrap --ensure`).
+4. **Init data service** (first deployment only, gated by `./data/init-state/data-initialized`) seeds the default tenant + tenant admin (`db migrate data`) and provisions the back-office operator (`backoffice bootstrap --ensure`). The marker is written only after **both** succeed.
 5. **Main application** starts and serves requests.
 
 ### Data Persistence
 
 All data is stored in host-mounted directories for easy access:
 
-- **./data/postgres**: PostgreSQL database files (in the `pgdata/` subdirectory — Postgres 18 requires `PGDATA` to be a subdir of the bind mount).
+- **./data/postgres**: PostgreSQL database files (in the `pgdata/` subdirectory — the Postgres 18 image refuses to start with data bind-mounted directly at the mount root, so the compose sets `PGDATA` to a subdir).
 - **./data/redis**: Redis persistence (token-blacklist data).
 - **./data/uploads**: Application file uploads.
 - **./data/init-state**: Tracks initialization state to prevent data re-setup.
@@ -233,7 +233,7 @@ example/
 | `BACKOFFICE_EMAIL` | `backoffice@example.com` | Back-office operator email (first run only). |
 | `BACKOFFICE_NAME` | `Platform Admin` | Back-office operator display name (first run only). |
 | `BACKOFFICE_PASSWORD` | generated / **required** | Back-office operator password (first run only). `setup.sh` generates one; the manual path must set it (fails closed if empty). Same complexity policy as `ADMIN_PASSWORD`. |
-| `BACKOFFICE_MFA_ENFORCED` | `false` | Demo default: password-only back-office login. Set `true` for production, then enrol TOTP via `inventario backoffice mfa setup`. |
+| `BACKOFFICE_MFA_ENFORCED` | `false` | Demo default: password-only back-office login. Set `true` for production, then enroll TOTP via `inventario backoffice mfa setup`. |
 
 > Build-time only (source mode): `VERSION`, `COMMIT`, and `BUILD_DATE` are optional image-label build args (defaults `dev` / `unknown` / `unknown`, auto-detected if unset) — see the commented block in `.env.example`. They are ignored in image mode.
 
@@ -250,6 +250,42 @@ example/
 7. **Keep `.env` private.** `setup.sh` writes it mode `0600` (and its `.bak.*` backups too); it holds cleartext secrets (`JWT_SECRET`, `FILE_SIGNING_KEY`, DB, admin and back-office passwords). On a shared host, do not loosen its permissions. If you create `.env` by hand, `chmod 600 .env`.
 8. **Enable back-office MFA** for production (`BACKOFFICE_MFA_ENFORCED=true` + `inventario backoffice mfa setup`). The example ships it disabled for convenience.
 9. **The seed endpoint** (`POST /api/v1/seed`) is unauthenticated and RLS-bypassing. `setup.sh --seed` enables it only transiently and disables it again; never enable it in production.
+
+## Upgrading an existing deployment
+
+Some changes are **not** applied automatically to a stack that was already initialized (the init-data step runs once, gated by `./data/init-state/data-initialized`):
+
+### PostgreSQL 18 data directory (⚠ back up first)
+
+This kit runs **PostgreSQL 18**, which stores data in a version-specific layout; the compose pins `PGDATA` to `./data/postgres/pgdata`. If you have an older cluster whose data sits directly in `./data/postgres` (e.g. a previous Postgres 17 setup), Postgres 18 starts a **fresh, empty** cluster in `pgdata/` and leaves the old files untouched — so the app looks like it lost its data. A major-version bump (17 → 18) needs a logical dump/restore regardless. **Back up `./data` first**, then:
+
+```bash
+# With the OLD stack running, dump everything:
+docker compose exec -T postgres pg_dumpall -U inventario > dump.sql
+# Upgrade (git pull) and start the new stack so Postgres 18 initializes ./data/postgres/pgdata, then restore:
+docker compose exec -T postgres psql -U inventario -d postgres < dump.sql
+```
+
+### Add the back-office operator to an already-initialized stack
+
+The back-office operator is auto-provisioned only on the **first** init. On a stack initialized before it was added, create it manually (idempotent):
+
+```bash
+docker compose run --rm --no-deps inventario backoffice bootstrap \
+  --email backoffice@example.com --name "Platform Admin" --mfa-enforced=false
+# Omit --password to get a strong generated one printed once.
+```
+
+### Enable back-office MFA (recommended for production)
+
+```bash
+docker compose run --rm --no-deps inventario backoffice mfa setup \
+  --email backoffice@example.com \
+  --jwt-secret "$(grep '^JWT_SECRET=' .env | cut -d= -f2-)"
+# Prints a TOTP secret + otpauth:// URL + backup codes ONCE. --jwt-secret MUST
+# match the server's JWT_SECRET or the enrollment is undecryptable at login.
+# Then set BACKOFFICE_MFA_ENFORCED=true.
+```
 
 ## Maintenance
 

--- a/example/README.md
+++ b/example/README.md
@@ -177,9 +177,9 @@ If you want full control instead of the script, configure the two files by hand.
 All data is stored in host-mounted directories for easy access:
 
 - **./data/postgres**: PostgreSQL database files (in the `pgdata/` subdirectory — the Postgres 18 image refuses to start with data bind-mounted directly at the mount root, so the compose sets `PGDATA` to a subdir).
-- **./data/redis**: Redis persistence (token-blacklist data).
 - **./data/uploads**: Application file uploads.
 - **./data/init-state**: Tracks initialization state to prevent data re-setup.
+- **`redis-data`** (named volume, not under `./data`): Redis token-blacklist cache. It uses a named volume because the redis image's working dir is `/data`; a host bind mount there makes healthchecks fail if the host dir is recreated. Remove it with `docker compose down -v`.
 
 **Directory Structure:**
 
@@ -187,7 +187,6 @@ All data is stored in host-mounted directories for easy access:
 example/
 ├── data/
 │   ├── postgres/          # PostgreSQL data files (under pgdata/ — PGDATA subdir)
-│   ├── redis/             # Redis token-blacklist persistence
 │   ├── uploads/           # Application file uploads
 │   └── init-state/        # Initialization tracking
 ├── docker-compose.yaml
@@ -343,8 +342,8 @@ Migrations run automatically on startup in either case.
 ### Reset Data (Development Only)
 
 ```bash
-# WARNING: this deletes all data
-docker compose down
+# WARNING: this deletes all data (-v also removes the redis named volume)
+docker compose down -v
 rm -rf ./data/
 docker compose up -d
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -21,9 +21,24 @@ Or skip the prompts with one of the two fastest paths:
 ./setup.sh --mode source -y --start
 ```
 
-When the stack is up, the script prints the access URL, the Swagger location, and the admin credentials. A generated admin password is printed once at the end and is also saved to `.env` as `ADMIN_PASSWORD` (recover it with `grep '^ADMIN_PASSWORD=' .env`). By default the app is published on `http://localhost:3333` (change with `--port`).
+When the stack is up, the script prints the access URL, the Swagger location, and the credentials for **two** logins (see [Logins](#logins) below). Both passwords are generated, printed once, and saved to `.env`. The script also asks whether to **seed demo data** so you don't log into an empty app (or pass `--seed`). By default the app is published on `http://localhost:3333` (change with `--port`).
 
 > The script is safe to re-run. It never clobbers an existing `.env` (re-run with `--force` to regenerate). It always regenerates the override for the mode you pick, backing up any previous one.
+
+## Logins
+
+The first run auto-provisions two independent accounts (created by the `inventario-init-data` service, or by `setup.sh` which generates their passwords into `.env`):
+
+| Login | URL | Default email | Password (in `.env`) |
+|-------|-----|---------------|----------------------|
+| **Tenant admin** (the app) | `http://localhost:3333/` | `admin@example.com` | `ADMIN_PASSWORD` |
+| **Back-office operator** (platform admin) | `http://localhost:3333/backoffice/login` | `backoffice@example.com` | `BACKOFFICE_PASSWORD` |
+
+Back-office users live **outside** the tenant model (no tenant, no group scoping) and manage the platform. The example provisions the operator with **MFA disabled** (`BACKOFFICE_MFA_ENFORCED=false`) so you can sign in with just a password. For production, set `BACKOFFICE_MFA_ENFORCED=true` and enrol TOTP via `inventario backoffice mfa setup` before the first sign-in.
+
+### Seeding demo data
+
+`setup.sh` asks whether to seed the database (or pass `--seed`) so you don't land in an empty app. Seeding briefly enables the unauthenticated, RLS-bypassing seed endpoint (`POST /api/v1/seed`), loads bundled example data into the default tenant, then **disables the endpoint again** and recreates the app container — so it is off in the steady state. `--seed` implies `--start`. Never leave the seed endpoint enabled in production.
 
 ## Deployment modes
 
@@ -45,8 +60,11 @@ In **image** mode the override sets `image:` and removes the `build:` section fr
 | `--admin-password <pw>` | generated | Initial admin password. If omitted, a strong random password is generated and printed once at the end. |
 | `--tenant-name <name>` | `Default Organization` | Initial organization (tenant) name. |
 | `--tenant-slug <slug>` | `default` | Initial tenant slug. |
+| `--backoffice-email <email>` | `backoffice@example.com` | Back-office (platform operator) email. |
+| `--backoffice-password <pw>` | generated | Back-office password. If omitted, a strong random one is generated and printed once. |
 | `--ephemeral-secrets` | off | Do **not** persist `JWT_SECRET` / `FILE_SIGNING_KEY`. They are left empty, so the app auto-generates throwaway keys per restart (fine for local testing, not for production). |
 | `--start` / `--no-start` | interactive prompt; `--no-start` with `-y` | Bring the stack up after preparing the files. |
+| `--seed` / `--no-seed` | interactive prompt when starting; no with `-y` | After start, seed demo data so the app isn't empty. Enables the seed endpoint only for the seeding step, then disables it. `--seed` implies `--start`. |
 | `-y`, `--yes` | off | Non-interactive; accept all defaults (mode `image`, no start). |
 | `--force` | off | Overwrite an existing `.env`/override. The old file is backed up to `<file>.bak.<n>` first. |
 | `-h`, `--help` | — | Show usage. |
@@ -151,14 +169,14 @@ If you want full control instead of the script, configure the two files by hand.
 1. **PostgreSQL starts** and creates the migration user via the init script.
 2. **Bootstrap service** runs `db bootstrap apply` to set up extensions and roles (idempotent — safe to run repeatedly).
 3. **Migration service** runs `db migrate up` to apply schema changes.
-4. **Init data service** runs `db migrate data` — only on first deployment, gated by `./data/init-state/data-initialized`.
+4. **Init data service** (first deployment only, gated by `./data/init-state/data-initialized`) seeds the default tenant + tenant admin (`db migrate data`) and provisions the back-office operator (`backoffice bootstrap --ensure`).
 5. **Main application** starts and serves requests.
 
 ### Data Persistence
 
 All data is stored in host-mounted directories for easy access:
 
-- **./data/postgres**: PostgreSQL database files.
+- **./data/postgres**: PostgreSQL database files (in the `pgdata/` subdirectory — Postgres 18 requires `PGDATA` to be a subdir of the bind mount).
 - **./data/redis**: Redis persistence (token-blacklist data).
 - **./data/uploads**: Application file uploads.
 - **./data/init-state**: Tracks initialization state to prevent data re-setup.
@@ -168,7 +186,7 @@ All data is stored in host-mounted directories for easy access:
 ```
 example/
 ├── data/
-│   ├── postgres/          # PostgreSQL data files
+│   ├── postgres/          # PostgreSQL data files (under pgdata/ — PGDATA subdir)
 │   ├── redis/             # Redis token-blacklist persistence
 │   ├── uploads/           # Application file uploads
 │   └── init-state/        # Initialization tracking
@@ -212,6 +230,10 @@ example/
 | `ADMIN_EMAIL` | `admin@example.com` | Initial admin user email (first run only). |
 | `ADMIN_PASSWORD` | generated / **required** | Initial admin user password (first run only). `setup.sh` generates a strong random one unless you pass `--admin-password`. In the manual path `.env.example` ships it empty, so set a value before first run; the base compose fails closed (errors) while it is unset/empty. Must satisfy: ≥8 chars with upper, lower, and a digit. |
 | `ADMIN_NAME` | `System Administrator` | Initial admin user display name (first run only). |
+| `BACKOFFICE_EMAIL` | `backoffice@example.com` | Back-office operator email (first run only). |
+| `BACKOFFICE_NAME` | `Platform Admin` | Back-office operator display name (first run only). |
+| `BACKOFFICE_PASSWORD` | generated / **required** | Back-office operator password (first run only). `setup.sh` generates one; the manual path must set it (fails closed if empty). Same complexity policy as `ADMIN_PASSWORD`. |
+| `BACKOFFICE_MFA_ENFORCED` | `false` | Demo default: password-only back-office login. Set `true` for production, then enrol TOTP via `inventario backoffice mfa setup`. |
 
 > Build-time only (source mode): `VERSION`, `COMMIT`, and `BUILD_DATE` are optional image-label build args (defaults `dev` / `unknown` / `unknown`, auto-detected if unset) — see the commented block in `.env.example`. They are ignored in image mode.
 
@@ -225,7 +247,9 @@ example/
 4. **PostgreSQL and Redis are internal only** (no host port exposure).
 5. **File uploads are persistent** but stored on the local filesystem (consider MinIO migration for scale).
 6. **Use an HTTPS reverse proxy** for production (nginx, Traefik, etc.).
-7. **Keep `.env` private.** `setup.sh` writes it mode `0600` (and its `.bak.*` backups too); it holds cleartext secrets (`JWT_SECRET`, `FILE_SIGNING_KEY`, DB and admin passwords). On a shared host, do not loosen its permissions. If you create `.env` by hand, `chmod 600 .env`.
+7. **Keep `.env` private.** `setup.sh` writes it mode `0600` (and its `.bak.*` backups too); it holds cleartext secrets (`JWT_SECRET`, `FILE_SIGNING_KEY`, DB, admin and back-office passwords). On a shared host, do not loosen its permissions. If you create `.env` by hand, `chmod 600 .env`.
+8. **Enable back-office MFA** for production (`BACKOFFICE_MFA_ENFORCED=true` + `inventario backoffice mfa setup`). The example ships it disabled for convenience.
+9. **The seed endpoint** (`POST /api/v1/seed`) is unauthenticated and RLS-bypassing. `setup.sh --seed` enables it only transiently and disables it again; never enable it in production.
 
 ## Maintenance
 

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -42,7 +42,11 @@ services:
     image: redis:8-alpine
     restart: unless-stopped
     volumes:
-      - ./data/redis:/data
+      # Named volume (not a ./data bind mount): the redis image's WORKDIR is /data,
+      # so a bind mount there makes every healthcheck/exec fail 'chdir /data' if the
+      # host dir is ever recreated (a known Docker Desktop staleness footgun). The
+      # token blacklist is a cache, so host-side access isn't needed.
+      - redis-data:/data
     networks:
       - inventario-internal
     healthcheck:
@@ -210,3 +214,8 @@ networks:
   inventario-internal:
     driver: bridge
     internal: false  # Allow outbound internet access for the application
+
+# Named volumes. Redis uses one (see the redis service) so its /data WORKDIR is
+# always present in the container regardless of host ./data state.
+volumes:
+  redis-data:

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -17,6 +17,11 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --lc-collate=C --lc-ctype=C"
       # Ensure proper initialization
       PGUSER: ${POSTGRES_USER:-inventario}
+      # Postgres 18+ images default PGDATA to a version-specific subdir and refuse
+      # to start when data is bind-mounted directly at /var/lib/postgresql/data
+      # ("unused mount/volume"). Pin PGDATA to a subdirectory of the mount so the
+      # bind mount keeps working (data lands in ./data/postgres/pgdata).
+      PGDATA: /var/lib/postgresql/data/pgdata
 
     volumes:
       # Persistent PostgreSQL data storage (host mount for easy access)
@@ -120,6 +125,16 @@ services:
       # ADMIN_PASSWORD in .env (see .env.example).
       INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: "${ADMIN_PASSWORD:?set ADMIN_PASSWORD in .env before first run (see .env.example)}"
       INVENTARIO_MIGRATE_DATA_ADMIN_NAME: ${ADMIN_NAME:-System Administrator}
+      # Back-office (platform operator) — auto-provisioned on first run, idempotent.
+      # Authenticates at /backoffice/login, OUTSIDE the tenant model.
+      BACKOFFICE_EMAIL: ${BACKOFFICE_EMAIL:-backoffice@example.com}
+      BACKOFFICE_NAME: ${BACKOFFICE_NAME:-Platform Admin}
+      # Fail closed like ADMIN_PASSWORD: setup.sh writes a real value; the manual
+      # path must set BACKOFFICE_PASSWORD in .env (see .env.example).
+      BACKOFFICE_PASSWORD: "${BACKOFFICE_PASSWORD:?set BACKOFFICE_PASSWORD in .env before first run (see .env.example)}"
+      # Demo default: password-only login. For production set true and enrol TOTP
+      # via 'inventario backoffice mfa setup' before the operator can sign in.
+      BACKOFFICE_MFA_ENFORCED: ${BACKOFFICE_MFA_ENFORCED:-false}
     volumes:
       # Track initialization state to prevent re-running (host mount for easy access)
       - ./data/init-state:/app/state

--- a/example/scripts/init-data.sh
+++ b/example/scripts/init-data.sh
@@ -1,31 +1,50 @@
 #!/bin/sh
 set -e
 
-if [ ! -f /app/state/data-initialized ]; then
-  echo "=== RUNNING INITIAL DATA SETUP ==="
-  echo "Database DSN: [configured]"
-
-  # Wait for database to be ready with retry mechanism
-  echo "Waiting for database to be ready for initial data setup..."
-  for i in $(seq 1 15); do
-    if inventario db migrate data \
-      --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
-      --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
-      --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
-      --admin-password="$INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD" \
-      --admin-name="$INVENTARIO_MIGRATE_DATA_ADMIN_NAME"; then
-      mkdir -p /app/state
-      touch /app/state/data-initialized
-      echo "Initial data setup completed successfully"
-      exit 0
-    else
-      echo "Attempt $i failed, retrying in 2 seconds..."
-      sleep 2
-    fi
-  done
-
-  echo "Failed to setup initial data after 15 attempts"
-  exit 1
-else
+if [ -f /app/state/data-initialized ]; then
   echo "Initial data already setup, skipping..."
+  exit 0
 fi
+
+echo "=== RUNNING INITIAL DATA SETUP ==="
+echo "Database DSN: [configured]"
+
+# Run a command with a short retry loop (the database may still be warming up).
+run_with_retry() {
+  desc="$1"
+  shift
+  for i in $(seq 1 15); do
+    if "$@"; then
+      echo "$desc: completed"
+      return 0
+    fi
+    echo "$desc: attempt $i failed, retrying in 2 seconds..."
+    sleep 2
+  done
+  echo "$desc: failed after 15 attempts"
+  return 1
+}
+
+# 1) Seed the default tenant + tenant admin user (the regular app login).
+run_with_retry "initial data (tenant + admin)" \
+  inventario db migrate data \
+    --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
+    --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
+    --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
+    --admin-password="$INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD" \
+    --admin-name="$INVENTARIO_MIGRATE_DATA_ADMIN_NAME"
+
+# 2) Provision the first back-office (platform-operator) user. Back-office users
+#    live OUTSIDE the tenant model and authenticate at /backoffice/login.
+#    --ensure makes this idempotent: it is a no-op once any operator exists.
+run_with_retry "back-office operator" \
+  inventario backoffice bootstrap \
+    --email="$BACKOFFICE_EMAIL" \
+    --name="$BACKOFFICE_NAME" \
+    --password="$BACKOFFICE_PASSWORD" \
+    --mfa-enforced="$BACKOFFICE_MFA_ENFORCED" \
+    --ensure
+
+mkdir -p /app/state
+touch /app/state/data-initialized
+echo "Initial data setup completed successfully"

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -630,7 +630,8 @@ compose_supports_wait() {
 # aborts the whole `up`. Pre-own the inventario-owned mounts to the image user.
 # ---------------------------------------------------------------------------
 prepare_data_dirs() {
-  mkdir -p data/postgres data/redis data/init-state data/uploads
+  # redis uses a named volume (see docker-compose.yaml), so no ./data/redis here.
+  mkdir -p data/postgres data/init-state data/uploads
   if [ "$(uname -s)" = "Linux" ]; then
     if ! chown -R 1001:1001 data/init-state data/uploads 2>/dev/null; then
       warn "Could not chown data/init-state, data/uploads to uid 1001. If 'up' fails with"
@@ -752,7 +753,7 @@ print_access_info() {
     fi
     printf '\n%s\n' "    Follow logs:  ${compose_str} logs -f inventario" >&2
     info "Stop:         ${compose_str} down"
-    info "Stop + wipe:  ${compose_str} down && rm -rf ./data"
+    info "Stop + wipe:  ${compose_str} down -v && rm -rf ./data   (-v also clears the redis volume)"
   else
     printf '\n%s\n' "${C_GREEN}${C_BOLD}Preparation complete.${C_RESET} To start the stack, run:" >&2
     if [ "$MODE" = "image" ]; then

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -73,9 +73,18 @@ TENANT_NAME="Default Organization"
 TENANT_SLUG="default"
 EPHEMERAL_SECRETS=0
 START=""                      # "" => prompt ; 1 => start ; 0 => no-start
+SEED=""                       # "" => prompt ; 1 => seed ; 0 => no-seed
+SEEDED=0                      # 1 once demo data has been seeded this run
 ASSUME_YES=0
 FORCE=0
 ENV_FLAGS_SUPPLIED=0          # 1 if any .env-only value flag was passed
+
+# Back-office (platform operator) — auto-provisioned by init-data on first run.
+BACKOFFICE_EMAIL="backoffice@example.com"
+BACKOFFICE_NAME="Platform Admin"
+BACKOFFICE_PASSWORD=""        # empty => generate
+BACKOFFICE_PASSWORD_GENERATED=0
+BACKOFFICE_MFA_ENFORCED="false"   # demo default: password-only login
 
 usage() {
   cat >&2 <<EOF
@@ -101,12 +110,19 @@ ${C_BOLD}Options:${C_RESET}
                             password is generated and printed once at the end.
   --tenant-name <name>      Default organization name. Default: "Default Organization".
   --tenant-slug <slug>      Default tenant slug. Default: default.
+  --backoffice-email <e>    Back-office (platform operator) email. Default: backoffice@example.com.
+  --backoffice-password <p> Back-office password. If omitted, a strong random one
+                            is generated and printed once at the end.
   --ephemeral-secrets       Do NOT persist JWT/file-signing secrets; leave them
                             empty so the app auto-generates throwaway keys per
                             restart (fine for local testing, not production).
   --start                   Bring the stack up after preparing.
   --no-start                Do not start the stack (just prepare files).
                             Default: prompt; with -y defaults to --no-start.
+  --seed                    After start, seed the database with demo data so the
+                            app is not empty. Enables the seed endpoint only for
+                            the seeding step, then disables it again. Implies --start.
+  --no-seed                 Do not seed. Default: prompt when starting; no with -y.
   -y, --yes                 Non-interactive; accept all defaults.
   --force                   Overwrite existing .env/override, backing up the old
                             file to <file>.bak.<n> first.
@@ -155,12 +171,22 @@ parse_args() {
       --tenant-slug)
         if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
         TENANT_SLUG="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --backoffice-email)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        BACKOFFICE_EMAIL="$val"; ENV_FLAGS_SUPPLIED=1 ;;
+      --backoffice-password)
+        if [ "$has_val" -eq 0 ]; then [ "$#" -ge 2 ] || die "Option '$key' requires a value."; val="$2"; shift; fi
+        BACKOFFICE_PASSWORD="$val"; ENV_FLAGS_SUPPLIED=1 ;;
       --ephemeral-secrets)
         EPHEMERAL_SECRETS=1 ;;
       --start)
         START=1 ;;
       --no-start)
         START=0 ;;
+      --seed)
+        SEED=1 ;;
+      --no-seed)
+        SEED=0 ;;
       -y|--yes)
         ASSUME_YES=1 ;;
       --force)
@@ -368,10 +394,14 @@ write_env() {
   # User-supplied values may contain '$'; escape them so Compose does not
   # interpolate them away. Generated secrets/passwords are alnum/hex (no-op).
   local env_tenant_name env_tenant_slug env_admin_email env_admin_password
+  local env_bo_email env_bo_name env_bo_password
   env_tenant_name="$(esc_env "$TENANT_NAME")"
   env_tenant_slug="$(esc_env "$TENANT_SLUG")"
   env_admin_email="$(esc_env "$ADMIN_EMAIL")"
   env_admin_password="$(esc_env "$ADMIN_PASSWORD")"
+  env_bo_email="$(esc_env "$BACKOFFICE_EMAIL")"
+  env_bo_name="$(esc_env "$BACKOFFICE_NAME")"
+  env_bo_password="$(esc_env "$BACKOFFICE_PASSWORD")"
 
   # Default DB credentials match .env.example (fine for a single-host example).
   # Subshell with a tight umask so the secrets file is 0600 from the first byte
@@ -422,6 +452,12 @@ DEFAULT_TENANT_SLUG=${env_tenant_slug}
 ADMIN_EMAIL=${env_admin_email}
 ADMIN_PASSWORD=${env_admin_password}
 ADMIN_NAME=System Administrator
+
+# Back-office (platform operator) — auto-provisioned on first run (/backoffice/login).
+BACKOFFICE_EMAIL=${env_bo_email}
+BACKOFFICE_NAME=${env_bo_name}
+BACKOFFICE_PASSWORD=${env_bo_password}
+BACKOFFICE_MFA_ENFORCED=${BACKOFFICE_MFA_ENFORCED}
 EOF
   )
 
@@ -507,6 +543,19 @@ services:
 EOF
   fi
 
+  # Opt-in DB seeding (setup.sh --seed): enable the public, unauthenticated,
+  # RLS-bypassing seed endpoint + bundled blob fixtures on the main service.
+  # These lines append under the inventario service's environment: block (the
+  # last block in both modes). setup.sh enables them ONLY to seed, then
+  # regenerates this override WITHOUT them and recreates the container, so the
+  # endpoint is OFF in the steady state.
+  if [ "${SEED:-0}" = "1" ]; then
+    {
+      printf '      %s\n' 'INVENTARIO_RUN_ENABLE_SEED_ENDPOINT: "true"'
+      printf '      %s\n' 'INVENTARIO_SEED_ALLOW_BLOB_UPLOADS: "true"'
+    } >> "$tmp"
+  fi
+
   if [ -f "$OVERRIDE_FILE" ] && cmp -s "$tmp" "$OVERRIDE_FILE"; then
     rm -f "$tmp"
     success "docker-compose.override.yaml already current (${MODE} mode) — left unchanged."
@@ -566,6 +615,34 @@ prepare_data_dirs() {
 }
 
 # ---------------------------------------------------------------------------
+# Seed demo data via the (transiently enabled) seed endpoint. The caller is
+# responsible for disabling the endpoint again afterwards.
+# ---------------------------------------------------------------------------
+seed_database() {
+  section "Seed demo data"
+  local port email slug body
+  port="$(unesc_env "$(read_env_value INVENTARIO_HOST_PORT)")"; port="${port:-$PORT}"
+  email="$(unesc_env "$(read_env_value ADMIN_EMAIL)")"; email="${email:-$ADMIN_EMAIL}"
+  slug="$(unesc_env "$(read_env_value DEFAULT_TENANT_SLUG)")"; slug="${slug:-$TENANT_SLUG}"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    warn "curl not found on host; skipping seeding. Seed manually: POST http://localhost:${port}/api/v1/seed"
+    return 0
+  fi
+
+  body="$(printf '{"user_email":"%s","tenant_slug":"%s"}' "$email" "$slug")"
+  log "Seeding demo data into tenant '${slug}' (user ${email}) ..."
+  if curl -fsS --max-time 120 -X POST "http://localhost:${port}/api/v1/seed" \
+       -H 'Content-Type: application/json' -d "$body" >/dev/null 2>&1; then
+    SEEDED=1
+    success "Database seeded with demo data."
+  else
+    warn "Seed request failed. The stack is up; retry with:"
+    warn "  curl -X POST http://localhost:${port}/api/v1/seed -H 'Content-Type: application/json' -d '${body}'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Start the stack.
 # ---------------------------------------------------------------------------
 start_stack() {
@@ -587,6 +664,16 @@ start_stack() {
     "${COMPOSE[@]}" up -d --build "${wait_flag[@]+"${wait_flag[@]}"}"
   fi
   success "Stack is up."
+
+  # Seed demo data, then disable the seed endpoint again for a secure steady state.
+  if [ "${SEED:-0}" = "1" ]; then
+    seed_database
+    log "Disabling the seed endpoint ..."
+    SEED=0
+    write_override
+    "${COMPOSE[@]}" up -d --no-build "${wait_flag[@]+"${wait_flag[@]}"}"
+    success "Seed endpoint disabled."
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -611,14 +698,26 @@ print_access_info() {
   else
     info "Admin password: (as supplied via --admin-password)"
   fi
+  info "Backoffice:  ${BACKOFFICE_EMAIL}  (sign in at /backoffice/login)"
+  if [ "$BACKOFFICE_PASSWORD_GENERATED" -eq 1 ]; then
+    printf '%s\n' "    Backoffice password (generated, shown once): ${C_BOLD}${BACKOFFICE_PASSWORD}${C_RESET}" >&2
+  elif [ "$ENV_REUSED" -eq 1 ]; then
+    info "Backoffice password: (unchanged — grep '^BACKOFFICE_PASSWORD=' \"$ENV_FILE\")"
+  else
+    info "Backoffice password: (as supplied via --backoffice-password)"
+  fi
   info ".env:        $ENV_FILE"
   info "override:    $OVERRIDE_FILE"
 
   if [ "$started" -eq 1 ]; then
     printf '\n%s\n' "${C_GREEN}${C_BOLD}Inventario is starting.${C_RESET}" >&2
-    info "Web UI:   http://localhost:${PORT}"
-    info "Swagger:  http://localhost:${PORT}/swagger  (if enabled by the app build)"
+    info "Web UI:    http://localhost:${PORT}"
+    info "Backoffice: http://localhost:${PORT}/backoffice/login"
+    info "Swagger:   http://localhost:${PORT}/swagger  (if enabled by the app build)"
     info "Readiness: http://localhost:${PORT}/readyz"
+    if [ "$SEEDED" -eq 1 ]; then
+      info "Demo data: seeded (the app is pre-populated)."
+    fi
     printf '\n%s\n' "    Follow logs:  ${compose_str} logs -f inventario" >&2
     info "Stop:         ${compose_str} down"
     info "Stop + wipe:  ${compose_str} down && rm -rf ./data"
@@ -648,6 +747,8 @@ main() {
   reject_ctrl "$ADMIN_EMAIL" "--admin-email"
   reject_ctrl "$TENANT_NAME" "--tenant-name"
   reject_ctrl "$TENANT_SLUG" "--tenant-slug"
+  reject_ctrl "$BACKOFFICE_EMAIL" "--backoffice-email"
+  reject_ctrl "$BACKOFFICE_PASSWORD" "--backoffice-password"
 
   [ -f "$COMPOSE_FILE" ] || die "docker-compose.yaml not found in $SCRIPT_DIR — run this from the example directory."
 
@@ -721,12 +822,18 @@ main() {
     will_write_env=1
   fi
   if [ "$will_write_env" -eq 1 ]; then
+    # Fail fast on a weak supplied password instead of aborting later in init-data.
     if [ -z "$ADMIN_PASSWORD" ]; then
       ADMIN_PASSWORD="$(gen_password)"
       ADMIN_PASSWORD_GENERATED=1
     elif [ "${#ADMIN_PASSWORD}" -lt 8 ] || ! password_meets_policy "$ADMIN_PASSWORD"; then
-      # Fail fast on a weak --admin-password instead of aborting later in init-data.
       die "--admin-password must be >= 8 chars with an upper-case letter, a lower-case letter, and a digit."
+    fi
+    if [ -z "$BACKOFFICE_PASSWORD" ]; then
+      BACKOFFICE_PASSWORD="$(gen_password)"
+      BACKOFFICE_PASSWORD_GENERATED=1
+    elif [ "${#BACKOFFICE_PASSWORD}" -lt 8 ] || ! password_meets_policy "$BACKOFFICE_PASSWORD"; then
+      die "--backoffice-password must be >= 8 chars with an upper-case letter, a lower-case letter, and a digit."
     fi
   fi
 
@@ -745,11 +852,11 @@ main() {
     fi
   fi
 
-  write_override
-  validate_config
-  prepare_data_dirs
-
-  # Resolve start decision.
+  # Resolve start + seed decisions BEFORE writing the override (seeding adds env
+  # to it). --seed implies starting unless --no-start was explicit.
+  if [ "${SEED:-}" = "1" ] && [ -z "$START" ]; then
+    START=1
+  fi
   if [ -z "$START" ]; then
     if [ "$ASSUME_YES" -eq 1 ]; then
       START=0
@@ -759,6 +866,23 @@ main() {
       START=0
     fi
   fi
+  # Seeding only makes sense once the app is running.
+  if [ -z "$SEED" ]; then
+    if [ "$START" -eq 1 ] && [ "$ASSUME_YES" -eq 0 ] && \
+       prompt_yes_no "Seed the database with demo data (so it is not empty)?" "n"; then
+      SEED=1
+    else
+      SEED=0
+    fi
+  fi
+  if [ "$SEED" -eq 1 ] && [ "$START" -ne 1 ]; then
+    warn "--seed requires starting the stack; skipping seeding (start it, then re-run with --seed)."
+    SEED=0
+  fi
+
+  write_override
+  validate_config
+  prepare_data_dirs
 
   if [ "$START" -eq 1 ]; then
     start_stack

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -35,9 +35,17 @@ IMAGE_REPO="ghcr.io/denisvmedia/inventario"
 
 # Track temp files for guaranteed cleanup on any exit (set -u safe on bash 3.2).
 TMP_FILES=()
+# Set to 1 while the (unauthenticated) seed endpoint is enabled on the running
+# stack, so an interrupted/failed run never silently leaves it live.
+SEED_ENDPOINT_LIVE=0
 cleanup() {
   if [ "${#TMP_FILES[@]}" -gt 0 ]; then
     rm -f "${TMP_FILES[@]+"${TMP_FILES[@]}"}"
+  fi
+  if [ "${SEED_ENDPOINT_LIVE:-0}" = "1" ]; then
+    err "WARNING: the seed endpoint may still be ENABLED on the running stack"
+    err "(POST /api/v1/seed is unauthenticated + RLS-bypassing). Disable it with:"
+    err "  ${COMPOSE[*]:-docker compose} up -d --no-build   (after re-running setup.sh, which regenerates a clean override)"
   fi
 }
 trap cleanup EXIT
@@ -368,6 +376,23 @@ write_env() {
   if [ -f "$ENV_FILE" ] && [ "$FORCE" -eq 0 ]; then
     ENV_REUSED=1
     success "Existing .env found — reusing it untouched (use --force to regenerate)."
+    # Self-heal: a .env from before this version lacks BACKOFFICE_PASSWORD, which
+    # the base compose now requires (fail-closed). Append the back-office block so
+    # `git pull && ./setup.sh` on an existing deployment doesn't fail at validate.
+    if [ -z "$(read_env_value BACKOFFICE_PASSWORD)" ]; then
+      local bo_pw; bo_pw="$(gen_password)"
+      {
+        printf '\n# Back-office (platform operator) — added by a setup.sh upgrade.\n'
+        printf 'BACKOFFICE_EMAIL=%s\n' "$(esc_env "$BACKOFFICE_EMAIL")"
+        printf 'BACKOFFICE_NAME=%s\n' "$(esc_env "$BACKOFFICE_NAME")"
+        printf 'BACKOFFICE_PASSWORD=%s\n' "$(esc_env "$bo_pw")"
+        printf 'BACKOFFICE_MFA_ENFORCED=%s\n' "$BACKOFFICE_MFA_ENFORCED"
+      } >> "$ENV_FILE"
+      BACKOFFICE_PASSWORD="$bo_pw"
+      BACKOFFICE_PASSWORD_GENERATED=1
+      warn "Existing .env lacked BACKOFFICE_PASSWORD — appended back-office settings (generated password)."
+      warn "The operator is auto-created only on first init; on an already-initialized stack, see README 'Upgrading an existing deployment'."
+    fi
     info "Secrets, ports and credentials already in .env are preserved."
     return 0
   fi
@@ -647,9 +672,11 @@ seed_database() {
 # ---------------------------------------------------------------------------
 start_stack() {
   section "Start"
+  # The seed endpoint is live from the moment the seed-enabled override comes up.
+  if [ "${SEED:-0}" = "1" ]; then SEED_ENDPOINT_LIVE=1; fi
   local wait_flag=()
   if compose_supports_wait; then
-    wait_flag=(--wait)
+    wait_flag=(--wait --wait-timeout 180)
   fi
 
   if [ "$MODE" = "image" ]; then
@@ -671,7 +698,12 @@ start_stack() {
     log "Disabling the seed endpoint ..."
     SEED=0
     write_override
-    "${COMPOSE[@]}" up -d --no-build "${wait_flag[@]+"${wait_flag[@]}"}"
+    if ! "${COMPOSE[@]}" up -d --no-build "${wait_flag[@]+"${wait_flag[@]}"}"; then
+      err "Failed to recreate the app to disable the seed endpoint."
+      err "The override on disk is clean, but the RUNNING container may still expose the unauthenticated POST /api/v1/seed."
+      die "Recover by re-running: ${COMPOSE[*]} up -d --no-build"
+    fi
+    SEED_ENDPOINT_LIVE=0
     success "Seed endpoint disabled."
   fi
 }
@@ -842,11 +874,13 @@ main() {
   # When an existing .env is reused, .env-only flags (port/admin/tenant) are NOT
   # applied. Report the values actually in effect and warn if flags were passed.
   if [ "$ENV_REUSED" -eq 1 ]; then
-    local eff_port eff_email
+    local eff_port eff_email eff_bo_email
     eff_port="$(unesc_env "$(read_env_value INVENTARIO_HOST_PORT)")"
     eff_email="$(unesc_env "$(read_env_value ADMIN_EMAIL)")"
+    eff_bo_email="$(unesc_env "$(read_env_value BACKOFFICE_EMAIL)")"
     [ -n "$eff_port" ] && PORT="$eff_port"
     [ -n "$eff_email" ] && ADMIN_EMAIL="$eff_email"
+    [ -n "$eff_bo_email" ] && BACKOFFICE_EMAIL="$eff_bo_email"
     if [ "$ENV_FLAGS_SUPPLIED" -eq 1 ]; then
       warn "Existing .env reused — --port/--admin-email/--admin-password/--tenant-* were ignored. Re-run with --force to apply them."
     fi


### PR DESCRIPTION
## Why

Trying to actually run the example surfaced four gaps:

1. **The stack wouldn't start.** `postgres:18-alpine` changed its data-dir layout; with data bind-mounted at `/var/lib/postgresql/data` the image now refuses to boot (`"unused mount/volume"`). The earlier reviews only ran `docker compose config`, never `up`, so this slipped through.
2. **No back-office login.** The platform-operator account (`/backoffice/login`) had to be created by hand (`inventario backoffice bootstrap`) — it isn't seeded by `db migrate data`.
3. **Empty app.** Nothing offered to seed demo data, so first login lands in an empty UI.
4. **No CI** exercised the example kit at all.

## What

- **`docker-compose.yaml`** — pin `PGDATA` to a subdirectory of the bind mount (`/var/lib/postgresql/data/pgdata`) so Postgres 18 starts; data lands in `./data/postgres/pgdata`. Wire `BACKOFFICE_*` into `inventario-init-data` with a **fail-closed** `BACKOFFICE_PASSWORD` (mirrors `ADMIN_PASSWORD`).
- **`scripts/init-data.sh`** — after the tenant admin, provision the first **back-office operator** via `backoffice bootstrap --ensure` (idempotent). Auto-created on first run, exactly like the tenant admin.
- **`setup.sh`** — generate + write `BACKOFFICE_*` (new `--backoffice-email` / `--backoffice-password`); add a **`--seed`** prompt/flag that enables the seed endpoint **only** to seed demo data into the default tenant, then disables it again and recreates the app container (secure steady state). `--seed` implies `--start`.
- **`.env.example`** — document the back-office account (MFA off for the demo, fail-closed password).
- **`README.md`** — new **Logins** section (tenant + back-office), seeding docs, env-var table + flag rows, Postgres `pgdata` note.
- **`.github/workflows/example-smoke-test.yml`** — **NEW.** `pull_request`-only, scoped to `example/**` and this workflow file — **no `push`/master trigger** (the kit is a convenience, not a release gate). Lints `setup.sh`, validates both modes' config, brings the stack up in image mode, and smoke-tests tenant login, back-office login, seeding, and that the seed endpoint is disabled again. This PR touches `example/**` + the workflow, so it runs here.

## Two logins (auto-provisioned)

| Login | URL | Email | Password |
|-------|-----|-------|----------|
| Tenant admin | `/` | `admin@example.com` | `ADMIN_PASSWORD` |
| Back-office operator | `/backoffice/login` | `backoffice@example.com` | `BACKOFFICE_PASSWORD` |

Back-office MFA is **off** in the example for convenience; set `BACKOFFICE_MFA_ENFORCED=true` + enrol TOTP for production.

## Verified locally (image mode, `--seed`)

- Fresh `./setup.sh --mode image -y --seed --force`: stack healthy.
- Tenant login → 200; back-office login → 200 (`platform_admin`).
- Seeded: 36 commodities / 3 locations / 10 areas in the default tenant.
- Seed endpoint disabled afterward (`POST /api/v1/seed` → 404); override left clean.
- `bash -n` + `shellcheck` clean; fail-closed `BACKOFFICE_PASSWORD`/`ADMIN_PASSWORD` confirmed; markdownlint 0 errors.

https://claude.ai/code/session_01NMehfFBUzKGTvKF1ZvG7a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Back-office operator login with optional multi-factor authentication (MFA) for platform administrators
  * Opt-in demo data seeding capability integrated into setup workflow
  * Improved setup experience with automatic credential generation and management

* **Documentation**
  * Comprehensive setup instructions updated with back-office credentials configuration
  * Enhanced PostgreSQL data persistence guidance
  * Added seeding workflow documentation and MFA setup guidance for production deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->