### PR TITLE
fix(ci): unbreak PR pipeline — Go 1.26.5 (Trivy CVE-2026-39822), govulncheck v1.6.0, deflake FeedbackDialog test

### DIFF
--- a/.github/workflows/cli-integration-test.yml
+++ b/.github/workflows/cli-integration-test.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
 
     - name: Cache Go modules
       uses: actions/cache@v6

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
       # Install Go
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/frontend-embed-smoke-test.yml
+++ b/.github/workflows/frontend-embed-smoke-test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/go-govulncheck.yml
+++ b/.github/workflows/go-govulncheck.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 
@@ -61,5 +61,5 @@ jobs:
       # fetched fresh at run time, so a pinned binary stays current on data);
       # bump deliberately in its own PR like the golangci-lint pin.
       - name: Run govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
         working-directory: go

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/go-swagger-docs.yml
+++ b/.github/workflows/go-swagger-docs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/go-test-postgres.yml
+++ b/.github/workflows/go-test-postgres.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
           cache: true
           cache-dependency-path: go/go.sum
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   concurrency: 8
-  go: "1.26.4"
+  go: "1.26.5"
 
 linters:
   default: none

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Base Go environment
-FROM golang:1.26.4-alpine AS go-base
+FROM golang:1.26.5-alpine AS go-base
 
 # Install common dependencies
 RUN apk add --no-cache \

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -1,3 +1,3 @@
 module github.com/denisvmedia/inventario/frontend
 
-go 1.26.4
+go 1.26.5

--- a/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/feedback/__tests__/FeedbackDialog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { http as msw, HttpResponse, delay } from "msw"
+import { http as msw, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -154,12 +154,18 @@ describe("<FeedbackDialog />", () => {
     // commodity_scan #1720 contract); the dialog must stay put.
     const navigate = vi.fn()
     setNavigateToMaintenance(navigate)
+    // The response is held on an explicit gate so the in-flight (disabled)
+    // window below lasts until the test releases it — a wall-clock delay
+    // (formerly 30ms) is a race on a loaded runner: waitFor's polling can
+    // miss the whole window and the toBeDisabled assertion flakes.
+    let releaseResponse!: () => void
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve
+    })
     server.use(
       ...baseUserHandlers,
       msw.post(api("/feedback"), async () => {
-        // Small delay so the in-flight (disabled) → settled (enabled)
-        // transition on the submit button is observable below.
-        await delay(30)
+        await responseGate
         // Mirror the real jsonapi.Errors payload the BE emits for the
         // errx sentinel (see apiserver/feedback.go): `status` is a text
         // label, `error` is an errormarshal object, and `code` carries
@@ -193,10 +199,12 @@ describe("<FeedbackDialog />", () => {
     await user.click(submit)
 
     // Drive the full submit cycle so the negative assertion isn't vacuous:
-    // the button disables while the request is in flight, then re-enables
+    // the button disables while the request is in flight (the gate keeps it
+    // in flight, so the disabled state can't be missed), then re-enables
     // once the 503 has been received AND the global bounce decision (in
     // lib/http.ts) has run. Only then is "navigate not called" meaningful.
     await waitFor(() => expect(submit).toBeDisabled())
+    releaseResponse()
     await waitFor(() => expect(submit).not.toBeDisabled())
 
     // The typed product 503 must NOT bounce the shell to /maintenance…

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/denisvmedia/inventario
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	github.com/go-extras/nolintguard/cmd/nolintguard


### PR DESCRIPTION
## Why

Since **2026-07-10 every fresh CI run is red** for reasons unrelated to the change under test — confirmed by auditing all 17 open bot PRs (identical failure signatures across unrelated heads):

1. **Trivy image-scan gate**: Go 1.26.4 stdlib carries **CVE-2026-39822** (HIGH, fixed in 1.26.5). Once Trivy's DB picked it up (2026-07-10), the `docker.yml` scan job fails **every** image build, and E2E / Kind / Helm-Kind cascade-fail waiting on the image.
2. **govulncheck v1.4.0 panic**: `ForEachElement called on type containing *types.TypeParam` (x/tools v0.46.0) on every fresh run since ~2026-07-08, regardless of PR content.
3. **FeedbackDialog typed-503 vitest race**: `waitFor(() => expect(submit).toBeDisabled())` vs a 30 ms msw delay — a loaded runner can miss the whole in-flight window. Observed red on #2181 and #2232 heads while the identical code stayed green on master (root-caused 2026-06-22, per the no-known-flakes rule).

## What

- Bump **all** Go pins 1.26.4 → **1.26.5**: `Dockerfile`, `go/go.mod`, `frontend/go.mod`, `.golangci.yml`, and 10 `setup-go` pins across workflows (grep-verified: zero `1.26.4` left).
- Bump the govulncheck pin `@v1.4.0` → **`@v1.6.0`** in `go-govulncheck.yml` (kept pinned per the existing policy comment).
- Rework the typed-503 test: the msw handler now blocks on an **explicit gate** the test releases only after observing the disabled state — the in-flight window is test-controlled, so the full submit-cycle assertion (disabled → release → enabled → no `/maintenance` bounce) is deterministic. The unused `delay` import is dropped.

## Verified locally

- `go build ./...` ✅ · `golangci-lint run` ✅ **0 issues** (with `go: "1.26.5"`)
- `govulncheck@v1.6.0 ./...` ✅ — **no panic**, 0 reachable vulnerabilities
- FeedbackDialog vitest **5/5 runs green** · `tsc -b` ✅ · eslint ✅ · prettier ✅
- `go1.26.5` toolchain downloads fine (so the `golang:1.26.5-alpine` image exists upstream)

Note: `go vet` reports two `testinggoroutine` findings in `internal/fileblob/drivertest` — **pre-existing** (red on master with 1.26.4 too), not part of the CI gate, left out of scope.

## Impact

Unblocks the 11 bot PRs currently red on the environmental gate (#2230 #2229 #2233 #2228 #2231 #2232 #2225 #2226 #2223 #2224 #2207) and every future PR — including the in-flight #2119 work. After merge they need a rebase/rerun to rebuild their images with 1.26.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the project’s Go toolchain to version 1.26.5 across builds, tests, linting, documentation, Docker images, and releases.
  * Updated the vulnerability-scanning tool to a newer version.

* **Bug Fixes**
  * Improved feedback submission test reliability by eliminating timing-sensitive behavior and verifying in-progress submission states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->