### PR TITLE
fix(services): row-first area/location file cleanup, self-healing retries, full test matrix (#2119)

### DIFF
--- a/go/apiserver/areas_test.go
+++ b/go/apiserver/areas_test.go
@@ -281,7 +281,9 @@ func TestAreaDelete_NonEmptyRejected(t *testing.T) {
 }
 
 // TestAreaDelete_CascadeStrategy covers #2137: DELETE ?strategy=cascade on a
-// non-empty area returns 204 and removes the area together with its commodities.
+// non-empty area returns 204 and removes the area together with its
+// commodities — and (#2119) the files attached to the area itself as well as
+// the files attached to the cascaded commodities (GET file → 404).
 func TestAreaDelete_CascadeStrategy(t *testing.T) {
 	c := qt.New(t)
 
@@ -292,6 +294,29 @@ func TestAreaDelete_CascadeStrategy(t *testing.T) {
 	area := expectedAreas[0]
 	commodityIDs := must.Must(registrySet.AreaRegistry.GetCommodities(context.Background(), area.ID))
 	c.Assert(commodityIDs, qt.Not(qt.HasLen), 0)
+
+	// A seeded file linked to the area's commodity, plus a file attached
+	// directly to the area — both must be removed by the cascade.
+	files := must.Must(registrySet.FileRegistry.List(context.Background()))
+	var commodityFileID string
+	for _, f := range files {
+		if f.LinkedEntityType == "commodity" && f.LinkedEntityID == commodityIDs[0] {
+			commodityFileID = f.ID
+			break
+		}
+	}
+	c.Assert(commodityFileID, qt.Not(qt.Equals), "")
+	areaFile := must.Must(registrySet.FileRegistry.Create(context.Background(), models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: "area-doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
 
 	req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/areas/"+area.ID+"?strategy=cascade", nil)
 	c.Assert(err, qt.IsNil)
@@ -313,11 +338,23 @@ func TestAreaDelete_CascadeStrategy(t *testing.T) {
 		_, err = registrySet.CommodityRegistry.Get(context.Background(), id)
 		c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 	}
+
+	// The area-attached file and the commodity-attached file are gone (#2119).
+	for _, fileID := range []string{areaFile.ID, commodityFileID} {
+		req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+fileID, nil)
+		c.Assert(err, qt.IsNil)
+		addTestUserAuthHeader(req, testUser.ID)
+		rr = httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+	}
 }
 
 // TestAreaDelete_UnlinkStrategy covers #2137: DELETE ?strategy=unlink on a
 // non-empty area returns 204, removes the area, and keeps its commodities — left
 // area-less (AreaID == nil); a GET on a surviving commodity still returns 200.
+// File fate (#2119): the file attached directly to the area is removed
+// (GET → 404) while the surviving commodity's file survives (GET → 200).
 func TestAreaDelete_UnlinkStrategy(t *testing.T) {
 	c := qt.New(t)
 
@@ -328,6 +365,29 @@ func TestAreaDelete_UnlinkStrategy(t *testing.T) {
 	area := expectedAreas[0]
 	commodityIDs := must.Must(registrySet.AreaRegistry.GetCommodities(context.Background(), area.ID))
 	c.Assert(commodityIDs, qt.Not(qt.HasLen), 0)
+
+	// A seeded file linked to a commodity that will SURVIVE the unlink, plus a
+	// file attached directly to the area that must be removed with it.
+	files := must.Must(registrySet.FileRegistry.List(context.Background()))
+	var commodityFileID string
+	for _, f := range files {
+		if f.LinkedEntityType == "commodity" && f.LinkedEntityID == commodityIDs[0] {
+			commodityFileID = f.ID
+			break
+		}
+	}
+	c.Assert(commodityFileID, qt.Not(qt.Equals), "")
+	areaFile := must.Must(registrySet.FileRegistry.Create(context.Background(), models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: "area-doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
 
 	req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/areas/"+area.ID+"?strategy=unlink", nil)
 	c.Assert(err, qt.IsNil)
@@ -356,6 +416,22 @@ func TestAreaDelete_UnlinkStrategy(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	}
+
+	// The area-attached file is gone (#2119)…
+	req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+areaFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+
+	// …while the surviving commodity's file is untouched.
+	req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+commodityFileID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 }
 
 // TestAreaDelete_BogusStrategy covers #2137: an unknown `?strategy=` value is
@@ -495,6 +571,32 @@ func TestAreaDelete_MissingArea(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+// TestAreaDelete_MissingArea_WithStrategy pins that a missing area id returns
+// 404 regardless of the ?strategy= value: the areaCtx middleware resolves the
+// entity before the handler runs, so the service-level idempotency of the
+// cascade/unlink paths (#2137) never turns a missing id into a 204 at the API
+// surface.
+func TestAreaDelete_MissingArea_WithStrategy(t *testing.T) {
+	for _, strategy := range []string{"cascade", "unlink"} {
+		t.Run(strategy, func(t *testing.T) {
+			c := qt.New(t)
+
+			params, testUser, testGroup := newParams()
+
+			req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/areas/missing-id?strategy="+strategy, nil)
+			c.Assert(err, qt.IsNil)
+			addTestUserAuthHeader(req, testUser.ID)
+			rr := httptest.NewRecorder()
+
+			mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+			handler := apiserver.APIServer(params, mockRestoreWorker)
+			handler.ServeHTTP(rr, req)
+
+			c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+		})
+	}
 }
 
 func TestAreaUpdate_WrongIDInRequestBody(t *testing.T) {

--- a/go/apiserver/locations_test.go
+++ b/go/apiserver/locations_test.go
@@ -112,7 +112,10 @@ func TestLocationsDelete_NonEmptyRejected(t *testing.T) {
 
 // TestLocationsDelete_CascadeStrategy covers #2137: DELETE ?strategy=cascade on
 // a non-empty location returns 204 and removes the location, its areas and the
-// commodities under them.
+// commodities under them — and (#2119) the files attached directly to the
+// location, the files attached to its child AREAS (pinning that the cascade
+// delegates through DeleteAreaRecursive rather than bare-row-deleting the
+// areas), and the files attached to the cascaded commodities (GET file → 404).
 func TestLocationsDelete_CascadeStrategy(t *testing.T) {
 	c := qt.New(t)
 
@@ -125,6 +128,41 @@ func TestLocationsDelete_CascadeStrategy(t *testing.T) {
 	c.Assert(areaIDs, qt.Not(qt.HasLen), 0)
 	commodityIDs := must.Must(registrySet.AreaRegistry.GetCommodities(c.Context(), areaIDs[0]))
 	c.Assert(commodityIDs, qt.Not(qt.HasLen), 0)
+
+	// A seeded file linked to the location's commodity, plus a file attached
+	// directly to the location and a file attached to one of its child areas —
+	// all three must be removed by the cascade.
+	files := must.Must(registrySet.FileRegistry.List(c.Context()))
+	var commodityFileID string
+	for _, f := range files {
+		if f.LinkedEntityType == "commodity" && f.LinkedEntityID == commodityIDs[0] {
+			commodityFileID = f.ID
+			break
+		}
+	}
+	c.Assert(commodityFileID, qt.Not(qt.Equals), "")
+	locationFile := must.Must(registrySet.FileRegistry.Create(c.Context(), models.FileEntity{
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loc-doc",
+			OriginalPath: "loc-doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+	areaFile := must.Must(registrySet.FileRegistry.Create(c.Context(), models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   areaIDs[0],
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: "area-doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
 
 	req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/locations/"+location.ID+"?strategy=cascade", nil)
 	c.Assert(err, qt.IsNil)
@@ -148,12 +186,25 @@ func TestLocationsDelete_CascadeStrategy(t *testing.T) {
 		_, err = registrySet.CommodityRegistry.Get(c.Context(), id)
 		c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 	}
+
+	// The location-attached, area-attached and commodity-attached files are
+	// all gone (#2119).
+	for _, fileID := range []string{locationFile.ID, areaFile.ID, commodityFileID} {
+		req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+fileID, nil)
+		c.Assert(err, qt.IsNil)
+		addTestUserAuthHeader(req, testUser.ID)
+		rr = httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+	}
 }
 
 // TestLocationsDelete_UnlinkStrategy covers #2137: DELETE ?strategy=unlink on a
 // non-empty location returns 204, removes the location and its areas, and keeps
 // the commodities — left area-less (AreaID == nil); a GET on a surviving
-// commodity still returns 200.
+// commodity still returns 200. File fate (#2119): the file attached directly
+// to the location is removed (GET → 404) while the surviving commodity's file
+// survives (GET → 200).
 func TestLocationsDelete_UnlinkStrategy(t *testing.T) {
 	c := qt.New(t)
 
@@ -166,6 +217,29 @@ func TestLocationsDelete_UnlinkStrategy(t *testing.T) {
 	c.Assert(areaIDs, qt.Not(qt.HasLen), 0)
 	commodityIDs := must.Must(registrySet.AreaRegistry.GetCommodities(c.Context(), areaIDs[0]))
 	c.Assert(commodityIDs, qt.Not(qt.HasLen), 0)
+
+	// A seeded file linked to a commodity that will SURVIVE the unlink, plus a
+	// file attached directly to the location that must be removed with it.
+	files := must.Must(registrySet.FileRegistry.List(c.Context()))
+	var commodityFileID string
+	for _, f := range files {
+		if f.LinkedEntityType == "commodity" && f.LinkedEntityID == commodityIDs[0] {
+			commodityFileID = f.ID
+			break
+		}
+	}
+	c.Assert(commodityFileID, qt.Not(qt.Equals), "")
+	locationFile := must.Must(registrySet.FileRegistry.Create(c.Context(), models.FileEntity{
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loc-doc",
+			OriginalPath: "loc-doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
 
 	req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/locations/"+location.ID+"?strategy=unlink", nil)
 	c.Assert(err, qt.IsNil)
@@ -198,6 +272,22 @@ func TestLocationsDelete_UnlinkStrategy(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	}
+
+	// The location-attached file is gone (#2119)…
+	req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+locationFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+
+	// …while the surviving commodity's file is untouched.
+	req, err = http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/files/"+commodityFileID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 }
 
 // TestLocationsDelete_BogusStrategy covers #2137: an unknown `?strategy=` value
@@ -224,6 +314,32 @@ func TestLocationsDelete_BogusStrategy(t *testing.T) {
 
 	// The location survives — nothing was removed.
 	c.Assert(must.Must(registrySet.LocationRegistry.Get(c.Context(), location.ID)), qt.IsNotNil)
+}
+
+// TestLocationsDelete_MissingLocation_WithStrategy pins that a missing
+// location id returns 404 regardless of the ?strategy= value: the locationCtx
+// middleware resolves the entity before the handler runs, so the
+// service-level idempotency of the cascade/unlink paths (#2137) never turns a
+// missing id into a 204 at the API surface.
+func TestLocationsDelete_MissingLocation_WithStrategy(t *testing.T) {
+	for _, strategy := range []string{"cascade", "unlink"} {
+		t.Run(strategy, func(t *testing.T) {
+			c := qt.New(t)
+
+			params, testUser, testGroup := newParams()
+
+			req, err := http.NewRequest("DELETE", "/api/v1/g/"+testGroup.Slug+"/locations/missing-id?strategy="+strategy, nil)
+			c.Assert(err, qt.IsNil)
+			addTestUserAuthHeader(req, testUser.ID)
+			rr := httptest.NewRecorder()
+
+			mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+			handler := apiserver.APIServer(params, mockRestoreWorker)
+			handler.ServeHTTP(rr, req)
+
+			c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+		})
+	}
 }
 
 func TestLocationsCreate(t *testing.T) {

--- a/go/backup/restore/processor/clear_existing_data_test.go
+++ b/go/backup/restore/processor/clear_existing_data_test.go
@@ -1,0 +1,142 @@
+package processor
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/appctx"
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // Register file driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// clearDataUploadLocation builds a file:// upload-location URL for the given
+// temp dir, matching the OS-specific scheme the rest of the tests use.
+func clearDataUploadLocation(tempDir string) string {
+	if runtime.GOOS == "windows" {
+		return "file:///" + tempDir + "?create_dir=1"
+	}
+	return "file://" + tempDir + "?create_dir=1"
+}
+
+// TestClearExistingData_SweepsAreaAndLocationLinkedFiles pins #2119 for the
+// restore full_replace path: clearExistingData must remove files attached to
+// areas and locations — rows AND physical blobs — via DeleteLocationRecursive
+// plus the second all-files sweep, while export-linked files are preserved
+// (the sweep explicitly skips linked_entity_type='export'). A regression that
+// re-introduces a LinkedEntityType skip in either pass would leave restore
+// full_replace orphaning area/location attachments again.
+func TestClearExistingData_SweepsAreaAndLocationLinkedFiles(t *testing.T) {
+	c := qt.New(t)
+
+	tempDir := c.TempDir()
+	uploadLocation := clearDataUploadLocation(tempDir)
+
+	factorySet := memory.NewFactorySet()
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "test-user-id"},
+			TenantID: "test-tenant-id",
+		},
+		Email: "test@example.com",
+		Name:  "Test User",
+	}
+	user := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+	ctx := appctx.WithUser(context.Background(), user)
+	registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
+	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
+
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+
+	// Files attached to the location and the area (rows + blobs) — must be
+	// swept by full_replace.
+	locationBlobKey := "loc-doc.pdf"
+	c.Assert(b.WriteAll(ctx, locationBlobKey, []byte("loc pdf"), nil), qt.IsNil)
+	locationFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loc-doc",
+			OriginalPath: locationBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	areaBlobKey := "area-doc.pdf"
+	c.Assert(b.WriteAll(ctx, areaBlobKey, []byte("area pdf"), nil), qt.IsNil)
+	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: areaBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	// A standalone file (no linked entity) — the second sweep must take it.
+	standaloneBlobKey := "standalone.pdf"
+	c.Assert(b.WriteAll(ctx, standaloneBlobKey, []byte("standalone pdf"), nil), qt.IsNil)
+	standaloneFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		File: &models.File{
+			Path:         "standalone",
+			OriginalPath: standaloneBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	// An export-linked file — must SURVIVE (backups are not user inventory).
+	exportBlobKey := "export.xml"
+	c.Assert(b.WriteAll(ctx, exportBlobKey, []byte("<export/>"), nil), qt.IsNil)
+	exportFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "export",
+		LinkedEntityID:   "test-export-id",
+		LinkedEntityMeta: "xml-1.0",
+		File: &models.File{
+			Path:         "export",
+			OriginalPath: exportBlobKey,
+			Ext:          ".xml",
+			MIMEType:     "application/xml",
+		},
+	}))
+
+	entityService := services.NewEntityService(factorySet, uploadLocation)
+	proc := NewRestoreOperationProcessor("test-restore-op", factorySet, entityService, uploadLocation, nil)
+
+	c.Assert(proc.clearExistingData(ctx), qt.IsNil)
+
+	// The location and area rows are gone.
+	_, err := registrySet.LocationRegistry.Get(ctx, location.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	_, err = registrySet.AreaRegistry.Get(ctx, area.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// The location-, area-linked and standalone files are gone — rows and blobs.
+	for _, fileID := range []string{locationFile.ID, areaFile.ID, standaloneFile.ID} {
+		_, err = registrySet.FileRegistry.Get(ctx, fileID)
+		c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	}
+	for _, key := range []string{locationBlobKey, areaBlobKey, standaloneBlobKey} {
+		c.Assert(must.Must(b.Exists(ctx, key)), qt.IsFalse,
+			qt.Commentf("blob %s must be swept by full_replace", key))
+	}
+
+	// The export-linked file survives — row and blob.
+	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, exportFile.ID)), qt.IsNotNil)
+	c.Assert(must.Must(b.Exists(ctx, exportBlobKey)), qt.IsTrue)
+}

--- a/go/registry/postgres/areas.go
+++ b/go/registry/postgres/areas.go
@@ -211,6 +211,20 @@ func (r *AreaRegistry) Update(ctx context.Context, area models.Area) (*models.Ar
 	return &area, nil
 }
 
+// Delete removes ONLY the area row (after the in-tx empty-check below rejects
+// an area that still holds commodities with ErrCannotDelete). The files LINKED
+// to the area (linked_entity_type='area') are NOT cascaded — the link is
+// polymorphic, there is no FK — and their physical blobs are not touched here.
+//
+// INVARIANT (#2119, mirroring the #2121 commodity note): user-initiated area
+// deletes MUST go through services.EntityService (DeleteArea /
+// DeleteAreaRecursive / UnlinkAndDeleteArea), which drop this row and then
+// remove each linked file (row + best-effort blob) via
+// FileService.DeleteLinkedFiles. Calling this bare row delete directly leaves
+// every area-linked file row and blob orphaned. The only legitimate direct
+// callers are tests; the group/tenant purgers never call this method — they
+// bypass it entirely with raw `DELETE FROM <table>` sweeps that also wipe the
+// (tenant, group)'s files table.
 func (r *AreaRegistry) Delete(ctx context.Context, id string) error {
 	reg := r.newSQLRegistry()
 	err := reg.Delete(ctx, id, func(ctx context.Context, tx *sqlx.Tx) error {

--- a/go/registry/postgres/files_linked_entity_test.go
+++ b/go/registry/postgres/files_linked_entity_test.go
@@ -1,0 +1,123 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestFileRegistry_Postgres_ListByLinkedEntity_AreaAndLocation exercises the
+// ListByLinkedEntity SQL path — the query the #2119 fix
+// (EntityService → FileService.DeleteLinkedFiles) depends on — for the 'area'
+// and 'location' link types against a real PostgreSQL schema. The query
+// itself carries no tenant filter (RLS supplies it), so the cross-group
+// isolation subtest is the load-bearing assertion: a user from another
+// tenant/group must see nothing for the same linked-entity id.
+func TestFileRegistry_Postgres_ListByLinkedEntity_AreaAndLocation(t *testing.T) {
+	c := qt.New(t)
+
+	set, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	user := getTestUser(c, set)
+	ctx := appctx.WithUser(c.Context(), user)
+
+	mk := func(name, linkedType, linkedID string) models.FileEntity {
+		return models.FileEntity{
+			Title:            name,
+			Type:             models.FileTypeDocument,
+			Category:         models.FileCategoryDocuments,
+			LinkedEntityType: linkedType,
+			LinkedEntityID:   linkedID,
+			LinkedEntityMeta: "images",
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ".pdf",
+				Ext:          ".pdf",
+				MIMEType:     "application/pdf",
+			},
+		}
+	}
+
+	// The linked-entity link is polymorphic (no FK), so plain ids suffice —
+	// no real area/location rows are required for the query under test.
+	seed := []models.FileEntity{
+		mk("area-doc-1", "area", "area-1"),
+		mk("area-doc-2", "area", "area-1"),
+		mk("loc-doc-1", "location", "loc-1"),
+		mk("com-doc-1", "commodity", "com-1"),
+	}
+	for _, fe := range seed {
+		fe.TenantID = user.TenantID
+		fe.CreatedByUserID = user.ID
+		_, err := set.FileRegistry.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	t.Run("lists files linked to an area", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := set.FileRegistry.ListByLinkedEntity(ctx, "area", "area-1")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+		for _, f := range got {
+			c.Assert(f.LinkedEntityType, qt.Equals, "area")
+			c.Assert(f.LinkedEntityID, qt.Equals, "area-1")
+		}
+	})
+
+	t.Run("lists files linked to a location", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := set.FileRegistry.ListByLinkedEntity(ctx, "location", "loc-1")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].LinkedEntityType, qt.Equals, "location")
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "loc-1")
+	})
+
+	t.Run("empty slice for an entity with no files", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := set.FileRegistry.ListByLinkedEntity(ctx, "area", "no-such-area")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("type mismatch yields nothing", func(t *testing.T) {
+		c := qt.New(t)
+		// Same id, wrong link type — the WHERE clause is on the pair.
+		got, err := set.FileRegistry.ListByLinkedEntity(ctx, "location", "area-1")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("RLS isolates another tenant and group", func(t *testing.T) {
+		c := qt.New(t)
+
+		dsn := skipIfNoPostgreSQL(t)
+		pool, err := getOrCreatePool(dsn)
+		c.Assert(err, qt.IsNil)
+		dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+		fs := postgres.NewFactorySet(dbx)
+
+		bgCtx := context.Background()
+		tenantB := mustCreateTenant(c, bgCtx, fs, "tenant-b-files")
+		userB := mustCreateUser(c, bgCtx, fs, tenantB, "user-b@files.example")
+		groupB := mustCreateActiveGroup(c, bgCtx, fs, tenantB, userB.ID)
+
+		setB := postgres.NewRegistrySetWithUserAndGroupID(dbx, userB.ID, tenantB, groupB)
+		ctxB := appctx.WithUser(bgCtx, userB)
+
+		// The same (type, id) pair that has two rows in group A yields NOTHING
+		// for a user scoped to another tenant/group.
+		got, err := setB.FileRegistry.ListByLinkedEntity(ctxB, "area", "area-1")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0,
+			qt.Commentf("RLS must hide group A's area-linked files from tenant/group B"))
+	})
+}

--- a/go/registry/postgres/group_purger_test.go
+++ b/go/registry/postgres/group_purger_test.go
@@ -318,10 +318,55 @@ func TestGroupPurger_Postgres_PurgesAllGroupDependents(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
+	// Files linked to the area and its location (#2119). The polymorphic link
+	// carries no FK, so nothing forces these rows out before the areas /
+	// locations DELETEs — the group purge (which sweeps the whole files table
+	// for the group) is the backstop for any orphaned area/location
+	// attachment, and these fixtures pin that it actually reaches both types.
+	areaRow, err := set.AreaRegistry.Get(ctx, areaID)
+	c.Assert(err, qt.IsNil)
+	areaLinkedFile, err := set.FileRegistry.Create(ctx, models.FileEntity{
+		Title:            "area-attachment",
+		Type:             models.FileTypeDocument,
+		Category:         models.FileCategoryDocuments,
+		LinkedEntityType: "area",
+		LinkedEntityID:   areaID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-attachment",
+			OriginalPath: "area-attachment.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	locationLinkedFile, err := set.FileRegistry.Create(ctx, models.FileEntity{
+		Title:            "location-attachment",
+		Type:             models.FileTypeDocument,
+		Category:         models.FileCategoryDocuments,
+		LinkedEntityType: "location",
+		LinkedEntityID:   areaRow.LocationID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "location-attachment",
+			OriginalPath: "location-attachment.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
 	// -- purge, then prove the group row can finally be removed -------------
 
 	err = fs.GroupPurger.PurgeGroupDependents(context.Background(), tenantID, groupID)
 	c.Assert(err, qt.IsNil)
+
+	// The area- and location-linked file rows (#2119) were purged with the
+	// rest of the group's files.
+	_, err = set.FileRegistry.Get(ctx, areaLinkedFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	_, err = set.FileRegistry.Get(ctx, locationLinkedFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 
 	// The final location_groups DELETE is what was blocked before the fix:
 	// any orphaned dependent (loan/tag/currency/thumbnail chain) would trip a

--- a/go/registry/postgres/locations.go
+++ b/go/registry/postgres/locations.go
@@ -187,6 +187,21 @@ func (r *LocationRegistry) Update(ctx context.Context, location models.Location)
 	return &location, nil
 }
 
+// Delete removes ONLY the location row (after the in-tx empty-check below
+// rejects a location that still holds areas with ErrCannotDelete). The files
+// LINKED to the location (linked_entity_type='location') are NOT cascaded —
+// the link is polymorphic, there is no FK — and their physical blobs are not
+// touched here.
+//
+// INVARIANT (#2119, mirroring the #2121 commodity note): user-initiated
+// location deletes MUST go through services.EntityService (DeleteLocation /
+// DeleteLocationRecursive / UnlinkAndDeleteLocation), which drop this row and
+// then remove each linked file (row + best-effort blob) via
+// FileService.DeleteLinkedFiles. Calling this bare row delete directly leaves
+// every location-linked file row and blob orphaned. The only legitimate direct
+// callers are tests; the group/tenant purgers never call this method — they
+// bypass it entirely with raw `DELETE FROM <table>` sweeps that also wipe the
+// (tenant, group)'s files table.
 func (r *LocationRegistry) Delete(ctx context.Context, id string) error {
 	reg := r.newSQLRegistry()
 	err := reg.Delete(ctx, id, func(ctx context.Context, tx *sqlx.Tx) error {

--- a/go/services/entity_service.go
+++ b/go/services/entity_service.go
@@ -77,6 +77,8 @@ func (s *EntityService) DeleteCommodityRecursive(ctx context.Context, id string)
 }
 
 // DeleteAreaRecursive deletes an area and all its commodities recursively
+//
+//nolint:dupl // deliberately mirrors DeleteLocationRecursive one level up the hierarchy; extracting a generic helper would obscure the per-entity delete contracts documented inline
 func (s *EntityService) DeleteAreaRecursive(ctx context.Context, id string) error {
 	areaReg, err := s.factorySet.AreaRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
@@ -87,7 +89,13 @@ func (s *EntityService) DeleteAreaRecursive(ctx context.Context, id string) erro
 	_, err = areaReg.Get(ctx, id)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			// Area is already deleted, nothing to do
+			// Area is already deleted. Still sweep files linked to it so a
+			// retry self-heals after a crash (or transient error) between the
+			// row delete below and its file cleanup: any file still linked to
+			// a nonexistent area id is garbage by definition. Normally a no-op.
+			if err := s.fileService.DeleteLinkedFiles(ctx, "area", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
+				return errxtrace.Wrap("failed to delete files of already-deleted area", err, errx.Attrs("areaID", id))
+			}
 			return nil
 		}
 		return errxtrace.Wrap("failed to get area", err)
@@ -109,27 +117,49 @@ func (s *EntityService) DeleteAreaRecursive(ctx context.Context, id string) erro
 		}
 	}
 
-	// Delete files attached directly to the area (#2119) before the area row
-	// is removed, mirroring the commodity path. ErrNotFound is tolerated so a
-	// concurrently-removed file doesn't abort the cascade.
+	// Delete the area row first — a rejected delete (ErrCannotDelete from a
+	// commodity added concurrently after the scan above, or ErrNotFound from a
+	// concurrent delete) must leave the area's files intact, mirroring the
+	// row-first contract of DeleteCommodityRecursive (#2120).
+	if err := areaReg.Delete(ctx, id); err != nil {
+		return errxtrace.Wrap("failed to delete area", err)
+	}
+
+	// The area row is gone; remove the files attached directly to it (#2119).
+	// ListByLinkedEntity still finds them after the row delete — the link is
+	// polymorphic (no FK). ErrNotFound is tolerated so a concurrently-removed
+	// file doesn't abort the cleanup.
 	if err := s.fileService.DeleteLinkedFiles(ctx, "area", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
 		return errxtrace.Wrap("failed to delete area files", err, errx.Attrs("areaID", id))
 	}
 
-	// Finally delete the area itself
-	return areaReg.Delete(ctx, id)
+	return nil
 }
 
 // DeleteLocationRecursive deletes a location and all its areas and commodities recursively
+//
+//nolint:dupl // deliberately mirrors DeleteAreaRecursive one level down the hierarchy; extracting a generic helper would obscure the per-entity delete contracts documented inline
 func (s *EntityService) DeleteLocationRecursive(ctx context.Context, id string) error {
 	locReg, err := s.factorySet.LocationRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to create location registry", err)
 	}
 
-	// Get the location to ensure it exists
+	// Check if location exists first - if it's already deleted, that's fine
+	// (idempotency parity with DeleteAreaRecursive).
 	_, err = locReg.Get(ctx, id)
 	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			// Location is already deleted. Still sweep files linked to it so a
+			// retry self-heals after a crash (or transient error) between the
+			// row delete below and its file cleanup: any file still linked to
+			// a nonexistent location id is garbage by definition. Normally a
+			// no-op.
+			if err := s.fileService.DeleteLinkedFiles(ctx, "location", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
+				return errxtrace.Wrap("failed to delete files of already-deleted location", err, errx.Attrs("locationID", id))
+			}
+			return nil
+		}
 		return errxtrace.Wrap("failed to get location", err)
 	}
 
@@ -149,15 +179,23 @@ func (s *EntityService) DeleteLocationRecursive(ctx context.Context, id string) 
 		}
 	}
 
-	// Delete files attached directly to the location (#2119) before the
-	// location row is removed, mirroring the commodity path. ErrNotFound is
-	// tolerated so a concurrently-removed file doesn't abort the cascade.
+	// Delete the location row first — a rejected delete (ErrCannotDelete from
+	// an area added concurrently after the scan above, or ErrNotFound from a
+	// concurrent delete) must leave the location's files intact, mirroring the
+	// row-first contract of DeleteCommodityRecursive (#2120).
+	if err := locReg.Delete(ctx, id); err != nil {
+		return errxtrace.Wrap("failed to delete location", err)
+	}
+
+	// The location row is gone; remove the files attached directly to it
+	// (#2119). ListByLinkedEntity still finds them after the row delete — the
+	// link is polymorphic (no FK). ErrNotFound is tolerated so a
+	// concurrently-removed file doesn't abort the cleanup.
 	if err := s.fileService.DeleteLinkedFiles(ctx, "location", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
 		return errxtrace.Wrap("failed to delete location files", err, errx.Attrs("locationID", id))
 	}
 
-	// Finally delete the location itself
-	return locReg.Delete(ctx, id)
+	return nil
 }
 
 // DeleteArea deletes an EMPTY area together with the files attached directly to
@@ -224,17 +262,24 @@ func (s *EntityService) DeleteLocation(ctx context.Context, id string) error {
 // so no other field is wiped. Like the recursive path this is NOT a single
 // transaction (matching the codebase's recursive-delete precedent); it is
 // idempotent / re-runnable: a commodity that has already been removed
-// (ErrNotFound) is skipped, and DeleteArea no-ops when the area is already gone.
+// (ErrNotFound) is skipped, an already-gone area is treated as success by the
+// guard below, and an ErrNotFound from the final DeleteArea (concurrent delete
+// after the guard) is tolerated.
 func (s *EntityService) UnlinkAndDeleteArea(ctx context.Context, id string) error {
 	areaReg, err := s.factorySet.AreaRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to create area registry", err)
 	}
 
-	// If the area is already gone there is nothing to unlink — treat as success.
+	// If the area is already gone there is nothing to unlink — treat as
+	// success, after sweeping any files still linked to it so a retry
+	// self-heals an interrupted earlier delete (see DeleteAreaRecursive).
 	_, err = areaReg.Get(ctx, id)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
+			if err := s.fileService.DeleteLinkedFiles(ctx, "area", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
+				return errxtrace.Wrap("failed to delete files of already-deleted area", err, errx.Attrs("areaID", id))
+			}
 			return nil
 		}
 		return errxtrace.Wrap("failed to get area", err)
@@ -271,7 +316,9 @@ func (s *EntityService) UnlinkAndDeleteArea(ctx context.Context, id string) erro
 	}
 
 	// The area is now empty; DeleteArea removes it together with its own files.
-	if err := s.DeleteArea(ctx, id); err != nil {
+	// ErrNotFound is tolerated: a concurrent delete between the guard above and
+	// this call must not fail the (documented) idempotent contract.
+	if err := s.DeleteArea(ctx, id); err != nil && !errors.Is(err, registry.ErrNotFound) {
 		return errxtrace.Wrap("failed to delete unlinked area", err, errx.Attrs("areaID", id))
 	}
 
@@ -290,18 +337,25 @@ func (s *EntityService) UnlinkAndDeleteArea(ctx context.Context, id string) erro
 // commodities too.
 //
 // Like the recursive path this is NOT a single transaction; it is idempotent /
-// re-runnable: an area already removed is skipped by UnlinkAndDeleteArea, and
-// DeleteLocation no-ops when the location is already gone.
+// re-runnable: an area already removed is skipped by UnlinkAndDeleteArea, an
+// already-gone location is treated as success by the guard below, and an
+// ErrNotFound from the final DeleteLocation (concurrent delete after the
+// guard) is tolerated.
 func (s *EntityService) UnlinkAndDeleteLocation(ctx context.Context, id string) error {
 	locReg, err := s.factorySet.LocationRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to create location registry", err)
 	}
 
-	// If the location is already gone there is nothing to unlink — success.
+	// If the location is already gone there is nothing to unlink — success,
+	// after sweeping any files still linked to it so a retry self-heals an
+	// interrupted earlier delete (see DeleteLocationRecursive).
 	_, err = locReg.Get(ctx, id)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
+			if err := s.fileService.DeleteLinkedFiles(ctx, "location", id); err != nil && !errors.Is(err, registry.ErrNotFound) {
+				return errxtrace.Wrap("failed to delete files of already-deleted location", err, errx.Attrs("locationID", id))
+			}
 			return nil
 		}
 		return errxtrace.Wrap("failed to get location", err)
@@ -324,8 +378,10 @@ func (s *EntityService) UnlinkAndDeleteLocation(ctx context.Context, id string) 
 	}
 
 	// The location is now empty; DeleteLocation removes it together with its
-	// own files.
-	if err := s.DeleteLocation(ctx, id); err != nil {
+	// own files. ErrNotFound is tolerated: a concurrent delete between the
+	// guard above and this call must not fail the (documented) idempotent
+	// contract.
+	if err := s.DeleteLocation(ctx, id); err != nil && !errors.Is(err, registry.ErrNotFound) {
 		return errxtrace.Wrap("failed to delete unlinked location", err, errx.Attrs("locationID", id))
 	}
 

--- a/go/services/entity_service_test.go
+++ b/go/services/entity_service_test.go
@@ -749,8 +749,8 @@ func TestDeleteCommodityRecursive_RowFirst(t *testing.T) {
 }
 
 // TestDeleteAreaRecursive_DeletesAttachedFiles asserts #2119: files attached
-// directly to an area (not via a commodity) are removed when the area is
-// recursively deleted.
+// directly to an area (not via a commodity) are removed — DB row AND physical
+// blob — when the area is recursively deleted.
 func TestDeleteAreaRecursive_DeletesAttachedFiles(t *testing.T) {
 	c := qt.New(t)
 
@@ -766,13 +766,19 @@ func TestDeleteAreaRecursive_DeletesAttachedFiles(t *testing.T) {
 	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
 	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
 
+	// Write the physical blob backing the area-attached file.
+	blobKey := "area-doc.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, blobKey, []byte("pdf bytes"), nil), qt.IsNil)
+
 	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
 		LinkedEntityType: "area",
 		LinkedEntityID:   area.ID,
 		LinkedEntityMeta: "images",
 		File: &models.File{
 			Path:         "area-doc",
-			OriginalPath: "area-doc.pdf",
+			OriginalPath: blobKey,
 			Ext:          ".pdf",
 			MIMEType:     "application/pdf",
 		},
@@ -786,11 +792,17 @@ func TestDeleteAreaRecursive_DeletesAttachedFiles(t *testing.T) {
 
 	_, err = registrySet.FileRegistry.Get(ctx, areaFile.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// The physical blob is gone too — not just the row.
+	c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsFalse)
 }
 
 // TestDeleteLocationRecursive_DeletesAttachedFiles asserts #2119: files
-// attached directly to a location are removed when the location is recursively
-// deleted.
+// attached directly to a location AND files attached to its child areas are
+// removed — DB rows AND physical blobs — when the location is recursively
+// deleted. The area-attached fixture pins that the location cascade reaches
+// area files through DeleteAreaRecursive delegation (a refactor that
+// bare-row-deletes the emptied areas would re-orphan them).
 func TestDeleteLocationRecursive_DeletesAttachedFiles(t *testing.T) {
 	c := qt.New(t)
 
@@ -804,6 +816,15 @@ func TestDeleteLocationRecursive_DeletesAttachedFiles(t *testing.T) {
 	service := services.NewEntityService(factorySet, uploadLocation)
 
 	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
+	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
+
+	// Write the physical blobs backing the location- and area-attached files.
+	locationBlobKey := "loc-doc.pdf"
+	areaBlobKey := "area-doc.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, locationBlobKey, []byte("pdf bytes"), nil), qt.IsNil)
+	c.Assert(b.WriteAll(ctx, areaBlobKey, []byte("pdf bytes"), nil), qt.IsNil)
 
 	locationFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
 		LinkedEntityType: "location",
@@ -811,7 +832,18 @@ func TestDeleteLocationRecursive_DeletesAttachedFiles(t *testing.T) {
 		LinkedEntityMeta: "images",
 		File: &models.File{
 			Path:         "loc-doc",
-			OriginalPath: "loc-doc.pdf",
+			OriginalPath: locationBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: areaBlobKey,
 			Ext:          ".pdf",
 			MIMEType:     "application/pdf",
 		},
@@ -822,9 +854,17 @@ func TestDeleteLocationRecursive_DeletesAttachedFiles(t *testing.T) {
 
 	_, err = registrySet.LocationRegistry.Get(ctx, location.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	_, err = registrySet.AreaRegistry.Get(ctx, area.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 
 	_, err = registrySet.FileRegistry.Get(ctx, locationFile.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	_, err = registrySet.FileRegistry.Get(ctx, areaFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// The physical blobs are gone too — not just the rows.
+	c.Assert(must.Must(b.Exists(ctx, locationBlobKey)), qt.IsFalse)
+	c.Assert(must.Must(b.Exists(ctx, areaBlobKey)), qt.IsFalse)
 }
 
 // TestDeleteArea_DeletesLinkedFiles asserts #2119: the non-recursive DeleteArea
@@ -845,17 +885,31 @@ func TestDeleteArea_DeletesLinkedFiles(t *testing.T) {
 	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
 	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
 
+	// Image file so the thumbnail-key cleanup path is exercised for the
+	// 'area' link type too, not just for commodities.
+	blobKey := "area-photo.jpg"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, blobKey, []byte("jpeg bytes"), nil), qt.IsNil)
+
 	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
 		LinkedEntityType: "area",
 		LinkedEntityID:   area.ID,
 		LinkedEntityMeta: "images",
 		File: &models.File{
-			Path:         "area-doc",
-			OriginalPath: "area-doc.pdf",
-			Ext:          ".pdf",
-			MIMEType:     "application/pdf",
+			Path:         "area-photo",
+			OriginalPath: blobKey,
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
 		},
 	}))
+
+	// Pre-write the canonical thumbnail blobs the file would own.
+	fileService := services.NewFileService(factorySet, uploadLocation)
+	thumbnailPaths := fileService.GetThumbnailPaths(areaFile.TenantID, areaFile.ID)
+	for _, p := range thumbnailPaths {
+		c.Assert(b.WriteAll(ctx, p, []byte("thumb bytes"), nil), qt.IsNil)
+	}
 
 	err := service.DeleteArea(ctx, area.ID)
 	c.Assert(err, qt.IsNil)
@@ -868,11 +922,20 @@ func TestDeleteArea_DeletesLinkedFiles(t *testing.T) {
 
 	linked := must.Must(registrySet.FileRegistry.ListByLinkedEntity(ctx, "area", area.ID))
 	c.Assert(linked, qt.HasLen, 0)
+
+	// The physical blob AND its thumbnails are gone — not just the rows.
+	c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsFalse)
+	for size, p := range thumbnailPaths {
+		c.Assert(must.Must(b.Exists(ctx, p)), qt.IsFalse,
+			qt.Commentf("thumbnail %s at %s must be deleted with the area file", size, p))
+	}
 }
 
 // TestDeleteArea_NonEmptyRejected asserts #2119: DeleteArea is non-recursive —
 // an area that still holds a commodity is rejected with ErrCannotDelete and
-// nothing is removed.
+// nothing is removed. The area-attached file (row + blob) surviving the
+// rejection pins the row-first ordering: a rejected delete never destroys
+// user files (#2120 contract).
 func TestDeleteArea_NonEmptyRejected(t *testing.T) {
 	c := qt.New(t)
 
@@ -892,12 +955,33 @@ func TestDeleteArea_NonEmptyRejected(t *testing.T) {
 		AreaID: new(area.ID),
 	}))
 
+	blobKey := "area-doc.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, blobKey, []byte("pdf bytes"), nil), qt.IsNil)
+
+	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: blobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
 	err := service.DeleteArea(ctx, area.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrCannotDelete)
 
 	// The area and its commodity survive.
 	c.Assert(must.Must(registrySet.AreaRegistry.Get(ctx, area.ID)), qt.IsNotNil)
 	c.Assert(must.Must(registrySet.CommodityRegistry.Get(ctx, commodity.ID)), qt.IsNotNil)
+
+	// The area-attached file survives the rejection — row and blob.
+	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, areaFile.ID)), qt.IsNotNil)
+	c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsTrue)
 }
 
 // TestDeleteLocation_DeletesLinkedFiles asserts #2119: the non-recursive
@@ -917,13 +1001,18 @@ func TestDeleteLocation_DeletesLinkedFiles(t *testing.T) {
 
 	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
 
+	blobKey := "loc-doc.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, blobKey, []byte("pdf bytes"), nil), qt.IsNil)
+
 	locationFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
 		LinkedEntityType: "location",
 		LinkedEntityID:   location.ID,
 		LinkedEntityMeta: "images",
 		File: &models.File{
 			Path:         "loc-doc",
-			OriginalPath: "loc-doc.pdf",
+			OriginalPath: blobKey,
 			Ext:          ".pdf",
 			MIMEType:     "application/pdf",
 		},
@@ -940,11 +1029,16 @@ func TestDeleteLocation_DeletesLinkedFiles(t *testing.T) {
 
 	linked := must.Must(registrySet.FileRegistry.ListByLinkedEntity(ctx, "location", location.ID))
 	c.Assert(linked, qt.HasLen, 0)
+
+	// The physical blob is gone too — not just the row.
+	c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsFalse)
 }
 
 // TestDeleteLocation_NonEmptyRejected asserts #2119: DeleteLocation is
 // non-recursive — a location that still holds an area is rejected with
-// ErrCannotDelete and nothing is removed.
+// ErrCannotDelete and nothing is removed. The location-attached file (row +
+// blob) surviving the rejection pins the row-first ordering: a rejected
+// delete never destroys user files (#2120 contract).
 func TestDeleteLocation_NonEmptyRejected(t *testing.T) {
 	c := qt.New(t)
 
@@ -960,17 +1054,39 @@ func TestDeleteLocation_NonEmptyRejected(t *testing.T) {
 	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
 	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
 
+	blobKey := "loc-doc.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, blobKey, []byte("pdf bytes"), nil), qt.IsNil)
+
+	locationFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loc-doc",
+			OriginalPath: blobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
 	err := service.DeleteLocation(ctx, location.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrCannotDelete)
 
 	// The location and its area survive.
 	c.Assert(must.Must(registrySet.LocationRegistry.Get(ctx, location.ID)), qt.IsNotNil)
 	c.Assert(must.Must(registrySet.AreaRegistry.Get(ctx, area.ID)), qt.IsNotNil)
+
+	// The location-attached file survives the rejection — row and blob.
+	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, locationFile.ID)), qt.IsNotNil)
+	c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsTrue)
 }
 
 // TestUnlinkAndDeleteArea_KeepsCommodities asserts #2137: the "unlink" strategy
-// removes a non-empty area (and the files attached directly to it) while
-// keeping its commodities — left area-less (AreaID == nil) rather than deleted.
+// removes a non-empty area (and the files attached directly to it — rows +
+// blobs, #2119) while keeping its commodities — left area-less (AreaID == nil)
+// rather than deleted — AND the files attached to those surviving commodities.
 func TestUnlinkAndDeleteArea_KeepsCommodities(t *testing.T) {
 	c := qt.New(t)
 
@@ -994,13 +1110,33 @@ func TestUnlinkAndDeleteArea_KeepsCommodities(t *testing.T) {
 		AreaID: new(area.ID),
 	}))
 
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+
+	areaBlobKey := "area-doc.pdf"
+	c.Assert(b.WriteAll(ctx, areaBlobKey, []byte("area pdf"), nil), qt.IsNil)
 	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
 		LinkedEntityType: "area",
 		LinkedEntityID:   area.ID,
 		LinkedEntityMeta: "images",
 		File: &models.File{
 			Path:         "area-doc",
-			OriginalPath: "area-doc.pdf",
+			OriginalPath: areaBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	// A file attached to a surviving commodity — unlink must NOT touch it.
+	commodityBlobKey := "com-doc.pdf"
+	c.Assert(b.WriteAll(ctx, commodityBlobKey, []byte("com pdf"), nil), qt.IsNil)
+	commodityFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   commodity1.ID,
+		LinkedEntityMeta: "manuals",
+		File: &models.File{
+			Path:         "com-doc",
+			OriginalPath: commodityBlobKey,
 			Ext:          ".pdf",
 			MIMEType:     "application/pdf",
 		},
@@ -1009,22 +1145,29 @@ func TestUnlinkAndDeleteArea_KeepsCommodities(t *testing.T) {
 	err := service.UnlinkAndDeleteArea(ctx, area.ID)
 	c.Assert(err, qt.IsNil)
 
-	// The area and the file attached directly to it are gone.
+	// The area and the file attached directly to it are gone — row and blob.
 	_, err = registrySet.AreaRegistry.Get(ctx, area.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 	_, err = registrySet.FileRegistry.Get(ctx, areaFile.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	c.Assert(must.Must(b.Exists(ctx, areaBlobKey)), qt.IsFalse)
 
 	// Both commodities survive, now area-less.
 	got1 := must.Must(registrySet.CommodityRegistry.Get(ctx, commodity1.ID))
 	c.Assert(got1.AreaID, qt.IsNil)
 	got2 := must.Must(registrySet.CommodityRegistry.Get(ctx, commodity2.ID))
 	c.Assert(got2.AreaID, qt.IsNil)
+
+	// The surviving commodity's file survives too — row and blob.
+	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, commodityFile.ID)), qt.IsNotNil)
+	c.Assert(must.Must(b.Exists(ctx, commodityBlobKey)), qt.IsTrue)
 }
 
 // TestUnlinkAndDeleteLocation_KeepsCommodities asserts #2137: the "unlink"
 // strategy removes a non-empty location and all its areas while keeping the
-// commodities filed under those areas — left area-less (AreaID == nil).
+// commodities filed under those areas — left area-less (AreaID == nil). Files
+// attached directly to the location AND to its areas are removed (rows +
+// blobs, #2119); files attached to the surviving commodities are NOT.
 func TestUnlinkAndDeleteLocation_KeepsCommodities(t *testing.T) {
 	c := qt.New(t)
 
@@ -1049,6 +1192,52 @@ func TestUnlinkAndDeleteLocation_KeepsCommodities(t *testing.T) {
 		AreaID: new(area2.ID),
 	}))
 
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+
+	locationBlobKey := "loc-doc.pdf"
+	c.Assert(b.WriteAll(ctx, locationBlobKey, []byte("loc pdf"), nil), qt.IsNil)
+	locationFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loc-doc",
+			OriginalPath: locationBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	areaBlobKey := "area-doc.pdf"
+	c.Assert(b.WriteAll(ctx, areaBlobKey, []byte("area pdf"), nil), qt.IsNil)
+	areaFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "area",
+		LinkedEntityID:   area1.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "area-doc",
+			OriginalPath: areaBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	// A file attached to a surviving commodity — unlink must NOT touch it.
+	commodityBlobKey := "com-doc.pdf"
+	c.Assert(b.WriteAll(ctx, commodityBlobKey, []byte("com pdf"), nil), qt.IsNil)
+	commodityFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   commodity2.ID,
+		LinkedEntityMeta: "manuals",
+		File: &models.File{
+			Path:         "com-doc",
+			OriginalPath: commodityBlobKey,
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
 	err := service.UnlinkAndDeleteLocation(ctx, location.ID)
 	c.Assert(err, qt.IsNil)
 
@@ -1060,9 +1249,198 @@ func TestUnlinkAndDeleteLocation_KeepsCommodities(t *testing.T) {
 	_, err = registrySet.AreaRegistry.Get(ctx, area2.ID)
 	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
 
+	// The location-attached and area-attached files are gone — rows and blobs.
+	_, err = registrySet.FileRegistry.Get(ctx, locationFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	c.Assert(must.Must(b.Exists(ctx, locationBlobKey)), qt.IsFalse)
+	_, err = registrySet.FileRegistry.Get(ctx, areaFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	c.Assert(must.Must(b.Exists(ctx, areaBlobKey)), qt.IsFalse)
+
 	// Both commodities survive, now area-less.
 	got1 := must.Must(registrySet.CommodityRegistry.Get(ctx, commodity1.ID))
 	c.Assert(got1.AreaID, qt.IsNil)
 	got2 := must.Must(registrySet.CommodityRegistry.Get(ctx, commodity2.ID))
 	c.Assert(got2.AreaID, qt.IsNil)
+
+	// The surviving commodity's file survives too — row and blob.
+	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, commodityFile.ID)), qt.IsNotNil)
+	c.Assert(must.Must(b.Exists(ctx, commodityBlobKey)), qt.IsTrue)
+}
+
+// TestEntityService_MissingEntityIsNoOp pins the idempotency contract shared
+// by the recursive (cascade, #2120) and unlink (#2137) delete paths: an
+// already-gone area/location is treated as success (nil), so retries and
+// parent cascades never fail on a concurrently-removed entity.
+// DeleteLocationRecursive historically errored here, unlike
+// DeleteAreaRecursive — this pins the restored parity (#2119). The orphan
+// sweep these branches also perform is covered separately by
+// TestEntityService_MissingEntitySweepsOrphanedFiles.
+func TestEntityService_MissingEntityIsNoOp(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *services.EntityService) error
+	}{
+		{
+			name: "DeleteAreaRecursive",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.DeleteAreaRecursive(ctx, "missing-id")
+			},
+		},
+		{
+			name: "DeleteLocationRecursive",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.DeleteLocationRecursive(ctx, "missing-id")
+			},
+		},
+		{
+			name: "UnlinkAndDeleteArea",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.UnlinkAndDeleteArea(ctx, "missing-id")
+			},
+		},
+		{
+			name: "UnlinkAndDeleteLocation",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.UnlinkAndDeleteLocation(ctx, "missing-id")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			factorySet := memory.NewFactorySet()
+			ctx := newTestContext(factorySet)
+			service := services.NewEntityService(factorySet, uploadLocationForTempDir(c.TempDir()))
+
+			c.Assert(tt.call(ctx, service), qt.IsNil)
+		})
+	}
+}
+
+// TestEntityService_MissingEntitySweepsOrphanedFiles pins the self-healing
+// retry contract (#2119): the already-gone (ErrNotFound → nil) branches of
+// the cascade and unlink delete paths still sweep files linked to the missing
+// entity id. A crash (or transient error) between the entity-row delete and
+// the file cleanup would otherwise strand those rows+blobs forever — the
+// entity row is gone, so every retry short-circuits before reaching the
+// cleanup. Any file still linked to a nonexistent entity id is garbage by
+// definition, so the sweep is safe; when nothing is linked it is a no-op
+// (pinned by TestEntityService_MissingEntityIsNoOp).
+func TestEntityService_MissingEntitySweepsOrphanedFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		call       func(context.Context, *services.EntityService, string) error
+	}{
+		{
+			name:       "DeleteAreaRecursive",
+			entityType: "area",
+			call: func(ctx context.Context, s *services.EntityService, id string) error {
+				return s.DeleteAreaRecursive(ctx, id)
+			},
+		},
+		{
+			name:       "DeleteLocationRecursive",
+			entityType: "location",
+			call: func(ctx context.Context, s *services.EntityService, id string) error {
+				return s.DeleteLocationRecursive(ctx, id)
+			},
+		},
+		{
+			name:       "UnlinkAndDeleteArea",
+			entityType: "area",
+			call: func(ctx context.Context, s *services.EntityService, id string) error {
+				return s.UnlinkAndDeleteArea(ctx, id)
+			},
+		},
+		{
+			name:       "UnlinkAndDeleteLocation",
+			entityType: "location",
+			call: func(ctx context.Context, s *services.EntityService, id string) error {
+				return s.UnlinkAndDeleteLocation(ctx, id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			tempDir := c.TempDir()
+			uploadLocation := uploadLocationForTempDir(tempDir)
+
+			factorySet := memory.NewFactorySet()
+			ctx := newTestContext(factorySet)
+			registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+			service := services.NewEntityService(factorySet, uploadLocation)
+
+			blobKey := "orphan-doc.pdf"
+			b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+			defer b.Close()
+			c.Assert(b.WriteAll(ctx, blobKey, []byte("pdf bytes"), nil), qt.IsNil)
+
+			// A file row still linked to an entity id whose row no longer
+			// exists — exactly what an interrupted earlier delete leaves.
+			orphan := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+				LinkedEntityType: tt.entityType,
+				LinkedEntityID:   "ghost-id",
+				LinkedEntityMeta: "images",
+				File: &models.File{
+					Path:         "orphan-doc",
+					OriginalPath: blobKey,
+					Ext:          ".pdf",
+					MIMEType:     "application/pdf",
+				},
+			}))
+
+			// Retrying the delete on the missing id still succeeds…
+			c.Assert(tt.call(ctx, service, "ghost-id"), qt.IsNil)
+
+			// …and sweeps the stranded file — row and blob.
+			_, err := registrySet.FileRegistry.Get(ctx, orphan.ID)
+			c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+			c.Assert(must.Must(b.Exists(ctx, blobKey)), qt.IsFalse)
+		})
+	}
+}
+
+// TestEntityService_MissingEntityNotFound pins the intentional CONTRAST with
+// TestEntityService_MissingEntityIsNoOp: the non-recursive DeleteArea /
+// DeleteLocation surface ErrNotFound for a missing id (the API maps it to
+// 404). The already-gone tolerance lives in their callers
+// (UnlinkAndDeleteArea/UnlinkAndDeleteLocation), not here (#2119).
+func TestEntityService_MissingEntityNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *services.EntityService) error
+	}{
+		{
+			name: "DeleteArea",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.DeleteArea(ctx, "missing-id")
+			},
+		},
+		{
+			name: "DeleteLocation",
+			call: func(ctx context.Context, s *services.EntityService) error {
+				return s.DeleteLocation(ctx, "missing-id")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			factorySet := memory.NewFactorySet()
+			ctx := newTestContext(factorySet)
+			service := services.NewEntityService(factorySet, uploadLocationForTempDir(c.TempDir()))
+
+			c.Assert(tt.call(ctx, service), qt.ErrorIs, registry.ErrNotFound)
+		})
+	}
 }

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -273,6 +273,107 @@ func TestFileService_DeleteLinkedFiles(t *testing.T) {
 	}
 }
 
+// TestFileService_DeleteLinkedFiles_AreaAndLocation pins #2119 at the
+// primitive level: DeleteLinkedFiles handles the 'area' and 'location' link
+// types exactly like 'commodity' — file rows AND physical blobs are removed.
+// The area case uses an image MIME so the canonical thumbnail-key cleanup is
+// exercised for these link types too.
+func TestFileService_DeleteLinkedFiles_AreaAndLocation(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		mimeType   string
+		ext        string
+	}{
+		{
+			name:       "area-linked image file",
+			entityType: "area",
+			mimeType:   "image/jpeg",
+			ext:        ".jpg",
+		},
+		{
+			name:       "location-linked document file",
+			entityType: "location",
+			mimeType:   "application/pdf",
+			ext:        ".pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx := newTestContext()
+
+			tempDir := c.TempDir()
+			var uploadLocation string
+			if runtime.GOOS == "windows" {
+				uploadLocation = "file:///" + tempDir + "?create_dir=1"
+			} else {
+				uploadLocation = "file://" + tempDir + "?create_dir=1"
+			}
+
+			factorySet := memory.NewFactorySet()
+			registrySet, err := factorySet.CreateUserRegistrySet(ctx)
+			c.Assert(err, qt.IsNil)
+
+			service := NewFileService(factorySet, uploadLocation)
+
+			b, err := blob.OpenBucket(ctx, uploadLocation)
+			c.Assert(err, qt.IsNil)
+			defer b.Close()
+
+			blobKey := "linked-" + tt.entityType + tt.ext
+			c.Assert(b.WriteAll(ctx, blobKey, []byte("test content"), nil), qt.IsNil)
+
+			entityID := "test-" + tt.entityType + "-id"
+			createdFile, err := registrySet.FileRegistry.Create(ctx, models.FileEntity{
+				Title:            "Linked File",
+				Type:             models.FileTypeFromMIME(tt.mimeType),
+				LinkedEntityType: tt.entityType,
+				LinkedEntityID:   entityID,
+				LinkedEntityMeta: "images",
+				File: &models.File{
+					Path:         "linked-" + tt.entityType,
+					OriginalPath: blobKey,
+					Ext:          tt.ext,
+					MIMEType:     tt.mimeType,
+				},
+			})
+			c.Assert(err, qt.IsNil)
+
+			// For the image case, pre-write the canonical thumbnail blobs the
+			// file would own so their cleanup is asserted too.
+			thumbnailPaths := service.GetThumbnailPaths(createdFile.TenantID, createdFile.ID)
+			if tt.mimeType == "image/jpeg" {
+				for _, p := range thumbnailPaths {
+					c.Assert(b.WriteAll(ctx, p, []byte("thumb"), nil), qt.IsNil)
+				}
+			}
+
+			err = service.DeleteLinkedFiles(ctx, tt.entityType, entityID)
+			c.Assert(err, qt.IsNil)
+
+			// File row is gone.
+			_, err = registrySet.FileRegistry.Get(ctx, createdFile.ID)
+			c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+			// Physical blob is gone.
+			exists, err := b.Exists(ctx, blobKey)
+			c.Assert(err, qt.IsNil)
+			c.Assert(exists, qt.IsFalse)
+
+			// Thumbnail blobs are gone for the image case.
+			if tt.mimeType == "image/jpeg" {
+				for size, p := range thumbnailPaths {
+					exists, err := b.Exists(ctx, p)
+					c.Assert(err, qt.IsNil)
+					c.Assert(exists, qt.IsFalse, qt.Commentf("thumbnail %s at %s should be deleted", size, p))
+				}
+			}
+		})
+	}
+}
+
 func TestFileService_DeleteLinkedFiles_NoFiles(t *testing.T) {
 	c := qt.New(t)
 	ctx := newTestContext()


### PR DESCRIPTION
Closes #2119.

## Context

The core #2119 fix — `DeleteLinkedFiles("area"/"location")` on every delete path — already shipped with the #2137 strategy work (PR #2138): all six `EntityService` delete methods clean linked files, both handlers route exclusively through `EntityService` with the `?strategy=` resolver, and every bulk deleter (restore `full_replace`, group purge incl. #2147, tenant hard-delete #2115) sweeps files type-agnostically. This PR is the **completeness pass**: an exhaustive audit of every deleter (API, restore, purgers, CLI, workers — no raw `AreaRegistry`/`LocationRegistry.Delete` caller exists outside `EntityService`) surfaced four consistency defects inside the shipped fix and a large test hole. It fixes the defects and back-fills the matrix.

## Code changes

1. **Row-first ordering for the recursive deletes** (`entity_service.go`). They were files-first — contradicting their own "mirroring the commodity path" comments (`DeleteCommodityRecursive` is row-first, #2120) — and carried a narrow **data-loss race**: a commodity/area created concurrently after the child scan makes the registry `Delete` return `ErrCannotDelete` (422, "nothing was deleted") *after* the entity's attachments were already destroyed. Now the registry delete goes first; a rejected delete leaves all files intact. `ListByLinkedEntity` still finds the files afterwards — the link is polymorphic, no FK.
2. **Idempotency parity**: `DeleteLocationRecursive`'s Get-first guard now returns `nil` for an already-gone location, matching `DeleteAreaRecursive` (matters for restore `clearExistingData` and future direct service callers; not API-visible — the ctx middleware 404s first).
3. **Self-healing retries**: all four already-gone guards (recursive ×2, unlink ×2) sweep files still linked to the dead id before returning `nil`. A service-level retry after a crash between row delete and file cleanup now recovers the orphans instead of stranding them forever (files linked to a nonexistent id are garbage by definition; RLS confines the sweep to the caller's tenant+group; normally a no-op).
4. **Unlink contract made true**: `UnlinkAndDeleteArea/Location` tolerate `ErrNotFound` from the final `DeleteArea/DeleteLocation`, so their documented idempotent/re-runnable contract holds under a concurrent delete between guard and final call.
5. **INVARIANT doc comments** on postgres `AreaRegistry.Delete` / `LocationRegistry.Delete` (#2121 pattern, mirrors `CommodityRegistry.Delete`): bare row deletes orphan linked files; `EntityService` is the sanctioned path.

## Ordering contract (the picky-reviewer FAQ)

- **All six methods are now row-first, blob-best-effort (#2120)**: entity row delete → linked-file rows → blobs (failures inside `DeleteFileWithPhysical` are swallowed by that documented contract).
- **Crash between row delete and file cleanup** → orphan file rows/blobs; recoverable: any retry of the same delete (or of a parent cascade/unlink) self-heals via the already-gone sweep; group purge and tenant hard-delete remain the terminal backstops. This is exactly the commodity precedent's window, now with a recovery path the commodity path itself doesn't need (its file IDs are collected pre-delete).
- **Concurrent attach during the multi-tx delete** can still escape cleanup — inherent to the polymorphic no-FK design (stated in #2119 itself); a DB-level fix needs a migration and a polymorphic FK is impossible. Backstops: group purge (now pinned by tests) + the proposed orphan-GC sweeper #2237.

## Tests (the actual bulk of the diff: +1133/-41)

Previously **zero** blob assertions existed on any area/location path (one test comment even falsely claimed "rows + blob" coverage). Now:

- **Service level**: blob-gone assertions (incl. thumbnail keys) for `DeleteAreaRecursive`, `DeleteLocationRecursive` (incl. child-area files), `DeleteArea`, `DeleteLocation`, both `Unlink*`; survivor matrix (commodity files survive unlink — rows *and* blobs); non-empty rejection leaves file row+blob intact (pins row-first); idempotency pins for all six (`nil` quartet + `ErrNotFound` pair, table-driven); self-heal sweep test (`TestEntityService_MissingEntitySweepsOrphanedFiles`).
- **API level**: cascade/unlink file-fate for areas and locations (`GET /files/{id}` → 404/200 after the 204), missing-id × strategy → 404.
- **Restore**: `full_replace` sweeps area/location/standalone file rows+blobs, export-linked survives (`clear_existing_data_test.go`, new).
- **Postgres lane**: `ListByLinkedEntity('area'/'location')` happy/empty/type-mismatch + **RLS cross-tenant/group isolation** (new `files_linked_entity_test.go`); group purger sweeps area/location-linked files (fixtures added). These self-skip without a DSN and run in the `go-test-postgres` CI lane.
- **file service**: table-driven `DeleteLinkedFiles` cases for `area` (image → thumbnail cleanup) and `location`.

E2E for the delete dialogs was deliberately left out (FE vitest + BE httptest cover both sides; full-stack dialog e2e is a quality follow-up, not a #2119 blocker).

## Out of scope — filed as follow-ups during this audit

- #2235 — `.inb` backup omits area/location-linked + standalone files → `full_replace` restore **loses** them (data-loss, separate surface).
- #2236 — area-less commodities (#1986) survive `full_replace` as stale rows while their files are swept.
- #2237 — periodic orphan-file GC sweeper (systematic backstop for the residual windows above).
- #2140 — FE cascade-dialog capped-fetch gate (pre-existing, untouched).

## Gates

`go build` ✅ · `golangci-lint run` ✅ 0 issues · `nolintguard` ✅ · `qtlint` ✅ · `go vet` (touched packages) ✅ · `go test ./...` ✅ 83 packages (memory backend; postgres tests self-skip locally, run in CI) · `-tags legacy_xml_backup` restore tests ✅. No migrations, no seeddata changes, no API-surface/swagger changes.

Note: bare full-repo `go vet` is red on master already (`internal/fileblob/drivertest` `testinggoroutine`, pre-existing, not part of the CI gate).