### PR TITLE
fix(backup): carry area/location/standalone files in .inb; full_replace wipes area-less commodities (#2235, #2236)

### DIFF
--- a/docs/site/src/content/docs/backup-and-restore.md
+++ b/docs/site/src/content/docs/backup-and-restore.md
@@ -36,8 +36,8 @@ Because the file is signed, Inventario can verify it hasn't been tampered with o
 
 1. Go to **Backup** and click **New export**.
 2. On the **What to export** step, choose a scope:
-   - **Full database** — everything: locations, areas, items, files, tags.
-   - **Selected items** — pick specific locations, areas, or items to include. Use the search box to find locations, then choose what to add. You have to pick at least one thing.
+   - **Full database** — everything: locations, areas, items, files, tags. "Files" here means *all* of them — the photos, invoices and manuals attached to an item, the files attached to a location or an area, and any standalone file that isn't attached to anything.
+   - **Selected items** — pick specific locations, areas, or items to include. Use the search box to find locations, then choose what to add. You have to pick at least one thing. Files attached to a location or area you selected come with it; standalone files are only included in a **Full database** export, since there's no parent to bring them along.
 3. Decide whether to **Include attached files (photos, invoices, manuals)**. Leave it on to bundle the actual files into the archive; turn it off for a smaller, metadata-only backup.
 4. Click **Next** to reach the **Confirm** step. Optionally add a **Description** to help you recognise the export later. If you leave it blank, Inventario names it for you (for example, "Backup · Full database · 2026-05-13 10:42 UTC").
 5. Review the summary and click **Create export**.
@@ -82,11 +82,11 @@ Restoring brings the contents of an export into your **current group**. Open an 
 | **Merge update** | Moderate | Inserts new rows and updates existing ones in place. |
 | **Full replace** | Destructive | Wipes existing data in the destination scope before importing. |
 
-**Full replace** removes your current data before importing, so Inventario shows a clear warning before you run it. Use it only when you really want the backup to become the source of truth.
+**Full replace** removes your current data before importing, so Inventario shows a clear warning before you run it. Use it only when you really want the backup to become the source of truth. It really does mean *everything*: items with no area assigned, files attached to a location or area, and standalone files are all wiped and then restored from the backup.
 
 ### Other options
 
-- **Restore attached files** — restore the actual photos, invoices, and manuals alongside the metadata. Turn it off to restore only the records. (This only has files to restore if the export was created with attachments included.)
+- **Restore attached files** — restore the actual files alongside the metadata: an item's photos, invoices and manuals, the files attached to a location or area, and standalone files. Turn it off to restore only the records. (This only has files to restore if the export was created with attachments included.)
 - **Dry run** — on by default. A dry run previews exactly what *would* change without modifying any data. Always worth running first.
 - **Description** — required. It's useful when you're comparing several dry-run reports.
 

--- a/docs/site/src/content/docs/backup-and-restore.md
+++ b/docs/site/src/content/docs/backup-and-restore.md
@@ -38,7 +38,7 @@ Because the file is signed, Inventario can verify it hasn't been tampered with o
 2. On the **What to export** step, choose a scope:
    - **Full database** — everything: locations, areas, items, files, tags. "Files" here means *all* of them — the photos, invoices and manuals attached to an item, the files attached to a location or an area, and any standalone file that isn't attached to anything.
    - **Selected items** — pick specific locations, areas, or items to include. Use the search box to find locations, then choose what to add. You have to pick at least one thing. Files attached to a location or area you selected come with it; standalone files are only included in a **Full database** export, since there's no parent to bring them along.
-3. Decide whether to **Include attached files (photos, invoices, manuals)**. Leave it on to bundle the actual files into the archive; turn it off for a smaller, metadata-only backup.
+3. Decide whether to **Include attached files (photos, invoices, manuals)**. Despite the shorter label, this covers *every* file in scope — item attachments, files attached to a location or an area, and standalone files. Leave it on to bundle the actual files into the archive; turn it off for a smaller, metadata-only backup.
 4. Click **Next** to reach the **Confirm** step. Optionally add a **Description** to help you recognise the export later. If you leave it blank, Inventario names it for you (for example, "Backup · Full database · 2026-05-13 10:42 UTC").
 5. Review the summary and click **Create export**.
 

--- a/go/backup/export/README.md
+++ b/go/backup/export/README.md
@@ -4,7 +4,9 @@ The `export` package is a core Go package that handles backup export generation 
 
 ## Overview
 
-The export package generates backup archives of inventory data, including locations, areas, commodities, and their associated commodity files (images, invoices, manuals). The default build streams the archive directly to blob storage without ever holding the whole payload (or any single file) in memory.
+The export package generates backup archives of inventory data: locations, areas, commodities, and **every** group file — commodity attachments (images, invoices, manuals), files attached to a location or an area, and standalone (unlinked) files (issue #2235). The default build streams the archive directly to blob storage without ever holding the whole payload (or any single file) in memory.
+
+Export artifacts themselves (`linked_entity_type = "export"`) are deliberately excluded: a backup must not embed previous backups.
 
 ## Backup Format
 
@@ -19,13 +21,34 @@ Files in this package split by build tag:
 An `.inb` artifact is an **outer tar** (`internal/inb`) holding:
 
 1. `payload.tar.gz.sig` — an Ed25519 signature (`internal/backupsign`) over the streaming SHA-256 digest of the payload.
-2. `payload.tar.gz` — a gzip(tar) payload whose members are:
+2. `payload.tar.gz` — a gzip(tar) payload whose members are, **in this order**:
    - `manifest.json` — written first; format, signing-key info, per-location index, and aggregate statistics (see `inb_types.go`).
-   - one `location-<slug>-<uuid>.json` member per location (location → areas → commodities, each commodity bundling its image/invoice/manual file references).
-   - `unassigned-commodities.json` — area-less commodities, written only when at least one is in scope (issue #1986).
-   - `files/<loc>/<commodity>/<bucket>/<name>` — the raw bytes of each referenced commodity file, streamed directly from blob storage.
+   - one `location-<slug>-<uuid>.json` member per location (location → areas → commodities, each commodity bundling its image/invoice/manual file references), each immediately followed by that location's commodity file bytes at `files/<loc-slug>/<commodity-uuid>/<bucket>/<file-uuid>/<name>`.
+   - `unassigned-commodities.json` — area-less commodities, written only when at least one is in scope (issue #1986), followed by their file bytes.
+   - `files/_index.json` — the **non-commodity files** document (issue #2235): every location-linked, area-linked and standalone file, each carrying its own `linkedEntityType` / `linkedEntityId` (the linked entity's immutable **UUID**) / `linkedEntityMeta` plus its `type` and `category`. Written only when at least one such file is in scope. Its bytes follow at `files/_entity/<type>/<entity-uuid>/<bucket>/<file-uuid>/<name>` and `files/_standalone/<file-uuid>/<name>`.
 
-The exporter stamps the resulting `FileEntity` with `Ext=".inb"`, `MIMEType="application/x-inventario-backup"`, and `LinkedEntityMeta="inb-2.0"` (`exportFileMeta` in `jsonexport.go`).
+Ordering is load-bearing in two ways: a JSON document always precedes the file bytes it references (restore registers each reference, then matches the members against it), and `files/_index.json` is written **last** — restore resolves each entity link through the location/area ID mapping, which only fills as the location documents are applied.
+
+The exporter stamps the resulting `FileEntity` with `Ext=".inb"`, `MIMEType="application/x-inventario-backup"`, and `LinkedEntityMeta="inb-2.0"` (`exportFileMeta` in `jsonexport.go`). That stamp is a `FileEntity` meta value, not the format version.
+
+### Format versioning
+
+`INBFormatVersion` (manifest `version`) is currently `"2.1"`. The **MAJOR** component is the compatibility contract the restore side enforces: a reader accepts any archive whose major version it knows and rejects a higher one with `ErrUnsupportedFormatVersion` *before* touching any data. MINOR bumps are additive-only — a new **optional** member plus an optional manifest pointer, dispatched by member name — so a 2.0 archive still restores unchanged on a 2.1 reader.
+
+Both optional members (`unassignedFile`, `filesFile`) are omitted entirely when empty, so an archive that uses neither is byte-stable against the 2.0 layout.
+
+### Scope rules for files
+
+| Export type | Commodity attachments | Location/area files | Standalone files |
+| --- | --- | --- | --- |
+| whole-class (`full_database`, `locations`, `areas`, `commodities`) | of every emitted commodity | all | all |
+| `selected_items` | of every emitted commodity | only of the locations/areas **explicitly selected** | none |
+
+Standalone files have no parent entity that could imply them into a selection, so they ride along with whole-class exports only — matching the legacy XML exporter.
+
+`selected_items` scopes entity files on the **explicit** selection, not on what the archive happens to emit: a selected commodity forces its parent location/area document to be emitted so the item has a home, but that implied parent's files stay out. Scoping on "emitted" instead would silently bundle a location's lease/floor plans into an archive where the user only picked one item — and would diverge from the legacy XML exporter, whose `selectedFileScope` is built from the selected item IDs alone (`service_legacy_xml.go`).
+
+A file whose blob is missing or unsized (orphan row, manual blob delete) is **dropped** from the document and the statistics in every branch. The tar header needs an exact size up front, and a restore hard-fails on a declared reference whose member never arrives.
 
 ### Legacy: XML (build-tag-gated)
 
@@ -51,6 +74,7 @@ The pre-#534 XML format (root `<inventory>` with base64-embedded file data) is *
 
 ### 4. Statistics Tracking
 - Counts for locations, areas, commodities, images, invoices, manuals, and total files
+- `imageCount` / `invoiceCount` / `manualCount` are legacy **commodity-scoped** bucket counters. Location-, area-linked and standalone files feed only the unified `fileCount` and `totalFileSize` (#2235) — a location image does not inflate `imageCount`.
 - Binary data size tracking, surfaced both on the `Export` record and in `manifest.json`
 
 ### 5. Memory-Safe Streaming
@@ -79,7 +103,8 @@ Defines the JSON documents written into the inner tar (kept in sync with `backup
 - **INBManifest**, **INBManifestLoc**, **INBManifestStats**, **INBSignatureInfo**
 - **INBLocationDoc**, **INBLocation**, **INBArea**, **INBCommodity**, **INBFileRef**
 - **INBUnassignedDoc** (area-less commodities, #1986)
-- Format constants: `INBFormatVersion = "2.0"`, `INBManifestName`, `INBUnassignedName`, `INBFilesPrefix`
+- **INBFilesDoc**, **INBEntityFileRef** (non-commodity files, #2235)
+- Format constants: `INBFormatVersion = "2.1"`, `INBManifestName`, `INBUnassignedName`, `INBFilesPrefix`, `INBFilesName`, `INBEntityFilesPrefix`, `INBStandaloneFilesPrefix`
 
 #### Export Types (`models/export.go`)
 - `ExportTypeFullDatabase`, `ExportTypeSelectedItems`, `ExportTypeLocations`, `ExportTypeAreas`, `ExportTypeCommodities`, `ExportTypeImported`

--- a/go/backup/export/inb_builder.go
+++ b/go/backup/export/inb_builder.go
@@ -54,6 +54,20 @@ type inbBuilder struct {
 	// used to resolve a commodity's cover_file_id DB key to the stable UUID
 	// written into the archive). #534 / #1451.
 	fileUUIDByDBID map[string]string
+
+	// locUUIDByDBID / areaUUIDByDBID resolve a file's volatile
+	// linked_entity_id (a DB key) to the linked entity's IMMUTABLE UUID, which
+	// is the only identity that round-trips across databases (issue #2235). A
+	// file whose linked id resolves to nothing (dangling link, out of RLS
+	// scope) is dropped rather than emitted with a reference restore cannot
+	// map.
+	locUUIDByDBID  map[string]string
+	areaUUIDByDBID map[string]string
+	// entityFiles / standaloneFiles are the NON-commodity files (issue #2235),
+	// size-resolved and in list order (orphans already dropped). They are
+	// emitted in the dedicated files member, never nested under a commodity.
+	entityFiles     []*entityCandidateFile
+	standaloneFiles []*entityCandidateFile
 }
 
 // candidateFile is a commodity-attached file whose size has already been
@@ -63,6 +77,17 @@ type inbBuilder struct {
 type candidateFile struct {
 	file *models.FileEntity
 	size int64
+}
+
+// entityCandidateFile is a size-resolved NON-commodity file (issue #2235): one
+// linked to a location or an area, or a standalone (unlinked) file. linkedType is
+// "location", "area", or "" for standalone; entityUUID is the linked entity's
+// IMMUTABLE UUID (empty for standalone), already resolved from the row's volatile
+// linked_entity_id.
+type entityCandidateFile struct {
+	candidateFile
+	linkedType string
+	entityUUID string
 }
 
 // pendingFile records a commodity file whose bytes must be streamed into the tar
@@ -101,6 +126,17 @@ type plannedUnassigned struct {
 	pending []pendingFile
 }
 
+// plannedFiles is the in-memory plan for the non-commodity files member (issue
+// #2235): the JSON document (metadata only) plus the ordered file bytes to
+// stream after it. present is false when no location-/area-linked or standalone
+// file is in scope, so the member is omitted entirely (archive byte-stability —
+// see INBFilesName).
+type plannedFiles struct {
+	present bool
+	doc     INBFilesDoc
+	pending []pendingFile
+}
+
 // inbScope captures the selection filter for an export. For whole-class export
 // types every in-scope entity is included; for ExportTypeSelectedItems the
 // allow-sets restrict which locations/areas/commodities round-trip.
@@ -110,6 +146,12 @@ type plannedUnassigned struct {
 // locations, but only emits the areas/commodities the user asked for (and the
 // locations that contain them).
 type inbScope struct {
+	// wholeClass marks one of the four whole-class export types (as opposed to
+	// selected_items). Standalone files have no parent entity that could imply
+	// them into a selection, so they ride along with a whole-class export only —
+	// mirroring the legacy XML exporter's rule (issue #2235).
+	wholeClass bool
+
 	// allLocations/allAreas/allCommodities mean "no per-entity filter for
 	// this class" — include every row of that class that survives the other
 	// filters.
@@ -140,7 +182,7 @@ func (b *inbBuilder) resolveScope() (*inbScope, error) {
 		// formats behaviourally equivalent. The per-type distinction only
 		// mattered for the flat XML sectioning, which the location-centric
 		// JSON format collapses.
-		return &inbScope{allLocations: true, allAreas: true, allCommodities: true}, nil
+		return &inbScope{wholeClass: true, allLocations: true, allAreas: true, allCommodities: true}, nil
 	case models.ExportTypeSelectedItems:
 		return b.resolveSelectedScope()
 	default:
@@ -181,13 +223,22 @@ func (b *inbBuilder) preload() error {
 	}
 	b.locations = locations
 
+	// A file's linked_entity_id is a DB key; the archive may only carry the
+	// immutable UUID (issue #2235), so index both directions up front.
+	b.locUUIDByDBID = make(map[string]string, len(locations))
+	for _, loc := range locations {
+		b.locUUIDByDBID[loc.ID] = loc.UUID
+	}
+
 	areas, err := b.loadAreas()
 	if err != nil {
 		return err
 	}
 	b.areasByLocationID = make(map[string][]*models.Area, len(areas))
+	b.areaUUIDByDBID = make(map[string]string, len(areas))
 	for _, area := range areas {
 		b.areasByLocationID[area.LocationID] = append(b.areasByLocationID[area.LocationID], area)
+		b.areaUUIDByDBID[area.ID] = area.UUID
 	}
 
 	commodities, err := b.loadCommodities()
@@ -205,7 +256,7 @@ func (b *inbBuilder) preload() error {
 		}
 	}
 
-	if err := b.indexCommodityFiles(); err != nil {
+	if err := b.indexFiles(); err != nil {
 		return err
 	}
 	return nil
@@ -250,11 +301,16 @@ func (b *inbBuilder) loadCommodities() ([]*models.Commodity, error) {
 	return commodities, nil
 }
 
-// indexCommodityFiles lists files once and groups the commodity attachments by
-// commodity DB ID and bucket, resolving each file's size up front. Orphan rows
-// (missing/unsized blob) are dropped here so they never appear in the doc or the
-// statistics.
-func (b *inbBuilder) indexCommodityFiles() error {
+// indexFiles lists the group's files ONCE and routes every row to its home:
+// commodity attachments are grouped by commodity DB ID and bucket, while
+// location-/area-linked and standalone files are collected for the dedicated
+// files member (issue #2235). Export artifacts (linked_entity_type "export") are
+// skipped — a backup must never embed previous backups.
+//
+// Orphan rows (missing/unsized blob) are dropped in EVERY branch, so they never
+// reach a document or the statistics. That drop is mandatory: the restore side
+// hard-fails when a declared file reference has no member in the archive.
+func (b *inbBuilder) indexFiles() error {
 	fileReg, err := b.svc.factorySet.FileRegistryFactory.CreateUserRegistry(b.ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to create file registry", err)
@@ -270,36 +326,96 @@ func (b *inbBuilder) indexCommodityFiles() error {
 		if file == nil || file.File == nil {
 			continue
 		}
-		if file.LinkedEntityType != "commodity" {
+		switch file.LinkedEntityType {
+		case "commodity":
+			b.indexCommodityFile(file)
+		case "location", "area":
+			b.indexEntityFile(file)
+		case "":
+			b.indexStandaloneFile(file)
+		default:
+			// "export" (and any future type this build does not know) is not
+			// user inventory — skip it.
 			continue
 		}
-		bucket := file.LinkedEntityMeta
-		if !isCommodityFileBucket(bucket) {
-			continue
-		}
-
-		// Record the DB-id → UUID mapping for EVERY commodity-attached file,
-		// before the orphan-size filter below: the cover-file cross-reference
-		// only needs the stable UUID, and resolving it for a file whose blob
-		// later proves missing is harmless (the restore drops the cover if its
-		// target file never lands).
-		b.fileUUIDByDBID[file.ID] = file.UUID
-
-		size, ok := b.resolveFileSize(file)
-		if !ok {
-			// A missing/unsized blob (orphan row, manual delete) is dropped so
-			// it is excluded from both the doc and the statistics.
-			continue
-		}
-
-		byBucket := b.filesByCommodityID[file.LinkedEntityID]
-		if byBucket == nil {
-			byBucket = map[string][]*candidateFile{}
-			b.filesByCommodityID[file.LinkedEntityID] = byBucket
-		}
-		byBucket[bucket] = append(byBucket[bucket], &candidateFile{file: file, size: size})
 	}
 	return nil
+}
+
+// indexCommodityFile files one commodity attachment under its commodity + bucket.
+// A bucket outside images/invoices/manuals cannot pass model validation, so such
+// a row is skipped rather than emitted.
+func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) {
+	bucket := file.LinkedEntityMeta
+	if !isCommodityFileBucket(bucket) {
+		return
+	}
+
+	// Record the DB-id → UUID mapping for EVERY commodity-attached file,
+	// before the orphan-size filter below: the cover-file cross-reference
+	// only needs the stable UUID, and resolving it for a file whose blob
+	// later proves missing is harmless (the restore drops the cover if its
+	// target file never lands).
+	b.fileUUIDByDBID[file.ID] = file.UUID
+
+	size, ok := b.resolveFileSize(file)
+	if !ok {
+		// A missing/unsized blob (orphan row, manual delete) is dropped so
+		// it is excluded from both the doc and the statistics.
+		return
+	}
+
+	byBucket := b.filesByCommodityID[file.LinkedEntityID]
+	if byBucket == nil {
+		byBucket = map[string][]*candidateFile{}
+		b.filesByCommodityID[file.LinkedEntityID] = byBucket
+	}
+	byBucket[bucket] = append(byBucket[bucket], &candidateFile{file: file, size: size})
+}
+
+// indexEntityFile collects one location-/area-linked file (issue #2235),
+// resolving the row's volatile linked_entity_id to the linked entity's immutable
+// UUID. A file whose linked entity does not resolve (dangling link, out of RLS
+// scope) or whose bucket is outside images/files is skipped rather than emitted
+// with a reference the restore side could not map.
+func (b *inbBuilder) indexEntityFile(file *models.FileEntity) {
+	if !isEntityFileBucket(file.LinkedEntityMeta) {
+		return
+	}
+
+	var entityUUID string
+	switch file.LinkedEntityType {
+	case "location":
+		entityUUID = b.locUUIDByDBID[file.LinkedEntityID]
+	case "area":
+		entityUUID = b.areaUUIDByDBID[file.LinkedEntityID]
+	}
+	if entityUUID == "" {
+		return
+	}
+
+	size, ok := b.resolveFileSize(file)
+	if !ok {
+		return
+	}
+	b.entityFiles = append(b.entityFiles, &entityCandidateFile{
+		candidateFile: candidateFile{file: file, size: size},
+		linkedType:    file.LinkedEntityType,
+		entityUUID:    entityUUID,
+	})
+}
+
+// indexStandaloneFile collects one unlinked file (issue #2235). linkedType and
+// entityUUID stay empty — model validation requires all three link fields empty
+// for a standalone row.
+func (b *inbBuilder) indexStandaloneFile(file *models.FileEntity) {
+	size, ok := b.resolveFileSize(file)
+	if !ok {
+		return
+	}
+	b.standaloneFiles = append(b.standaloneFiles, &entityCandidateFile{
+		candidateFile: candidateFile{file: file, size: size},
+	})
 }
 
 // resolveFileSize returns the byte size to declare for a file member: the
@@ -450,6 +566,125 @@ func (b *inbBuilder) planUnassigned(scope *inbScope) plannedUnassigned {
 		b.stats.CommodityCount++
 	}
 	return plannedUnassigned{present: true, doc: doc, pending: pending}
+}
+
+// planFiles builds the in-memory plan for the non-commodity files member (issue
+// #2235): every location-/area-linked and standalone file in scope, each carrying
+// its own polymorphic link so restore recreates the row with the original
+// linked_entity_type / linked_entity_id / linked_entity_meta.
+//
+// Scope (legacy XML parity): a whole-class export carries every entity file plus
+// the standalone files; a selected_items export carries only the files of the
+// locations/areas the user EXPLICITLY selected, and NO standalone files (they have
+// no parent that could imply them into the selection). See entityFileInScope.
+//
+// Statistics: these files bump FileCount + BinaryDataSize only. ImageCount /
+// InvoiceCount / ManualCount are legacy COMMODITY-scoped counters (see
+// export/types.ExportStats), so a location image must not inflate imageCount.
+func (b *inbBuilder) planFiles(scope *inbScope) plannedFiles {
+	var doc INBFilesDoc
+	var pending []pendingFile
+
+	appendCandidate := func(cand *entityCandidateFile) {
+		ref, pf := b.buildEntityFileRef(cand)
+		doc.Files = append(doc.Files, ref)
+		pending = append(pending, pf)
+		b.stats.FileCount++
+		b.stats.BinaryDataSize += cand.size
+	}
+
+	for _, cand := range b.entityFiles {
+		if !b.entityFileInScope(cand, scope) {
+			continue
+		}
+		appendCandidate(cand)
+	}
+	if scope.wholeClass {
+		for _, cand := range b.standaloneFiles {
+			appendCandidate(cand)
+		}
+	}
+
+	if len(doc.Files) == 0 {
+		return plannedFiles{present: false}
+	}
+	return plannedFiles{present: true, doc: doc, pending: pending}
+}
+
+// entityFileInScope reports whether a location-/area-linked file rides along with
+// this export: always for a whole-class export, and for selected_items only when
+// the user EXPLICITLY selected that location/area.
+//
+// The explicit-only rule is the legacy XML exporter's rule (selectedFileScope is
+// built from the selected item IDs — see service_legacy_xml.go), and the one the
+// user-facing docs promise ("files attached to a location or area you selected come
+// with it"). Scoping on "was the parent EMITTED" instead would silently bundle the
+// files of a parent that is only in the archive because it hosts a selected
+// commodity — e.g. selecting one item would leak the location's lease and floor
+// plans into a shared archive.
+//
+// An explicitly selected location/area is always emitted (inScopeLocations /
+// areasForLocation), so its files can never reference a missing parent document.
+func (*inbBuilder) entityFileInScope(cand *entityCandidateFile, scope *inbScope) bool {
+	if scope.wholeClass {
+		return true
+	}
+	// The row's linked_entity_id is a DB key, and so are the selection sets.
+	switch cand.linkedType {
+	case "location":
+		return scope.locationIDs[cand.file.LinkedEntityID]
+	case "area":
+		return scope.areaIDs[cand.file.LinkedEntityID]
+	}
+	return false
+}
+
+// buildEntityFileRef builds a non-commodity file reference + its pending stream
+// entry (issue #2235). The archive member keeps a <file-uuid> segment for the
+// same anti-collision reason as the commodity layout (two files of one entity can
+// share a basename), and the whole path goes through SanitizeArchivePath — the
+// restore side rejects any member whose sanitized form differs from its raw name.
+func (b *inbBuilder) buildEntityFileRef(cand *entityCandidateFile) (INBEntityFileRef, pendingFile) {
+	file := cand.file
+	name := blobkeys.SanitizeArchivePath(fileMemberName(file))
+
+	var archivePath string
+	if cand.linkedType == "" {
+		archivePath = fmt.Sprintf("%s%s/%s", INBStandaloneFilesPrefix, file.UUID, name)
+	} else {
+		archivePath = fmt.Sprintf("%s%s/%s/%s/%s/%s",
+			INBEntityFilesPrefix, cand.linkedType, cand.entityUUID, file.LinkedEntityMeta, file.UUID, name)
+	}
+	archivePath = blobkeys.SanitizeArchivePath(archivePath)
+
+	ref := INBEntityFileRef{
+		INBFileRef: INBFileRef{
+			ID:           file.UUID,
+			Path:         archivePath,
+			Name:         file.Path,
+			OriginalPath: file.OriginalPath,
+			Extension:    file.Ext,
+			MimeType:     file.MIMEType,
+			Title:        file.Title,
+			Description:  file.Description,
+			Tags:         []string(file.Tags),
+			CreatedAt:    file.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:    file.UpdatedAt.UTC().Format(time.RFC3339),
+		},
+		LinkedEntityType: cand.linkedType,
+		LinkedEntityID:   cand.entityUUID,
+		LinkedEntityMeta: file.LinkedEntityMeta,
+		Type:             string(file.Type),
+		Category:         string(file.Category),
+	}
+	// A standalone file must carry NO link at all — model validation requires
+	// linked_entity_type/id/meta to be empty together.
+	if cand.linkedType == "" {
+		ref.LinkedEntityMeta = ""
+	}
+
+	pf := pendingFile{archivePath: archivePath, blobKey: file.OriginalPath, size: cand.size}
+	return ref, pf
 }
 
 // planLocation builds the in-memory plan for one location: its JSON document
@@ -635,6 +870,7 @@ type inbPlan struct {
 	locations    []plannedLocation
 	manifestLocs []INBManifestLoc
 	unassigned   plannedUnassigned
+	files        plannedFiles
 }
 
 // run returns the Pass-1 plan; it does NOT write anything itself, so writePayload
@@ -661,10 +897,13 @@ func (b *inbBuilder) run() (inbPlan, error) {
 		})
 	}
 
+	unassigned := b.planUnassigned(scope)
+
 	return inbPlan{
 		locations:    planned,
 		manifestLocs: manifestLocs,
-		unassigned:   b.planUnassigned(scope),
+		unassigned:   unassigned,
+		files:        b.planFiles(scope),
 	}, nil
 }
 
@@ -708,6 +947,30 @@ func (b *inbBuilder) writeUnassigned(pu plannedUnassigned) error {
 	return nil
 }
 
+// writeFiles writes the non-commodity files member (issue #2235): its JSON
+// document FIRST, then the referenced file bytes — the same JSON-before-bytes
+// ordering as the location members, so restore registers each file reference
+// before its bytes arrive. A no-op when no such file was in scope (present=false),
+// so the member is omitted and the archive stays byte-stable.
+//
+// Called LAST by writePayload: the restore side resolves each ref's location/area
+// link through the ID mapping, which is only populated as the location documents
+// are applied.
+func (b *inbBuilder) writeFiles(pf plannedFiles) error {
+	if !pf.present {
+		return nil
+	}
+	if err := b.writeJSONMember(INBFilesName, pf.doc); err != nil {
+		return err
+	}
+	for _, f := range pf.pending {
+		if err := b.flushPendingFile(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // flushPendingFile streams one collected file's bytes into the tar. The byte
 // count is informational here — the statistics were already accumulated in Pass
 // 1 from the resolved size, so a stream error fails the export rather than
@@ -730,6 +993,19 @@ var commodityFileBuckets = []string{"images", "invoices", "manuals"}
 func isCommodityFileBucket(meta string) bool {
 	switch meta {
 	case "images", "invoices", "manuals":
+		return true
+	default:
+		return false
+	}
+}
+
+// isEntityFileBucket reports whether a linked_entity_meta value is one of the two
+// location/area attachment buckets (issue #2235). Anything else cannot pass model
+// validation for a location/area file, so such a row is dropped rather than
+// exported into an archive that would fail on restore.
+func isEntityFileBucket(meta string) bool {
+	switch meta {
+	case "images", "files":
 		return true
 	default:
 		return false

--- a/go/backup/export/inb_builder.go
+++ b/go/backup/export/inb_builder.go
@@ -482,8 +482,16 @@ func (b *inbBuilder) resolveFileSize(file *models.FileEntity) (size int64, prese
 		return 0, false, errxtrace.Wrap("failed to read file blob attributes", err,
 			errx.Attrs("file_id", file.ID, "blob_key", file.OriginalPath))
 	}
-	if attrs.Size <= 0 {
-		return 0, false, nil
+	// A ZERO size is a real file, not an orphan: the upload path stores whatever
+	// the multipart part carried and never rejects an empty one, so a 0-byte row
+	// is legitimate — and tar members may be zero-length. Dropping it here would
+	// silently omit the file from the backup and lose the row on a full_replace
+	// restore. Only a negative size is impossible; that is a corrupt attribute
+	// and would produce an invalid tar header, so it fails the export.
+	if attrs.Size < 0 {
+		return 0, false, errxtrace.Wrap("blob reported a negative size",
+			errx.NewSentinel("corrupt blob attributes"),
+			errx.Attrs("file_id", file.ID, "blob_key", file.OriginalPath, "size", attrs.Size))
 	}
 	return attrs.Size, true, nil
 }

--- a/go/backup/export/inb_builder.go
+++ b/go/backup/export/inb_builder.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/shopspring/decimal"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 
 	"github.com/denisvmedia/inventario/backup/export/types"
 	"github.com/denisvmedia/inventario/internal/blobkeys"
@@ -326,17 +328,23 @@ func (b *inbBuilder) indexFiles() error {
 		if file == nil || file.File == nil {
 			continue
 		}
+		// A blob probe that cannot determine a file's state aborts the export:
+		// an incomplete-but-successful backup is worse than a failed one.
+		var indexErr error
 		switch file.LinkedEntityType {
 		case "commodity":
-			b.indexCommodityFile(file)
+			indexErr = b.indexCommodityFile(file)
 		case "location", "area":
-			b.indexEntityFile(file)
+			indexErr = b.indexEntityFile(file)
 		case "":
-			b.indexStandaloneFile(file)
+			indexErr = b.indexStandaloneFile(file)
 		default:
 			// "export" (and any future type this build does not know) is not
 			// user inventory — skip it.
 			continue
+		}
+		if indexErr != nil {
+			return indexErr
 		}
 	}
 	return nil
@@ -345,10 +353,10 @@ func (b *inbBuilder) indexFiles() error {
 // indexCommodityFile files one commodity attachment under its commodity + bucket.
 // A bucket outside images/invoices/manuals cannot pass model validation, so such
 // a row is skipped rather than emitted.
-func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) {
+func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) error {
 	bucket := file.LinkedEntityMeta
 	if !isCommodityFileBucket(bucket) {
-		return
+		return nil
 	}
 
 	// Record the DB-id → UUID mapping for EVERY commodity-attached file,
@@ -358,11 +366,14 @@ func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) {
 	// target file never lands).
 	b.fileUUIDByDBID[file.ID] = file.UUID
 
-	size, ok := b.resolveFileSize(file)
-	if !ok {
-		// A missing/unsized blob (orphan row, manual delete) is dropped so
-		// it is excluded from both the doc and the statistics.
-		return
+	size, present, err := b.resolveFileSize(file)
+	if err != nil {
+		return err
+	}
+	if !present {
+		// A confirmed-missing/unsized blob (orphan row, manual delete) is dropped
+		// so it is excluded from both the doc and the statistics.
+		return nil
 	}
 
 	byBucket := b.filesByCommodityID[file.LinkedEntityID]
@@ -371,6 +382,7 @@ func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) {
 		b.filesByCommodityID[file.LinkedEntityID] = byBucket
 	}
 	byBucket[bucket] = append(byBucket[bucket], &candidateFile{file: file, size: size})
+	return nil
 }
 
 // indexEntityFile collects one location-/area-linked file (issue #2235),
@@ -378,9 +390,9 @@ func (b *inbBuilder) indexCommodityFile(file *models.FileEntity) {
 // UUID. A file whose linked entity does not resolve (dangling link, out of RLS
 // scope) or whose bucket is outside images/files is skipped rather than emitted
 // with a reference the restore side could not map.
-func (b *inbBuilder) indexEntityFile(file *models.FileEntity) {
+func (b *inbBuilder) indexEntityFile(file *models.FileEntity) error {
 	if !isEntityFileBucket(file.LinkedEntityMeta) {
-		return
+		return nil
 	}
 
 	var entityUUID string
@@ -391,58 +403,89 @@ func (b *inbBuilder) indexEntityFile(file *models.FileEntity) {
 		entityUUID = b.areaUUIDByDBID[file.LinkedEntityID]
 	}
 	if entityUUID == "" {
-		return
+		return nil
 	}
 
-	size, ok := b.resolveFileSize(file)
-	if !ok {
-		return
+	size, present, err := b.resolveFileSize(file)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
 	}
 	b.entityFiles = append(b.entityFiles, &entityCandidateFile{
 		candidateFile: candidateFile{file: file, size: size},
 		linkedType:    file.LinkedEntityType,
 		entityUUID:    entityUUID,
 	})
+	return nil
 }
 
 // indexStandaloneFile collects one unlinked file (issue #2235). linkedType and
 // entityUUID stay empty — model validation requires all three link fields empty
 // for a standalone row.
-func (b *inbBuilder) indexStandaloneFile(file *models.FileEntity) {
-	size, ok := b.resolveFileSize(file)
-	if !ok {
-		return
+func (b *inbBuilder) indexStandaloneFile(file *models.FileEntity) error {
+	size, present, err := b.resolveFileSize(file)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
 	}
 	b.standaloneFiles = append(b.standaloneFiles, &entityCandidateFile{
 		candidateFile: candidateFile{file: file, size: size},
 	})
+	return nil
 }
 
 // resolveFileSize returns the byte size to declare for a file member: the
-// recorded SizeBytes when >0, else a single bucket attributes probe. ok=false
-// when the blob is missing/unsized so the caller skips it (orphan).
-func (b *inbBuilder) resolveFileSize(file *models.FileEntity) (int64, bool) {
-	if size := fileSizeHint(file); size > 0 {
+// recorded SizeBytes when >0, else a single bucket attributes probe.
+//
+// present=false means the blob is CONFIRMED absent (an orphan row: a manual
+// delete, a seed fixture that never wrote bytes) — the caller drops the file from
+// both the document and the statistics. Dropping it here is deliberate: a
+// declared member whose bytes never land would abort the WHOLE export in
+// flushPendingFile (the streaming exporter cannot recover once the document
+// referencing the member has been emitted), and would hard-fail every restore of
+// the resulting archive with ErrMissingFileMembers.
+//
+// A non-nil error means the probe could NOT determine the blob's state (a
+// transient bucket failure: network, throttling, a 5xx). That must NOT be
+// conflated with "absent": treating it as an orphan would silently drop a live
+// file and hand the user a backup that looks successful but is incomplete —
+// exactly the failure class this format change exists to eliminate. So it fails
+// the export instead.
+func (b *inbBuilder) resolveFileSize(file *models.FileEntity) (size int64, present bool, err error) {
+	if hint := fileSizeHint(file); hint > 0 {
 		// Trust the recorded size for the tar header, but still confirm the blob
-		// actually exists before committing the file to the plan. A row can carry
-		// a SizeBytes hint while its bytes were never written (seed fixtures) or
-		// were manually deleted; without this probe the missing blob isn't caught
-		// until flushPendingFile streams it, which aborts the WHOLE export instead
-		// of dropping the single orphan here (the streaming exporter cannot recover
-		// once the location JSON referencing the member has already been emitted).
+		// actually exists before committing the file to the plan. Exists reports
+		// (false, nil) only when the blob is definitively missing; any error means
+		// the state is unknown, so it propagates.
 		exists, err := b.bucket.Exists(b.ctx, file.OriginalPath)
-		if err != nil || !exists {
-			return 0, false
+		if err != nil {
+			return 0, false, errxtrace.Wrap("failed to probe file blob", err,
+				errx.Attrs("file_id", file.ID, "blob_key", file.OriginalPath))
 		}
-		return size, true
+		if !exists {
+			return 0, false, nil
+		}
+		return hint, true, nil
 	}
-	// Probe the bucket for the exact size — the tar header needs it. A missing
-	// blob fails the probe and the file is treated as an orphan.
+	// No usable size hint — probe the bucket for the exact size, which the tar
+	// header needs. Only a NotFound is an orphan; every other failure is unknown
+	// state and fails the export.
 	attrs, err := b.bucket.Attributes(b.ctx, file.OriginalPath)
-	if err != nil || attrs.Size <= 0 {
-		return 0, false
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return 0, false, nil
+		}
+		return 0, false, errxtrace.Wrap("failed to read file blob attributes", err,
+			errx.Attrs("file_id", file.ID, "blob_key", file.OriginalPath))
 	}
-	return attrs.Size, true
+	if attrs.Size <= 0 {
+		return 0, false, nil
+	}
+	return attrs.Size, true, nil
 }
 
 // inScopeLocations returns the locations to emit. For selected_items it also

--- a/go/backup/export/inb_probe_test.go
+++ b/go/backup/export/inb_probe_test.go
@@ -1,0 +1,65 @@
+//go:build !legacy_xml_backup
+
+package export
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	_ "github.com/denisvmedia/inventario/internal/fileblob"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// closedBucket returns a bucket whose every operation fails with a
+// FailedPrecondition — the stand-in for a transient storage failure (network
+// blip, throttling, a 5xx), i.e. a probe that cannot determine whether the blob
+// exists. Distinct from a bucket that simply doesn't hold the key, which answers
+// NotFound / (false, nil).
+func closedBucket(c *qt.C) *blob.Bucket {
+	b := must.Must(blob.OpenBucket(context.Background(), "file://inb-probe?memfs=1&create_dir=1"))
+	c.Assert(b.Close(), qt.IsNil)
+	return b
+}
+
+func probeFile(sizeHint int64) *models.FileEntity {
+	f := &models.FileEntity{
+		Title: "probe",
+		File:  &models.File{Path: "probe", Ext: ".jpg", MIMEType: "image/jpeg", SizeBytes: sizeHint},
+	}
+	f.OriginalPath = "t/tenant-a/files/probe.jpg"
+	return f
+}
+
+// TestResolveFileSize_TransientProbeFailureFailsExport pins the difference between
+// "the blob is gone" and "I could not find out". Only the former is an orphan the
+// exporter may silently drop; treating the latter as an orphan would hand the user
+// a backup that reports success while missing live files — the exact silent
+// data-loss class #2235 exists to eliminate. Both probe branches are covered: the
+// Exists path (taken when the row carries a SizeBytes hint) and the Attributes
+// path (taken when it does not).
+func TestResolveFileSize_TransientProbeFailureFailsExport(t *testing.T) {
+	tests := []struct {
+		name     string
+		sizeHint int64 // >0 → Exists probe; 0 → Attributes probe
+	}{
+		{name: "exists probe (size hint present)", sizeHint: 512},
+		{name: "attributes probe (no size hint)", sizeHint: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			b := &inbBuilder{ctx: context.Background(), bucket: closedBucket(c)}
+
+			size, present, err := b.resolveFileSize(probeFile(tt.sizeHint))
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(present, qt.IsFalse)
+			c.Assert(size, qt.Equals, int64(0))
+		})
+	}
+}

--- a/go/backup/export/inb_types.go
+++ b/go/backup/export/inb_types.go
@@ -10,9 +10,16 @@ package export
 // UUID, never a volatile DB primary key, so a backup round-trips stably across
 // databases.
 
-// INBFormatVersion is the manifest `version` for the JSON `.inb` format. Bumped
-// only on a breaking change to the document shapes.
-const INBFormatVersion = "2.0"
+// INBFormatVersion is the manifest `version` for the JSON `.inb` format. The
+// MAJOR component is the compatibility contract the restore side enforces (see
+// backup/restore/processor.checkInbFormatVersion): a reader accepts any archive
+// whose major version it knows and rejects a higher one outright. MINOR bumps
+// are additive-only — a new OPTIONAL member plus an optional manifest pointer,
+// dispatched by member name — so a 2.0 archive still restores unchanged.
+//
+// 2.1 (#2235) added the non-commodity files member (INBFilesName): files linked
+// to locations and areas, plus standalone files.
+const INBFormatVersion = "2.1"
 
 // INBManifestName is the inner-tar member holding the manifest document.
 const INBManifestName = "manifest.json"
@@ -24,9 +31,44 @@ const INBManifestName = "manifest.json"
 // keeping archives with no unassigned items byte-stable (no empty member).
 const INBUnassignedName = "unassigned-commodities.json"
 
-// INBFilesPrefix is the inner-tar path prefix under which commodity file bytes
-// are stored: `files/<loc-slug>/<commodity-uuid>/<bucket>/<sanitized-name>`.
+// INBFilesPrefix is the inner-tar path prefix under which file bytes are stored.
+// A commodity attachment lives at
+// `files/<loc-slug>/<commodity-uuid>/<bucket>/<file-uuid>/<sanitized-name>` —
+// the `<file-uuid>` segment is what keeps two same-named attachments of one
+// commodity from colliding on a single member name.
 const INBFilesPrefix = "files/"
+
+// INBFilesName is the inner-tar member holding the NON-commodity files document
+// (issue #2235): every group file that is not a commodity attachment — files
+// linked to a location or an area, and standalone (unlinked) files. Commodity
+// attachments are NOT repeated here; they stay nested under their commodity
+// (INBCommodity.Images/Invoices/Manuals).
+//
+// The member deliberately lives UNDER the `files/` prefix rather than at the top
+// level. An older reader dispatches any other top-level `*.json` member to its
+// location-document handler, which would fail the whole restore on a document
+// that carries no location — and on full_replace that happens AFTER the existing
+// data was already wiped. Under `files/` the same reader routes it to its file
+// handler, which finds no matching reference, counts one error, and carries on.
+// The depth also guarantees no collision with real file members (always 6
+// segments).
+//
+// Written ONLY when at least one non-commodity file is in scope, so an archive
+// without any stays byte-stable (no empty member, no manifest pointer).
+const INBFilesName = INBFilesPrefix + "_index.json"
+
+// INBEntityFilesPrefix / INBStandaloneFilesPrefix are the archive homes of the
+// non-commodity file BYTES (issue #2235):
+//
+//	files/_entity/<linked-type>/<entity-uuid>/<bucket>/<file-uuid>/<name>
+//	files/_standalone/<file-uuid>/<name>
+//
+// Both keep a `<file-uuid>` segment for the same anti-collision reason as the
+// commodity layout, and both are run through blobkeys.SanitizeArchivePath.
+const (
+	INBEntityFilesPrefix     = INBFilesPrefix + "_entity/"
+	INBStandaloneFilesPrefix = INBFilesPrefix + "_standalone/"
+)
 
 // INBManifest is the top-level descriptor written as manifest.json. It records
 // the format, the signing key the archive was signed with (informational only —
@@ -49,8 +91,14 @@ type INBManifest struct {
 	// unassigned commodities (then the member is absent entirely). Restore
 	// keys off member names and tolerates its absence, so older archives
 	// without this field round-trip unchanged.
-	UnassignedFile string           `json:"unassignedFile,omitempty"`
-	Statistics     INBManifestStats `json:"statistics"`
+	UnassignedFile string `json:"unassignedFile,omitempty"`
+	// FilesFile names the inner-tar member holding the non-commodity files
+	// document (issue #2235), or "" when the archive carries no location-,
+	// area-linked or standalone file (then the member is absent entirely).
+	// Restore keys off member names, so a 2.0 archive without this field
+	// round-trips unchanged.
+	FilesFile  string           `json:"filesFile,omitempty"`
+	Statistics INBManifestStats `json:"statistics"`
 }
 
 // INBSignatureInfo records the signing algorithm + the public key (base64) and
@@ -187,4 +235,39 @@ type INBFileRef struct {
 	Tags         []string `json:"tags,omitempty"`
 	CreatedAt    string   `json:"createdAt,omitempty"`
 	UpdatedAt    string   `json:"updatedAt,omitempty"`
+}
+
+// INBFilesDoc is the document written as the INBFilesName member (issue #2235):
+// the group's NON-commodity files. Commodity attachments are not repeated here —
+// they stay nested under their commodity.
+type INBFilesDoc struct {
+	Files []INBEntityFileRef `json:"files"`
+}
+
+// INBEntityFileRef is a file reference that carries its OWN polymorphic link, so
+// the restore side can recreate the row with the original linked_entity_type /
+// linked_entity_id / linked_entity_meta instead of assuming a commodity
+// attachment (issue #2235).
+//
+// LinkedEntityID is the linked entity's IMMUTABLE UUID — never the volatile
+// files.linked_entity_id DB key, which is regenerated on restore. Restore maps
+// it back to the destination DB id through the location/area ID mapping.
+//
+// Type and Category are carried EXPLICITLY: models.FileCategoryFromContext has
+// no "area" and no standalone branch, so re-deriving them on the restore side
+// would silently rewrite the user-visible category.
+type INBEntityFileRef struct {
+	INBFileRef
+
+	// LinkedEntityType is "location", "area", or "" for a standalone file.
+	LinkedEntityType string `json:"linkedEntityType,omitempty"`
+	// LinkedEntityID is the linked location/area UUID; "" for a standalone file.
+	LinkedEntityID string `json:"linkedEntityId,omitempty"`
+	// LinkedEntityMeta is the location/area bucket ("images" or "files"); "" for
+	// a standalone file.
+	LinkedEntityMeta string `json:"linkedEntityMeta,omitempty"`
+	// Type / Category are the models.FileType / models.FileCategory values as
+	// stored, carried verbatim so they round-trip losslessly.
+	Type     string `json:"type,omitempty"`
+	Category string `json:"category,omitempty"`
 }

--- a/go/backup/export/inb_types.go
+++ b/go/backup/export/inb_types.go
@@ -50,8 +50,12 @@ const INBFilesPrefix = "files/"
 // that carries no location — and on full_replace that happens AFTER the existing
 // data was already wiped. Under `files/` the same reader routes it to its file
 // handler, which finds no matching reference, counts one error, and carries on.
-// The depth also guarantees no collision with real file members (always 6
-// segments).
+//
+// It cannot collide with a file-BYTES member either: every byte member nests at
+// least one level deeper under `files/` — commodity attachments under
+// `<location-slug>/<commodity-uuid>/<bucket>/<file-uuid>/`, non-commodity ones
+// under `_entity/…` or `_standalone/<file-uuid>/` — so no byte member is ever a
+// direct `files/<name>` child, which is exactly what this document is.
 //
 // Written ONLY when at least one non-commodity file is in scope, so an archive
 // without any stays byte-stable (no empty member, no manifest pointer).

--- a/go/backup/export/jsonexport.go
+++ b/go/backup/export/jsonexport.go
@@ -161,7 +161,13 @@ func (s *ExportService) writePayload(
 	if plan.unassigned.present {
 		unassignedMember = INBUnassignedName
 	}
-	if err := builder.writeManifest(plan.manifestLocs, unassignedMember); err != nil {
+	// Same rule for the non-commodity files member (issue #2235): named only
+	// when one will actually be written.
+	filesMember := ""
+	if plan.files.present {
+		filesMember = INBFilesName
+	}
+	if err := builder.writeManifest(plan.manifestLocs, unassignedMember, filesMember); err != nil {
 		return nil, nil, err
 	}
 
@@ -176,6 +182,14 @@ func (s *ExportService) writePayload(
 	// Then the area-less commodities member (issue #1986), same JSON-before-bytes
 	// ordering. Omitted entirely when no unassigned commodity is in scope.
 	if err := builder.writeUnassigned(plan.unassigned); err != nil {
+		return nil, nil, err
+	}
+
+	// Finally the non-commodity files member (issue #2235). It MUST come after
+	// every location member: restore resolves each ref's location/area link
+	// through the ID mapping, which is only populated as the location documents
+	// are applied. Omitted entirely when no such file is in scope.
+	if err := builder.writeFiles(plan.files); err != nil {
 		return nil, nil, err
 	}
 
@@ -267,8 +281,9 @@ func (b *inbBuilder) writeFileMember(archivePath, blobKey string, size int64) (i
 
 // writeManifest emits the manifest.json member from the accumulated stats and
 // the per-location index. unassignedMember names the area-less commodities member
-// (issue #1986), or "" when none is written (then the field is omitted).
-func (b *inbBuilder) writeManifest(locs []INBManifestLoc, unassignedMember string) error {
+// (issue #1986) and filesMember the non-commodity files member (issue #2235);
+// either is "" when that member is not written (then the field is omitted).
+func (b *inbBuilder) writeManifest(locs []INBManifestLoc, unassignedMember, filesMember string) error {
 	manifest := INBManifest{
 		ExportDate:  time.Now().UTC().Format(time.RFC3339),
 		ExportType:  string(b.export.Type),
@@ -282,6 +297,7 @@ func (b *inbBuilder) writeManifest(locs []INBManifestLoc, unassignedMember strin
 		},
 		Locations:      locs,
 		UnassignedFile: unassignedMember,
+		FilesFile:      filesMember,
 		Statistics: INBManifestStats{
 			LocationCount:  b.stats.LocationCount,
 			AreaCount:      b.stats.AreaCount,

--- a/go/backup/inb_entity_files_test.go
+++ b/go/backup/inb_entity_files_test.go
@@ -1,0 +1,774 @@
+//go:build !legacy_xml_backup
+
+package backup_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/backup/restore/processor"
+	"github.com/denisvmedia/inventario/backup/restore/types"
+	"github.com/denisvmedia/inventario/internal/backupsign"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// blobBody builds a deterministic body of exactly size bytes, matching the shape
+// attachCommodityFileFull writes, so a round-trip can compare the restored bytes
+// against the source bytes.
+func blobBody(size int) []byte {
+	return bytes.Repeat([]byte("inventario-blob-chunk"), size/21+1)[:size]
+}
+
+// attachEntityFile creates a FileEntity linked to a LOCATION or an AREA (issue
+// #2235) and writes its blob under the source tenant's namespace. meta is the
+// location/area bucket ("images" or "files"). Returns the file's immutable UUID.
+func (f *inbFixture) attachEntityFile(c *qt.C, linkedType, entityID, meta, name, ext, mime string, size int) string {
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	created := must.Must(fileReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Title:                    name,
+		Type:                     models.FileTypeFromMIME(mime),
+		Category:                 models.FileCategoryFromContext(linkedType, meta, mime),
+		Tags:                     models.StringSlice{},
+		LinkedEntityType:         linkedType,
+		LinkedEntityID:           entityID,
+		LinkedEntityMeta:         meta,
+		File: &models.File{
+			Path:      name,
+			Ext:       ext,
+			MIMEType:  mime,
+			SizeBytes: int64(size),
+		},
+	}))
+	f.writeSourceBlob(c, created, ext, size)
+	return created.UUID
+}
+
+// attachStandaloneFile creates an unlinked FileEntity (all three link fields
+// empty) and writes its blob. Returns the file's immutable UUID.
+func (f *inbFixture) attachStandaloneFile(c *qt.C, name, ext, mime string, size int) string {
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	created := must.Must(fileReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Title:                    name,
+		Type:                     models.FileTypeFromMIME(mime),
+		Category:                 models.FileCategoryFromMIME(mime),
+		Tags:                     models.StringSlice{},
+		File: &models.File{
+			Path:      name,
+			Ext:       ext,
+			MIMEType:  mime,
+			SizeBytes: int64(size),
+		},
+	}))
+	f.writeSourceBlob(c, created, ext, size)
+	return created.UUID
+}
+
+// writeSourceBlob points a freshly created file row at a tenant-namespaced blob
+// key and writes size bytes there, so the exporter can stream it.
+func (f *inbFixture) writeSourceBlob(c *qt.C, file *models.FileEntity, ext string, size int) {
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	blobKey := "t/tenant-a/files/" + file.UUID + ext
+	file.OriginalPath = blobKey
+	must.Must(fileReg.Update(f.ctx, *file))
+
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+	c.Assert(bucket.WriteAll(f.ctx, blobKey, blobBody(size), nil), qt.IsNil)
+}
+
+// locationByUUID / areaByUUID look a restored row up by its immutable UUID (the
+// DB id is regenerated on restore, the UUID is not).
+func (f *inbFixture) locationByUUID(c *qt.C, uuid string) *models.Location {
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	for _, loc := range must.Must(locReg.List(f.ctx)) {
+		if loc != nil && loc.UUID == uuid {
+			return loc
+		}
+	}
+	c.Fatalf("location with UUID %s not found after restore", uuid)
+	return nil
+}
+
+func (f *inbFixture) areaByUUID(c *qt.C, uuid string) *models.Area {
+	areaReg := must.Must(f.fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	for _, area := range must.Must(areaReg.List(f.ctx)) {
+		if area != nil && area.UUID == uuid {
+			return area
+		}
+	}
+	c.Fatalf("area with UUID %s not found after restore", uuid)
+	return nil
+}
+
+// TestINBRoundTrip_NonCommodityFiles is the #2235 fidelity test: files attached to
+// a LOCATION or an AREA, and STANDALONE files, must survive a full export →
+// full_replace restore — metadata, polymorphic link, and blob BYTES. Before the
+// files member they were never exported at all, while full_replace swept them, so
+// a restore permanently destroyed them.
+func TestINBRoundTrip_NonCommodityFiles(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	srcLoc := must.Must(locReg.Get(f.ctx, f.locID))
+	areaReg := must.Must(f.fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	srcArea := must.Must(areaReg.Get(f.ctx, f.areaID))
+
+	const (
+		locImageSize   = 300
+		locFileSize    = 512
+		areaImageSize  = 700
+		areaFileSize   = 128
+		standaloneSize = 4096
+	)
+	commodityImage := f.attachCommodityFile(c, "images", 256)
+	locImage := f.attachEntityFile(c, "location", f.locID, "images", "front-door", ".jpg", "image/jpeg", locImageSize)
+	locDoc := f.attachEntityFile(c, "location", f.locID, "files", "lease", ".pdf", "application/pdf", locFileSize)
+	areaImage := f.attachEntityFile(c, "area", f.areaID, "images", "shelf", ".jpg", "image/jpeg", areaImageSize)
+	areaDoc := f.attachEntityFile(c, "area", f.areaID, "files", "layout", ".pdf", "application/pdf", areaFileSize)
+	standalone := f.attachStandaloneFile(c, "receipt-scan", ".pdf", "application/pdf", standaloneSize)
+
+	blobKey, archive := f.runExport(c, signer)
+
+	// The archive carries the files member, the manifest points at it, and the
+	// document precedes its byte members (restore registers refs from the doc,
+	// then matches each member against them).
+	order, jsons := innerMembers(c, archive)
+	var manifest map[string]any
+	c.Assert(json.Unmarshal(jsons["manifest.json"], &manifest), qt.IsNil)
+	c.Assert(manifest["filesFile"], qt.Equals, "files/_index.json")
+
+	docIdx := memberIndex(c, order, "files/_index.json")
+	for _, uuid := range []string{locImage, locDoc, areaImage, areaDoc, standalone} {
+		byteIdx := memberIndexContaining(c, order, uuid)
+		c.Assert(byteIdx > docIdx, qt.IsTrue,
+			qt.Commentf("file %s bytes must follow files/_index.json; members=%v", uuid, order))
+	}
+	// Every location member precedes the files document: the entity links are
+	// resolved through the ID mapping, which only fills as locations are applied.
+	c.Assert(memberIndex(c, order, "location-home-"+srcLoc.UUID+".json") < docIdx, qt.IsTrue)
+
+	// Statistics: the non-commodity files feed the unified fileCount and
+	// totalFileSize only. imageCount stays a COMMODITY-scoped legacy counter, so
+	// the location/area images must NOT inflate it.
+	stats := manifest["statistics"].(map[string]any)
+	c.Assert(stats["fileCount"], qt.Equals, float64(6))
+	c.Assert(stats["imageCount"], qt.Equals, float64(1))
+	c.Assert(stats["totalFileSize"], qt.Equals,
+		float64(256+locImageSize+locFileSize+areaImageSize+areaFileSize+standaloneSize))
+
+	final, err := restoreInb(c, f, signer, blobKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+	c.Assert(final.ErrorCount, qt.Equals, 0)
+
+	// The restore-side statistics mirror the export-side rule: every restored file
+	// feeds the unified FileCount, while ImageCount stays COMMODITY-scoped — the
+	// location/area images must not inflate the count the operation reports.
+	c.Assert(final.FileCount, qt.Equals, 6)
+	c.Assert(final.ImageCount, qt.Equals, 1)
+	c.Assert(final.InvoiceCount, qt.Equals, 0)
+	c.Assert(final.ManualCount, qt.Equals, 0)
+
+	// Links must point at the RESTORED location/area rows (fresh DB ids), never
+	// at the archive's ids and never at nothing.
+	restoredLoc := f.locationByUUID(c, srcLoc.UUID)
+	restoredArea := f.areaByUUID(c, srcArea.UUID)
+
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+
+	entityCases := []struct {
+		uuid     string
+		linked   string
+		entityID string
+		meta     string
+		path     string
+		ext      string
+		category models.FileCategory
+		fileType models.FileType
+		size     int64
+	}{
+		{locImage, "location", restoredLoc.ID, "images", "front-door", ".jpg", models.FileCategoryImages, models.FileTypeImage, locImageSize},
+		{locDoc, "location", restoredLoc.ID, "files", "lease", ".pdf", models.FileCategoryDocuments, models.FileTypeDocument, locFileSize},
+		{areaImage, "area", restoredArea.ID, "images", "shelf", ".jpg", models.FileCategoryImages, models.FileTypeImage, areaImageSize},
+		{areaDoc, "area", restoredArea.ID, "files", "layout", ".pdf", models.FileCategoryDocuments, models.FileTypeDocument, areaFileSize},
+		{standalone, "", "", "", "receipt-scan", ".pdf", models.FileCategoryDocuments, models.FileTypeDocument, standaloneSize},
+	}
+	for _, tc := range entityCases {
+		c.Run(tc.path, func(c *qt.C) {
+			restored := f.fileByUUID(c, tc.uuid)
+			c.Assert(restored.LinkedEntityType, qt.Equals, tc.linked)
+			c.Assert(restored.LinkedEntityID, qt.Equals, tc.entityID)
+			c.Assert(restored.LinkedEntityMeta, qt.Equals, tc.meta)
+			c.Assert(restored.Category, qt.Equals, tc.category)
+			c.Assert(restored.Type, qt.Equals, tc.fileType)
+			c.Assert(restored.File, qt.IsNotNil)
+			c.Assert(restored.File.Path, qt.Equals, tc.path)
+			c.Assert(restored.File.Ext, qt.Equals, tc.ext)
+			c.Assert(restored.File.SizeBytes, qt.Equals, tc.size)
+
+			// The blob is re-minted under the importing tenant from the file's
+			// immutable UUID, and carries the ORIGINAL bytes.
+			key := "t/tenant-a/files/" + tc.uuid + tc.ext
+			c.Assert(restored.File.OriginalPath, qt.Equals, key)
+			c.Assert(must.Must(bucket.ReadAll(f.ctx, key)), qt.DeepEquals, blobBody(int(tc.size)))
+		})
+	}
+
+	// The commodity attachment still round-trips through its nested ref — the new
+	// member does not duplicate or displace it.
+	c.Assert(f.fileByUUID(c, commodityImage).LinkedEntityType, qt.Equals, "commodity")
+}
+
+// memberIndex returns the position of an exact member name in the archive.
+func memberIndex(c *qt.C, order []string, name string) int {
+	for i, m := range order {
+		if m == name {
+			return i
+		}
+	}
+	c.Fatalf("member %s not found; members=%v", name, order)
+	return -1
+}
+
+// memberIndexContaining returns the position of the first member whose name
+// contains the needle (used to find a file's byte member by its UUID segment).
+func memberIndexContaining(c *qt.C, order []string, needle string) int {
+	for i, m := range order {
+		if m != "files/_index.json" && bytes.Contains([]byte(m), []byte(needle)) {
+			return i
+		}
+	}
+	c.Fatalf("no member containing %s; members=%v", needle, order)
+	return -1
+}
+
+// TestINBExport_NoFilesMemberWhenNone proves an archive whose only files are
+// commodity attachments omits the files member entirely (byte-stability, #2235) —
+// so a backup of a group that never used location/area/standalone files is
+// unchanged from the 2.0 layout apart from the version string.
+func TestINBExport_NoFilesMemberWhenNone(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+	f.attachCommodityFile(c, "images", 128)
+
+	_, archive := f.runExport(c, signer)
+	order, jsons := innerMembers(c, archive)
+	c.Assert(order, qt.Not(qt.Contains), "files/_index.json")
+
+	var manifest map[string]any
+	c.Assert(json.Unmarshal(jsons["manifest.json"], &manifest), qt.IsNil)
+	_, present := manifest["filesFile"]
+	c.Assert(present, qt.IsFalse)
+}
+
+// TestINBExport_DropsEntityFileWithMissingBlob is the orphan-drop parity guard for
+// the new member: a location-linked row whose blob was never written must be
+// dropped from the files document and the statistics, exactly like a commodity
+// attachment. Without it the archive would declare a member it never carries, and
+// EVERY restore of that archive would hard-fail with ErrMissingFileMembers.
+func TestINBExport_DropsEntityFileWithMissingBlob(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	present := f.attachEntityFile(c, "location", f.locID, "images", "front-door", ".jpg", "image/jpeg", 256)
+
+	// A location file with a SizeBytes hint but no blob behind it (manual delete,
+	// seed fixture) — the exporter must drop it.
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	orphan := must.Must(fileReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Title:                    "orphan",
+		Type:                     models.FileTypeImage,
+		Category:                 models.FileCategoryImages,
+		Tags:                     models.StringSlice{},
+		LinkedEntityType:         "location",
+		LinkedEntityID:           f.locID,
+		LinkedEntityMeta:         "images",
+		File:                     &models.File{Path: "ghost", Ext: ".jpg", MIMEType: "image/jpeg", SizeBytes: 512},
+	}))
+	orphan.OriginalPath = "t/tenant-a/files/" + orphan.UUID + ".jpg"
+	must.Must(fileReg.Update(f.ctx, *orphan))
+
+	blobKey, archive := f.runExport(c, signer)
+
+	_, jsons := innerMembers(c, archive)
+	filesDoc := string(jsons["files/_index.json"])
+	c.Assert(filesDoc, qt.Contains, present)
+	c.Assert(filesDoc, qt.Not(qt.Contains), orphan.UUID)
+
+	var manifest map[string]any
+	c.Assert(json.Unmarshal(jsons["manifest.json"], &manifest), qt.IsNil)
+	stats := manifest["statistics"].(map[string]any)
+	c.Assert(stats["fileCount"], qt.Equals, float64(1))
+
+	// The archive is internally consistent, so it still restores cleanly.
+	final, err := restoreInb(c, f, signer, blobKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted)
+	c.Assert(final.ErrorCount, qt.Equals, 0)
+}
+
+// TestINBExport_SelectedItemsExcludesOutOfScopeEntityFiles pins the scope rule for
+// the new member (legacy XML parity): a selected_items export carries the files of
+// the locations/areas the user EXPLICITLY selected, excludes the files of every
+// location/area it did not select, and excludes standalone files — which have no
+// parent that could imply them into the selection.
+func TestINBExport_SelectedItemsExcludesOutOfScopeEntityFiles(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	// A second location + area that are NOT selected, each with an attached file.
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	otherLoc := must.Must(locReg.Create(f.ctx, models.Location{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Name:                     "Office",
+		Address:                  "9 Side St",
+	}))
+	areaReg := must.Must(f.fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	otherArea := must.Must(areaReg.Create(f.ctx, models.Area{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Name:                     "Desk",
+		LocationID:               otherLoc.ID,
+	}))
+
+	selectedLocFile := f.attachEntityFile(c, "location", f.locID, "files", "lease", ".pdf", "application/pdf", 64)
+	selectedAreaFile := f.attachEntityFile(c, "area", f.areaID, "images", "shelf", ".jpg", "image/jpeg", 64)
+	otherLocFile := f.attachEntityFile(c, "location", otherLoc.ID, "files", "other-lease", ".pdf", "application/pdf", 64)
+	otherAreaFile := f.attachEntityFile(c, "area", otherArea.ID, "images", "other-shelf", ".jpg", "image/jpeg", 64)
+	standalone := f.attachStandaloneFile(c, "receipt-scan", ".pdf", "application/pdf", 64)
+
+	srcLoc := must.Must(locReg.Get(f.ctx, f.locID))
+	srcArea := must.Must(areaReg.Get(f.ctx, f.areaID))
+	_, archive := f.runExportRow(c, signer, models.Export{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Type:                     models.ExportTypeSelectedItems,
+		Status:                   models.ExportStatusPending,
+		Description:              "selected backup",
+		SelectedItems: models.ValuerSlice[models.ExportSelectedItem]{
+			{ID: srcLoc.ID, Type: models.ExportSelectedItemTypeLocation, Name: srcLoc.Name},
+			{ID: srcArea.ID, Type: models.ExportSelectedItemTypeArea, Name: srcArea.Name},
+		},
+	})
+
+	_, jsons := innerMembers(c, archive)
+	filesDoc := string(jsons["files/_index.json"])
+	c.Assert(filesDoc, qt.Contains, selectedLocFile)
+	c.Assert(filesDoc, qt.Contains, selectedAreaFile)
+	c.Assert(filesDoc, qt.Not(qt.Contains), otherLocFile)
+	c.Assert(filesDoc, qt.Not(qt.Contains), otherAreaFile)
+	c.Assert(filesDoc, qt.Not(qt.Contains), standalone)
+}
+
+// TestINBExport_SelectedCommodityExcludesImpliedParentFiles is the other half of
+// the scope rule: selecting a single COMMODITY forces its parent location and area
+// documents to be emitted (the item needs a home), but their attached files must
+// NOT ride along. Scoping the entity files on "was the parent emitted" would leak
+// the location's lease and the area's floor plan into an archive the user built to
+// share one item — and would diverge from the legacy XML exporter, which scopes
+// files on the explicitly selected IDs alone.
+func TestINBExport_SelectedCommodityExcludesImpliedParentFiles(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	comReg := must.Must(f.fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+	com := must.Must(comReg.List(f.ctx))[0]
+
+	commodityImage := f.attachCommodityFile(c, "images", 256)
+	// Files of the PARENTS the selection merely implies — neither is selected.
+	f.attachEntityFile(c, "location", f.locID, "files", "lease", ".pdf", "application/pdf", 64)
+	f.attachEntityFile(c, "area", f.areaID, "images", "floor-plan", ".jpg", "image/jpeg", 64)
+
+	_, archive := f.runExportRow(c, signer, models.Export{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{TenantID: "tenant-a", GroupID: f.group.ID, CreatedByUserID: f.user.ID},
+		Type:                     models.ExportTypeSelectedItems,
+		Status:                   models.ExportStatusPending,
+		Description:              "one item",
+		SelectedItems: models.ValuerSlice[models.ExportSelectedItem]{
+			{ID: com.ID, Type: models.ExportSelectedItemTypeCommodity, Name: com.Name},
+		},
+	})
+
+	order, jsons := innerMembers(c, archive)
+
+	// No entity file is in scope, so the member is omitted entirely.
+	c.Assert(order, qt.Not(qt.Contains), "files/_index.json")
+	var manifest map[string]any
+	c.Assert(json.Unmarshal(jsons["manifest.json"], &manifest), qt.IsNil)
+	_, present := manifest["filesFile"]
+	c.Assert(present, qt.IsFalse)
+
+	// The selected commodity's own attachment still rides along, and the
+	// statistics count it alone.
+	stats := manifest["statistics"].(map[string]any)
+	c.Assert(stats["fileCount"], qt.Equals, float64(1))
+	c.Assert(memberIndexContaining(c, order, commodityImage) > 0, qt.IsTrue)
+}
+
+// TestINBRestore_EntityFileMissingMemberFails proves the missing-member guard
+// covers the new refs too: an archive that DECLARES a location-linked file in the
+// files document but never carries its bytes must fail the restore rather than
+// silently lose the file.
+func TestINBRestore_EntityFileMissingMemberFails(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	loc := must.Must(locReg.Get(f.ctx, f.locID))
+
+	filesDoc := types.INBFilesDoc{Files: []types.INBEntityFileRef{{
+		INBFileRef: types.INBFileRef{
+			ID:        "ghost-file-uuid",
+			Path:      "files/_entity/location/" + loc.UUID + "/files/ghost-file-uuid/ghost.pdf",
+			Name:      "ghost",
+			Extension: ".pdf",
+			MimeType:  "application/pdf",
+		},
+		LinkedEntityType: "location",
+		LinkedEntityID:   loc.UUID,
+		LinkedEntityMeta: "files",
+	}}}
+
+	archive := signedArchiveFromInnerTar(c, signer, func(tw *tar.Writer) {
+		writeMember(c, tw, &tar.Header{Name: "manifest.json", Mode: 0o600, Typeflag: tar.TypeReg}, []byte(`{"version":"2.1"}`))
+		writeMember(c, tw, &tar.Header{Name: "location-home.json", Mode: 0o600, Typeflag: tar.TypeReg},
+			must.Must(json.Marshal(inbLocationOnlyDoc(loc))))
+		writeMember(c, tw, &tar.Header{Name: "files/_index.json", Mode: 0o600, Typeflag: tar.TypeReg},
+			must.Must(json.Marshal(filesDoc)))
+		// NOTE: the declared byte member is intentionally absent.
+	})
+
+	key := "t/tenant-a/restores/missing-entity-member.inb"
+	writeArchive(c, f, key, archive)
+
+	final, err := restoreInb(c, f, signer, key)
+	c.Assert(err, qt.ErrorIs, processor.ErrMissingFileMembers)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusFailed)
+}
+
+// TestINBRestore_EntityFileUnmappedLinkIsCounted proves a files-document ref whose
+// linked location never landed is DROPPED with a counted error rather than
+// persisted with a dangling linked_entity_id. The restore itself still completes.
+func TestINBRestore_EntityFileUnmappedLinkIsCounted(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	loc := must.Must(locReg.Get(f.ctx, f.locID))
+
+	const memberPath = "files/_entity/location/no-such-location/files/dangling-uuid/x.pdf"
+	filesDoc := types.INBFilesDoc{Files: []types.INBEntityFileRef{{
+		INBFileRef: types.INBFileRef{
+			ID:        "dangling-uuid",
+			Path:      memberPath,
+			Name:      "x",
+			Extension: ".pdf",
+			MimeType:  "application/pdf",
+		},
+		LinkedEntityType: "location",
+		LinkedEntityID:   "no-such-location", // never emitted in this archive
+		LinkedEntityMeta: "files",
+	}}}
+
+	archive := signedArchiveFromInnerTar(c, signer, func(tw *tar.Writer) {
+		writeMember(c, tw, &tar.Header{Name: "manifest.json", Mode: 0o600, Typeflag: tar.TypeReg}, []byte(`{"version":"2.1"}`))
+		writeMember(c, tw, &tar.Header{Name: "location-home.json", Mode: 0o600, Typeflag: tar.TypeReg},
+			must.Must(json.Marshal(inbLocationOnlyDoc(loc))))
+		writeMember(c, tw, &tar.Header{Name: "files/_index.json", Mode: 0o600, Typeflag: tar.TypeReg},
+			must.Must(json.Marshal(filesDoc)))
+		writeMember(c, tw, &tar.Header{Name: memberPath, Mode: 0o600, Typeflag: tar.TypeReg}, []byte("pdf-bytes"))
+	})
+
+	key := "t/tenant-a/restores/dangling-link.inb"
+	writeArchive(c, f, key, archive)
+
+	final, err := restoreInb(c, f, signer, key)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted)
+	c.Assert(final.ErrorCount, qt.Equals, 1)
+
+	// No row was created for the dangling reference.
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	for _, file := range must.Must(fileReg.List(f.ctx)) {
+		c.Assert(file.UUID, qt.Not(qt.Equals), "dangling-uuid")
+	}
+}
+
+// versionGateArchive builds a minimal signed archive (manifest + one location
+// document) whose manifest body is exactly manifestJSON, and stores it.
+func versionGateArchive(c *qt.C, f *inbFixture, signer *backupsign.Signer, manifestJSON string) string {
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	loc := must.Must(locReg.Get(f.ctx, f.locID))
+
+	archive := signedArchiveFromInnerTar(c, signer, func(tw *tar.Writer) {
+		writeMember(c, tw, &tar.Header{Name: "manifest.json", Mode: 0o600, Typeflag: tar.TypeReg}, []byte(manifestJSON))
+		writeMember(c, tw, &tar.Header{Name: "location-home.json", Mode: 0o600, Typeflag: tar.TypeReg},
+			must.Must(json.Marshal(inbLocationOnlyDoc(loc))))
+	})
+
+	key := "t/tenant-a/restores/version-gate.inb"
+	writeArchive(c, f, key, archive)
+	return key
+}
+
+// TestINBRestore_SupportedFormatVersions is the compatibility half of the version
+// contract (#2235): a reader accepts every archive whose MAJOR version it knows —
+// including a 2.0 archive (no files member, no filesFile field) and an archive
+// with no version at all. MINOR bumps are additive-only, so a future 2.x also
+// restores here rather than being rejected.
+func TestINBRestore_SupportedFormatVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+	}{
+		{name: "absent version", manifest: `{}`},
+		{name: "2.0 archive without files member", manifest: `{"version":"2.0"}`},
+		{name: "current 2.1 archive", manifest: `{"version":"2.1"}`},
+		{name: "future minor of a known major", manifest: `{"version":"2.9"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			signer := testSigner(c)
+			f := newInbFixture(c)
+
+			key := versionGateArchive(c, f, signer, tt.manifest)
+
+			final, err := restoreInb(c, f, signer, key)
+			c.Assert(err, qt.IsNil)
+			c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+		})
+	}
+}
+
+// TestINBRestore_RejectsUnsupportedFormatMajor is the unhappy twin: an archive
+// declaring a MAJOR version above what this build knows is rejected outright —
+// and, crucially, BEFORE prepareRestore, so a full_replace leaves the existing
+// data intact instead of failing on a database it has already wiped.
+func TestINBRestore_RejectsUnsupportedFormatMajor(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	key := versionGateArchive(c, f, signer, `{"version":"3.0"}`)
+
+	final, err := restoreInb(c, f, signer, key)
+	c.Assert(err, qt.ErrorIs, processor.ErrUnsupportedFormatVersion)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusFailed)
+
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	c.Assert(must.Must(locReg.List(f.ctx)), qt.HasLen, 1)
+}
+
+// TestINBRestore_OldArchiveWithCommodityFileStillRestores is the backward-compat
+// contract in full: a 2.0 archive (no files member, no filesFile manifest field)
+// restores its commodity attachment on the 2.1 reader exactly as before, with no
+// counted errors.
+func TestINBRestore_OldArchiveWithCommodityFileStillRestores(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	comReg := must.Must(f.fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+	com := must.Must(comReg.List(f.ctx))[0]
+	areaReg := must.Must(f.fs.AreaRegistryFactory.CreateUserRegistry(f.ctx))
+	area := must.Must(areaReg.Get(f.ctx, f.areaID))
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	loc := must.Must(locReg.Get(f.ctx, f.locID))
+
+	const memberPath = "files/home/legacy/images/legacy-file-uuid/photo.jpg"
+	body := []byte("legacy-jpeg-bytes")
+	doc := types.INBLocationDoc{
+		Location: types.INBLocation{ID: loc.UUID, Name: loc.Name, Address: loc.Address},
+		Areas:    []types.INBArea{{ID: area.UUID, Name: area.Name, LocationID: loc.UUID}},
+		Commodities: []types.INBCommodity{{
+			ID:                    com.UUID,
+			Name:                  com.Name,
+			ShortName:             com.ShortName,
+			Type:                  string(com.Type),
+			AreaID:                area.UUID,
+			Count:                 com.Count,
+			Status:                string(com.Status),
+			OriginalPriceCurrency: string(com.OriginalPriceCurrency),
+			Draft:                 com.Draft,
+			Images: []types.INBFileRef{{
+				ID:        "legacy-file-uuid",
+				Path:      memberPath,
+				Name:      "photo",
+				Extension: ".jpg",
+				MimeType:  "image/jpeg",
+			}},
+		}},
+	}
+
+	archive := signedArchiveFromInnerTar(c, signer, func(tw *tar.Writer) {
+		writeMember(c, tw, &tar.Header{Name: "manifest.json", Mode: 0o600, Typeflag: tar.TypeReg}, []byte(`{"version":"2.0"}`))
+		writeMember(c, tw, &tar.Header{Name: "location-home.json", Mode: 0o600, Typeflag: tar.TypeReg}, must.Must(json.Marshal(doc)))
+		writeMember(c, tw, &tar.Header{Name: memberPath, Mode: 0o600, Typeflag: tar.TypeReg}, body)
+	})
+
+	key := "t/tenant-a/restores/legacy-2-0.inb"
+	writeArchive(c, f, key, archive)
+
+	final, err := restoreInb(c, f, signer, key)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+	c.Assert(final.ErrorCount, qt.Equals, 0)
+
+	restored := f.fileByUUID(c, "legacy-file-uuid")
+	c.Assert(restored.LinkedEntityType, qt.Equals, "commodity")
+	c.Assert(restored.LinkedEntityMeta, qt.Equals, "images")
+	c.Assert(restored.Category, qt.Equals, models.FileCategoryImages)
+
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+	c.Assert(must.Must(bucket.ReadAll(f.ctx, "t/tenant-a/files/legacy-file-uuid.jpg")), qt.DeepEquals, body)
+}
+
+// TestINBRestore_FullReplaceReplacesAreaLessCommodity is the #2236 end-to-end
+// guard. A pre-existing area-less commodity (#1986) is not reachable through the
+// location → area recursion clearExistingData used to rely on, so it survived the
+// wipe; full_replace then re-created the archive's copy with the SAME preserved
+// UUID, colliding on the unique index — a counted error that dropped the whole
+// item AND cascaded "references unmapped commodity" onto each of its files, while
+// the restore still reported Completed. After the fix the survivor is swept, so the
+// restore is clean and the item lands exactly once.
+func TestINBRestore_FullReplaceReplacesAreaLessCommodity(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	looseUUID := f.addUnassignedCommodity(c, "Loose Gadget")
+	blobKey, _ := f.runExport(c, signer)
+
+	// The archive already contains the area-less commodity, and the target DB
+	// still holds the original row with the same UUID — exactly the collision.
+	final, err := restoreInb(c, f, signer, blobKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+	c.Assert(final.ErrorCount, qt.Equals, 0)
+
+	comReg := must.Must(f.fs.CommodityRegistryFactory.CreateUserRegistry(f.ctx))
+	var matches int
+	for _, com := range must.Must(comReg.List(f.ctx)) {
+		if com.UUID == looseUUID {
+			matches++
+		}
+	}
+	c.Assert(matches, qt.Equals, 1)
+}
+
+// TestINBRestore_EntityFilesUnderMergeStrategies pins the merge matrix for the new
+// files: an archive restored over rows that already carry the same UUIDs must land
+// each file exactly once, still linked to its location (or still standalone) — and
+// with no counted errors, since merge seeds the ID mapping from the existing rows.
+func TestINBRestore_EntityFilesUnderMergeStrategies(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy types.RestoreStrategy
+	}{
+		{name: "merge_add skips the existing file", strategy: types.RestoreStrategyMergeAdd},
+		{name: "merge_update re-points the existing file", strategy: types.RestoreStrategyMergeUpdate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			signer := testSigner(c)
+			f := newInbFixture(c)
+
+			locFile := f.attachEntityFile(c, "location", f.locID, "images", "front-door", ".jpg", "image/jpeg", 256)
+			standalone := f.attachStandaloneFile(c, "receipt-scan", ".pdf", "application/pdf", 128)
+
+			blobKey, _ := f.runExport(c, signer)
+
+			final, err := restoreInbWithOptions(c, f, signer, blobKey, models.RestoreOptions{
+				Strategy: string(tt.strategy),
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+			c.Assert(final.ErrorCount, qt.Equals, 0)
+
+			c.Assert(f.fileByUUID(c, locFile).LinkedEntityType, qt.Equals, "location")
+			c.Assert(f.fileByUUID(c, standalone).LinkedEntityType, qt.Equals, "")
+			c.Assert(f.countFilesWithUUID(c, locFile), qt.Equals, 1)
+			c.Assert(f.countFilesWithUUID(c, standalone), qt.Equals, 1)
+		})
+	}
+}
+
+// TestINBRestore_DryRunDoesNotPersistEntityFiles: a dry-run consumes the files
+// member and its byte members (so the missing-member check stays satisfied) but
+// creates no row. Note it DOES count "references unmapped location" errors, which
+// is the pre-existing dry-run behaviour for every linked file — nothing is
+// persisted, so there is no ID mapping to resolve a link against.
+func TestINBRestore_DryRunDoesNotPersistEntityFiles(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	f.attachEntityFile(c, "location", f.locID, "images", "front-door", ".jpg", "image/jpeg", 256)
+	f.attachStandaloneFile(c, "receipt-scan", ".pdf", "application/pdf", 128)
+
+	blobKey, _ := f.runExport(c, signer)
+
+	// Snapshot AFTER the export — it creates the archive's own artifact row.
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	before := len(must.Must(fileReg.List(f.ctx)))
+
+	final, err := restoreInbWithOptions(c, f, signer, blobKey, models.RestoreOptions{
+		Strategy: string(types.RestoreStrategyFullReplace),
+		DryRun:   true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted)
+
+	// No new file rows.
+	c.Assert(must.Must(fileReg.List(f.ctx)), qt.HasLen, before)
+}
+
+// countFilesWithUUID counts the file rows carrying a given immutable UUID — 1 for
+// a correct restore, >1 would mean the row was duplicated instead of matched.
+func (f *inbFixture) countFilesWithUUID(c *qt.C, uuid string) int {
+	fileReg := must.Must(f.fs.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	var n int
+	for _, file := range must.Must(fileReg.List(f.ctx)) {
+		if file != nil && file.UUID == uuid {
+			n++
+		}
+	}
+	return n
+}
+
+// inbLocationOnlyDoc builds a location document with no areas/commodities, for
+// hand-built archives that only need the location to exist so an entity file can
+// link to it.
+func inbLocationOnlyDoc(loc *models.Location) types.INBLocationDoc {
+	return types.INBLocationDoc{
+		Location: types.INBLocation{ID: loc.UUID, Name: loc.Name, Address: loc.Address},
+	}
+}
+
+// writeArchive stores a hand-built .inb archive in the fixture's bucket.
+func writeArchive(c *qt.C, f *inbFixture, key string, archive []byte) {
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+	c.Assert(bucket.WriteAll(f.ctx, key, archive, nil), qt.IsNil)
+}

--- a/go/backup/inb_entity_files_test.go
+++ b/go/backup/inb_entity_files_test.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -571,6 +572,29 @@ func TestINBRestore_RejectsUnsupportedFormatMajor(t *testing.T) {
 
 	final, err := restoreInb(c, f, signer, key)
 	c.Assert(err, qt.ErrorIs, processor.ErrUnsupportedFormatVersion)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusFailed)
+
+	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))
+	c.Assert(must.Must(locReg.List(f.ctx)), qt.HasLen, 1)
+}
+
+// TestINBRestore_RejectsOversizedManifest closes the bypass around the version
+// gate: an implausibly large manifest must NOT be waved through as "no version to
+// gate on". If it were, a crafted archive could pad its manifest past the cap,
+// skip the MAJOR check entirely, and reach prepareRestore — where full_replace
+// wipes the target before a format this build cannot read is ever parsed. The
+// pre-existing location must survive.
+func TestINBRestore_RejectsOversizedManifest(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	// A syntactically valid manifest padded past the 4 MiB pre-scan cap.
+	manifest := `{"version":"3.0","pad":"` + strings.Repeat("A", 5<<20) + `"}`
+	key := versionGateArchive(c, f, signer, manifest)
+
+	final, err := restoreInb(c, f, signer, key)
+	c.Assert(err, qt.ErrorIs, processor.ErrJSONDocTooLarge)
 	c.Assert(final.Status, qt.Equals, models.RestoreStatusFailed)
 
 	locReg := must.Must(f.fs.LocationRegistryFactory.CreateUserRegistry(f.ctx))

--- a/go/backup/inb_entity_files_test.go
+++ b/go/backup/inb_entity_files_test.go
@@ -578,6 +578,50 @@ func TestINBRestore_RejectsUnsupportedFormatMajor(t *testing.T) {
 	c.Assert(must.Must(locReg.List(f.ctx)), qt.HasLen, 1)
 }
 
+// TestINBRoundTrip_EmptyFileSurvives pins that a legitimately EMPTY file is
+// backed up, not silently dropped. The upload path stores whatever the multipart
+// part carried and never rejects a 0-byte one, so an empty row is a real user
+// file. The exporter used to treat a zero size as "orphan" and skip it — which,
+// because full_replace sweeps every file first, meant the row was destroyed by a
+// restore. Tar members may be zero-length; the file rides along like any other.
+func TestINBRoundTrip_EmptyFileSurvives(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	// Zero-byte rows on both new paths: linked to an entity, and standalone.
+	emptyLocDoc := f.attachEntityFile(c, "location", f.locID, "files", "blank-form", ".pdf", "application/pdf", 0)
+	emptyStandalone := f.attachStandaloneFile(c, "empty-note", ".txt", "text/plain", 0)
+
+	blobKey, _ := f.runExport(c, signer)
+
+	final, err := restoreInb(c, f, signer, blobKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+	c.Assert(final.ErrorCount, qt.Equals, 0)
+
+	bucket := must.Must(blob.OpenBucket(f.ctx, inbUploadLocation))
+	defer bucket.Close()
+
+	for _, tc := range []struct {
+		uuid string
+		ext  string
+	}{
+		{uuid: emptyLocDoc, ext: ".pdf"},
+		{uuid: emptyStandalone, ext: ".txt"},
+	} {
+		c.Run(tc.uuid, func(c *qt.C) {
+			restored := f.fileByUUID(c, tc.uuid)
+			c.Assert(restored.File, qt.IsNotNil)
+			c.Assert(restored.File.SizeBytes, qt.Equals, int64(0))
+
+			key := "t/tenant-a/files/" + tc.uuid + tc.ext
+			c.Assert(restored.File.OriginalPath, qt.Equals, key)
+			c.Assert(must.Must(bucket.ReadAll(f.ctx, key)), qt.HasLen, 0)
+		})
+	}
+}
+
 // TestINBRestore_RejectsOversizedManifest closes the bypass around the version
 // gate: an implausibly large manifest must NOT be waved through as "no version to
 // gate on". If it were, a crafted archive could pad its manifest past the cap,

--- a/go/backup/inb_roundtrip_test.go
+++ b/go/backup/inb_roundtrip_test.go
@@ -49,11 +49,12 @@ func testSigner(c *qt.C) *backupsign.Signer {
 // inbFixture builds an in-memory factory seeded with a tenant/user/group and a
 // location → area → commodity, returning the factory plus a user/group context.
 type inbFixture struct {
-	fs    *registry.FactorySet
-	ctx   context.Context
-	user  *models.User
-	group *models.LocationGroup
-	locID string
+	fs     *registry.FactorySet
+	ctx    context.Context
+	user   *models.User
+	group  *models.LocationGroup
+	locID  string
+	areaID string
 }
 
 func newInbFixture(c *qt.C) *inbFixture {
@@ -109,7 +110,7 @@ func newInbFixture(c *qt.C) *inbFixture {
 		Draft: true,
 	}))
 
-	return &inbFixture{fs: fs, ctx: uctx, user: user, group: group, locID: loc.ID}
+	return &inbFixture{fs: fs, ctx: uctx, user: user, group: group, locID: loc.ID, areaID: area.ID}
 }
 
 // attachCommodityFile creates an image FileEntity linked to the fixture's first
@@ -323,7 +324,7 @@ func TestINBExport_ContainerStructure(t *testing.T) {
 	// Manifest records the format, signature info, and stats.
 	var manifest map[string]any
 	c.Assert(json.Unmarshal(manifestData, &manifest), qt.IsNil)
-	c.Assert(manifest["version"], qt.Equals, "2.0")
+	c.Assert(manifest["version"], qt.Equals, "2.1")
 	c.Assert(manifest["format"], qt.Equals, "json")
 	sigBlock := manifest["signature"].(map[string]any)
 	c.Assert(sigBlock["algorithm"], qt.Equals, backupsign.Algorithm)

--- a/go/backup/restore/README.md
+++ b/go/backup/restore/README.md
@@ -35,7 +35,7 @@ Every file reference carries its linked entity's **immutable UUID**, never a DB 
 
 ### 2. Memory-Safe Streaming
 - The verified payload is inflated and walked member-by-member; file bytes are streamed straight into blob storage, never buffered.
-- Per-member and total caps bound a hostile archive (`maxInbMembers`, `maxInbTotalUncompress` = 8 GiB, `maxLocationDocBytes` = 32 MiB).
+- Per-member and total caps bound a hostile archive (`maxInbMembers`, `maxInbTotalUncompress` = 8 GiB, `maxJSONDocBytes` = 32 MiB for every JSON document member, `maxInbManifestBytes` = 4 MiB for the manifest pre-scan).
 
 ### 3. Detailed Step Logging
 - Step-by-step logging of the restoration process with status updates per phase and per entity
@@ -201,7 +201,7 @@ options := types.RestoreOptions{
 
 ## Error Handling
 - **Graceful Degradation**: most per-item failures are tolerated and counted in `RestoreStats.Errors`
-- **Hard Failures**: signature verification failure, framing violations, missing file members (`ErrMissingFileMembers`), oversized members (`ErrLocationDocTooLarge`), and malformed entity fields (`ErrMalformedEntity`) abort the whole restore
+- **Hard Failures**: signature verification failure, framing violations, missing file members (`ErrMissingFileMembers`), oversized JSON members (`ErrJSONDocTooLarge` — including an implausibly large manifest, which must never let an archive skip the version gate), an unsupported format MAJOR (`ErrUnsupportedFormatVersion`), and malformed entity fields (`ErrMalformedEntity`) abort the whole restore
 - **Status Tracking**: failed restores marked with a detailed error message
 
 ## Performance Considerations

--- a/go/backup/restore/README.md
+++ b/go/backup/restore/README.md
@@ -16,7 +16,15 @@ The decode body splits by build tag; everything around it is format-agnostic.
 - `service.go` — the thin `RestoreService` that constructs a processor.
 - `worker.go`, `status_querier.go` — background worker and a query-only status helper.
 
-An `.inb` archive (see the `export` package) is an outer tar of `payload.tar.gz.sig` + `payload.tar.gz`. On restore the payload is spooled to a temp file while a streaming SHA-256 digest is computed, the signature is verified **before** inflate, and only then is the inner tar walked: per-location JSON members recreate entities, and `files/...` members stream their bytes into a re-minted tenant blob key. A bad/missing signature, a non-`.inb` upload, or any framing violation fails the restore hard.
+An `.inb` archive (see the `export` package) is an outer tar of `payload.tar.gz.sig` + `payload.tar.gz`. On restore the payload is spooled to a temp file while a streaming SHA-256 digest is computed, the signature is verified **before** inflate, the manifest's format version is gated, and only then is the inner tar walked: per-location JSON members recreate entities, `files/_index.json` registers the non-commodity files, and `files/...` members stream their bytes into a re-minted tenant blob key. A bad/missing signature, a non-`.inb` upload, or any framing violation fails the restore hard.
+
+### Format-version gate
+
+Before `prepareRestore` runs — i.e. before a `full_replace` wipes anything — `checkInbFormatVersion` reads the manifest (always the first member) and rejects any archive whose **MAJOR** version is above `maxSupportedInbMajor` with `ErrUnsupportedFormatVersion`. An absent version and any known-major MINOR are accepted, which is what lets a 2.0 archive restore unchanged on a 2.1 reader. Running the gate before the wipe is deliberate: a version rejection must never leave the operator with an emptied database.
+
+### Linked-entity resolution
+
+Every file reference carries its linked entity's **immutable UUID**, never a DB key. At byte time the walker maps it to the destination DB id through `IDMapping` (`Commodities` / `Locations` / `Areas`); a standalone file resolves to no link at all (#2235). A reference whose entity never landed is dropped with a counted error rather than persisted with a dangling `linked_entity_id`. This is why the exporter emits `files/_index.json` after every location member — the mapping only fills as the location documents are applied.
 
 ## Key Features
 
@@ -34,7 +42,8 @@ An `.inb` archive (see the `export` package) is an outer tar of `payload.tar.gz.
 - Real-time progress tracking persisted as restore steps
 
 ### 4. File Data Restoration
-- Commodity file members are streamed into a re-minted tenant blob key (never the archive path or source key)
+- File members are streamed into a re-minted tenant blob key, `t/<tenant>/files/<file-uuid><ext>` (never the archive path or source key), so an archive always lands in the importing tenant's namespace
+- Commodity attachments, location-/area-linked files and standalone files all round-trip, each recreated with its original `linked_entity_type` / `linked_entity_id` / `linked_entity_meta` (#2235)
 - A declared file reference whose member never arrives fails the restore (`ErrMissingFileMembers`) rather than silently dropping data
 - Cover-photo cross-references (#1451) are patched after all files are restored
 
@@ -74,7 +83,7 @@ Background worker that manages restore processing:
 - Configurable poll interval (default: 10 seconds) and max-concurrency (default: 1)
 
 #### `.inb` Schemas (`types/types_inb.go`)
-Decoded counterparts to the export-side `.inb` documents (kept in sync with `backup/export/inb_types.go`): `INBLocationDoc`, `INBLocation`, `INBArea`, `INBCommodity`, `INBFileRef`, `INBUnassignedDoc`, plus the member-name constants `INBManifestMember`, `INBUnassignedMember`.
+Decoded counterparts to the export-side `.inb` documents (kept in sync with `backup/export/inb_types.go`): `INBLocationDoc`, `INBLocation`, `INBArea`, `INBCommodity`, `INBFileRef`, `INBUnassignedDoc`, `INBFilesDoc`, `INBEntityFileRef`, `INBFileLink`, plus the member-name constants `INBManifestMember`, `INBUnassignedMember`, `INBFilesMember`.
 
 #### Restore Types (`types/types.go`)
 - **RestoreOptions**: `Strategy`, `IncludeFileData`, `DryRun`
@@ -90,6 +99,14 @@ types.RestoreStrategyFullReplace // "full_replace"
 - **Behavior**: Clears existing data before restoration
 - **Use Case**: Complete replacement from backup
 - **Risk**: All current data is lost
+
+`clearExistingData` runs three passes, in order (see `processor_shared.go`):
+
+1. `DeleteLocationRecursive` per location — cascades areas, their commodities, and the files of that subtree.
+2. `DeleteCommodityRecursive` per **surviving** commodity. Commodities are enumerated directly because `commodity.area_id` is nullable since #1986: an area-less commodity is unreachable through the location → area recursion, so before #2236 its row survived the wipe while the file sweep still deleted its attachments — a zombie item with no files, whose preserved UUID then collided with the archive's own copy on re-create.
+3. A type-agnostic sweep of the remaining file rows + blobs, catching standalone files and any orphan.
+
+Files with `linked_entity_type = "export"` are skipped by the sweep: that is the archive being restored, plus the backup history — not user inventory.
 
 #### Merge Add Strategy
 ```go

--- a/go/backup/restore/processor/clear_existing_data_test.go
+++ b/go/backup/restore/processor/clear_existing_data_test.go
@@ -140,3 +140,93 @@ func TestClearExistingData_SweepsAreaAndLocationLinkedFiles(t *testing.T) {
 	c.Assert(must.Must(registrySet.FileRegistry.Get(ctx, exportFile.ID)), qt.IsNotNil)
 	c.Assert(must.Must(b.Exists(ctx, exportBlobKey)), qt.IsTrue)
 }
+
+// TestClearExistingData_SweepsAreaLessCommodities pins #2236: commodity.area_id is
+// nullable since #1986, so an area-less commodity is NOT reachable through the
+// location → area recursion. Before the direct commodity enumeration, its row
+// survived a full_replace wipe while the type-agnostic file sweep still deleted
+// its attachments — leaving a zombie item with no files, whose preserved UUID then
+// collided with the archive's own copy on re-create. full_replace must really mean
+// full replace: after clearExistingData no commodity of any kind may remain.
+func TestClearExistingData_SweepsAreaLessCommodities(t *testing.T) {
+	c := qt.New(t)
+
+	tempDir := c.TempDir()
+	uploadLocation := clearDataUploadLocation(tempDir)
+
+	factorySet := memory.NewFactorySet()
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "test-user-id"},
+			TenantID: "test-tenant-id",
+		},
+		Email: "test@example.com",
+		Name:  "Test User",
+	}
+	user := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+	ctx := appctx.WithUser(context.Background(), user)
+	registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+	location := must.Must(registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"}))
+	area := must.Must(registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID}))
+
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+
+	// An area-BOUND commodity (reached by the location recursion) and an
+	// area-LESS one (#1986 — reachable only by the direct enumeration).
+	boundCommodity := must.Must(registrySet.CommodityRegistry.Create(ctx, models.Commodity{
+		Name:                  "Bound TV",
+		ShortName:             "btv",
+		Type:                  models.CommodityTypeElectronics,
+		AreaID:                new(area.ID),
+		Count:                 1,
+		Status:                models.CommodityStatusInUse,
+		OriginalPriceCurrency: "USD",
+		Draft:                 true,
+	}))
+	looseCommodity := must.Must(registrySet.CommodityRegistry.Create(ctx, models.Commodity{
+		Name:      "Loose Gadget",
+		ShortName: "lg",
+		Type:      models.CommodityTypeElectronics,
+		// AreaID left nil — the #2236 survivor.
+		Count:                 1,
+		Status:                models.CommodityStatusInUse,
+		OriginalPriceCurrency: "USD",
+		Draft:                 true,
+	}))
+	c.Assert(looseCommodity.AreaID, qt.IsNil)
+
+	looseBlobKey := "loose-photo.jpg"
+	c.Assert(b.WriteAll(ctx, looseBlobKey, []byte("loose jpeg"), nil), qt.IsNil)
+	looseFile := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryImages,
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   looseCommodity.ID,
+		LinkedEntityMeta: "images",
+		File: &models.File{
+			Path:         "loose-photo",
+			OriginalPath: looseBlobKey,
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+		},
+	}))
+
+	entityService := services.NewEntityService(factorySet, uploadLocation)
+	proc := NewRestoreOperationProcessor("test-restore-op", factorySet, entityService, uploadLocation, nil)
+
+	c.Assert(proc.clearExistingData(ctx), qt.IsNil)
+
+	// No commodity of either kind survives.
+	c.Assert(must.Must(registrySet.CommodityRegistry.List(ctx)), qt.HasLen, 0)
+	_, err := registrySet.CommodityRegistry.Get(ctx, boundCommodity.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	_, err = registrySet.CommodityRegistry.Get(ctx, looseCommodity.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// The area-less commodity's file went with it — row and blob.
+	_, err = registrySet.FileRegistry.Get(ctx, looseFile.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+	c.Assert(must.Must(b.Exists(ctx, looseBlobKey)), qt.IsFalse)
+}

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -39,7 +39,7 @@ import (
 const (
 	maxInbMembers         = 1_000_000
 	maxInbTotalUncompress = 8 << 30  // 8 GiB of inflated bytes
-	maxLocationDocBytes   = 32 << 20 // 32 MiB per location JSON member
+	maxJSONDocBytes       = 32 << 20 // 32 MiB per JSON document member
 	maxInbManifestBytes   = 4 << 20  // 4 MiB for the manifest pre-scan
 )
 
@@ -50,11 +50,13 @@ const (
 const maxSupportedInbMajor = 2
 
 var (
-	// ErrLocationDocTooLarge is returned when a single location JSON member
-	// declares a size above maxLocationDocBytes. Without a per-member cap one
-	// location document could claim up to the 8 GiB total and OOM the worker via
-	// io.ReadAll.
-	ErrLocationDocTooLarge = errx.NewSentinel("backup location document exceeds the maximum allowed size")
+	// ErrJSONDocTooLarge is returned when a JSON document member (a location
+	// document, the area-less commodities document of #1986, or the
+	// non-commodity files document of #2235) declares a size above
+	// maxJSONDocBytes. Without a per-member cap one document could claim up to
+	// the 8 GiB total and OOM the worker via io.ReadAll. The failing member name
+	// is attached, so the message stays diagnosable across all three.
+	ErrJSONDocTooLarge = errx.NewSentinel("backup JSON document exceeds the maximum allowed size")
 
 	// ErrMissingFileMembers is returned when one or more declared commodity file
 	// references were never delivered as file members in the archive. Succeeding
@@ -439,8 +441,8 @@ func (w *inbWalker) handleLocationMember(hdr *tar.Header, r io.Reader) error {
 	// Per-member cap: a location JSON is parsed whole via io.ReadAll, so without
 	// this a single member could declare up to the 8 GiB total and OOM the
 	// worker. 32 MiB is far above any realistic location document.
-	if hdr.Size < 0 || hdr.Size > maxLocationDocBytes {
-		return errx.Classify(ErrLocationDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxLocationDocBytes))
+	if hdr.Size < 0 || hdr.Size > maxJSONDocBytes {
+		return errx.Classify(ErrJSONDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxJSONDocBytes))
 	}
 	data, err := io.ReadAll(io.LimitReader(r, hdr.Size))
 	if err != nil {
@@ -498,8 +500,8 @@ func (w *inbWalker) applyLocationDoc(doc *types.INBLocationDoc) error {
 // #1986) and recreates each commodity with a nil area. The same per-member size
 // cap as location documents applies (a flat commodity list, no file bytes).
 func (w *inbWalker) handleUnassignedMember(hdr *tar.Header, r io.Reader) error {
-	if hdr.Size < 0 || hdr.Size > maxLocationDocBytes {
-		return errx.Classify(ErrLocationDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxLocationDocBytes))
+	if hdr.Size < 0 || hdr.Size > maxJSONDocBytes {
+		return errx.Classify(ErrJSONDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxJSONDocBytes))
 	}
 	data, err := io.ReadAll(io.LimitReader(r, hdr.Size))
 	if err != nil {
@@ -683,8 +685,8 @@ func (w *inbWalker) registerFileRefs(commodityUUID, bucket string, refs []types.
 // the JSON-before-bytes contract keep working unchanged). The same per-member size
 // cap as location documents applies — the document is parsed whole via io.ReadAll.
 func (w *inbWalker) handleFilesMember(hdr *tar.Header, r io.Reader) error {
-	if hdr.Size < 0 || hdr.Size > maxLocationDocBytes {
-		return errx.Classify(ErrLocationDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxLocationDocBytes))
+	if hdr.Size < 0 || hdr.Size > maxJSONDocBytes {
+		return errx.Classify(ErrJSONDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxJSONDocBytes))
 	}
 	data, err := io.ReadAll(io.LimitReader(r, hdr.Size))
 	if err != nil {

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -173,10 +173,20 @@ func checkInbFormatVersion(payload io.Reader) error {
 	if err != nil {
 		return errxtrace.Wrap("failed to read inner tar", err)
 	}
-	if hdr.Name != types.INBManifestMember || hdr.Size < 0 || hdr.Size > maxInbManifestBytes {
-		// No manifest up front (or an implausibly large one) — leave it to the
-		// walk, which drains unknown members and caps every one it parses.
+	if hdr.Name != types.INBManifestMember {
+		// No manifest up front. Pre-manifest archives are still readable, and the
+		// walk drains unknown members, so this is not itself a violation — there
+		// is simply no declared version to gate on.
 		return nil
+	}
+	if hdr.Size < 0 || hdr.Size > maxInbManifestBytes {
+		// An implausibly-sized manifest is a framing violation, and it must NOT
+		// fall through to "no constraint": that would let a crafted archive skip
+		// the version gate entirely and reach prepareRestore, where full_replace
+		// wipes the target before a format this build cannot read is even parsed.
+		// Fail while the target is still intact.
+		return errx.Classify(ErrJSONDocTooLarge,
+			errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxInbManifestBytes))
 	}
 
 	data, err := io.ReadAll(io.LimitReader(tr, hdr.Size))

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-extras/errx"
@@ -39,7 +40,14 @@ const (
 	maxInbMembers         = 1_000_000
 	maxInbTotalUncompress = 8 << 30  // 8 GiB of inflated bytes
 	maxLocationDocBytes   = 32 << 20 // 32 MiB per location JSON member
+	maxInbManifestBytes   = 4 << 20  // 4 MiB for the manifest pre-scan
 )
+
+// maxSupportedInbMajor is the highest `.inb` format MAJOR version this build can
+// read. MINOR bumps are additive-only (a new optional member dispatched by name),
+// so any 2.x archive restores here; a 3.x archive would carry shape changes this
+// reader cannot know about, so it is rejected outright rather than half-applied.
+const maxSupportedInbMajor = 2
 
 var (
 	// ErrLocationDocTooLarge is returned when a single location JSON member
@@ -59,6 +67,12 @@ var (
 	// and counts — a malformed field means the archive itself is corrupt, so it
 	// aborts the whole restore rather than silently coercing the bad value.
 	ErrMalformedEntity = errx.NewSentinel("backup archive contains a malformed entity field")
+
+	// ErrUnsupportedFormatVersion is returned when the archive's manifest
+	// declares a format MAJOR version above maxSupportedInbMajor. Checked BEFORE
+	// prepareRestore so a full_replace never wipes the target for an archive
+	// this build cannot read.
+	ErrUnsupportedFormatVersion = errx.NewSentinel("backup format version is not supported by this server")
 )
 
 // decodeAndRestore is the default `.inb` decode entry point (#534). It verifies
@@ -108,6 +122,18 @@ func (l *RestoreOperationProcessor) decodeAndRestore(ctx context.Context, reader
 		return stats, errxtrace.Wrap("failed to rewind temp payload", err)
 	}
 
+	// 5. Gate on the declared format version BEFORE prepareRestore: full_replace
+	//    wipes the existing data in prepareRestore, so an archive this build
+	//    cannot read must be rejected while the target is still intact. The
+	//    payload is already spooled to a temp file, so this costs one extra gzip
+	//    open + the first member (manifest.json is always written first).
+	if err := checkInbFormatVersion(tmp); err != nil {
+		return stats, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return stats, errxtrace.Wrap("failed to rewind temp payload", err)
+	}
+
 	prep, err := l.prepareRestore(ctx, options)
 	if err != nil {
 		return stats, err
@@ -117,6 +143,70 @@ func (l *RestoreOperationProcessor) decodeAndRestore(ctx context.Context, reader
 		return stats, err
 	}
 	return stats, nil
+}
+
+// checkInbFormatVersion inspects the archive's manifest and rejects a format
+// MAJOR version this build cannot read (ErrUnsupportedFormatVersion). Only the
+// FIRST inner-tar member is read: the exporter always writes manifest.json first
+// (pinned by TestINBExport_ManifestIsFirstMember), so this stays a cheap pre-scan
+// rather than a second full inflate.
+//
+// Deliberately permissive in the other direction — an absent, empty, or
+// unparseable version, and any MAJOR at or below maxSupportedInbMajor, is
+// accepted. MINOR bumps are additive-only (a new optional member dispatched by
+// name), which is what lets a 2.0 archive keep restoring on a 2.1 reader.
+func checkInbFormatVersion(payload io.Reader) error {
+	gzr, err := gzip.NewReader(payload)
+	if err != nil {
+		return errxtrace.Wrap("failed to open gzip reader", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	hdr, err := tr.Next()
+	if err == io.EOF {
+		// An empty payload has nothing to gate; the walk reports it.
+		return nil
+	}
+	if err != nil {
+		return errxtrace.Wrap("failed to read inner tar", err)
+	}
+	if hdr.Name != types.INBManifestMember || hdr.Size < 0 || hdr.Size > maxInbManifestBytes {
+		// No manifest up front (or an implausibly large one) — leave it to the
+		// walk, which drains unknown members and caps every one it parses.
+		return nil
+	}
+
+	data, err := io.ReadAll(io.LimitReader(tr, hdr.Size))
+	if err != nil {
+		return errxtrace.Wrap("failed to read manifest member", err)
+	}
+	var manifest types.INBManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return errxtrace.Wrap("failed to decode manifest document", err)
+	}
+
+	major, ok := inbFormatMajor(manifest.Version)
+	if ok && major > maxSupportedInbMajor {
+		return errx.Classify(ErrUnsupportedFormatVersion,
+			errx.Attrs("version", manifest.Version, "max_supported_major", maxSupportedInbMajor))
+	}
+	return nil
+}
+
+// inbFormatMajor extracts the MAJOR component of a manifest format version
+// ("2.1" → 2). ok=false for an absent or unparseable value, which the caller
+// treats as "no constraint" rather than a failure.
+func inbFormatMajor(version string) (int, bool) {
+	if version == "" {
+		return 0, false
+	}
+	majorPart, _, _ := strings.Cut(version, ".")
+	major, err := strconv.Atoi(majorPart)
+	if err != nil {
+		return 0, false
+	}
+	return major, true
 }
 
 // applyInbPayload inflates the verified payload and walks the inner tar in
@@ -258,9 +348,24 @@ func (w *inbWalker) applyPendingCovers() error {
 
 // inbPendingFile records the metadata a file member needs once its bytes arrive.
 type inbPendingFile struct {
-	ref           types.INBFileRef
-	bucket        string // images / invoices / manuals
-	commodityUUID string
+	ref  types.INBFileRef
+	link inbFileLink
+}
+
+// inbFileLink is a file's ARCHIVE-side link: the linked entity's immutable UUID
+// plus its bucket, resolved to a destination DB id only when the bytes arrive
+// (the ID mapping is filled as the entity documents are applied).
+//
+// linkedType is "commodity" (nested under a commodity — the pre-#2235 shape),
+// "location"/"area" (from the files member), or "" for a standalone file.
+// fileType/category are carried by the files member and empty for a commodity
+// ref, which re-derives them from the bucket + MIME as before.
+type inbFileLink struct {
+	linkedType string
+	entityUUID string
+	meta       string
+	fileType   string
+	category   string
 }
 
 // inbPendingCover records a commodity → cover-photo cross-reference that can
@@ -303,9 +408,15 @@ type inbWalker struct {
 func (w *inbWalker) handleMember(hdr *tar.Header, r io.Reader) error {
 	switch {
 	case hdr.Name == types.INBManifestMember:
-		// Manifest is informational; drain it so the tar advances.
+		// Manifest is informational here — its format version was already gated
+		// in checkInbFormatVersion, before any data was touched. Drain it so the
+		// tar advances.
 		_, err := io.Copy(io.Discard, r)
 		return err
+	case hdr.Name == types.INBFilesMember:
+		// Non-commodity files document (issue #2235). It lives UNDER the `files/`
+		// prefix, so it must be matched before the file-bytes case below.
+		return w.handleFilesMember(hdr, r)
 	case strings.HasPrefix(hdr.Name, "files/"):
 		return w.handleFileMember(hdr, r)
 	case hdr.Name == types.INBUnassignedMember:
@@ -559,8 +670,78 @@ func (w *inbWalker) queueCoverPatch(c *types.INBCommodity) {
 func (w *inbWalker) registerFileRefs(commodityUUID, bucket string, refs []types.INBFileRef) {
 	for _, ref := range refs {
 		key := blobkeys.SanitizeArchivePath(ref.Path)
-		w.fileRefs[key] = inbPendingFile{ref: ref, bucket: bucket, commodityUUID: commodityUUID}
+		w.fileRefs[key] = inbPendingFile{
+			ref:  ref,
+			link: inbFileLink{linkedType: "commodity", entityUUID: commodityUUID, meta: bucket},
+		}
 	}
+}
+
+// handleFilesMember decodes the non-commodity files document (issue #2235) and
+// registers its references, so the file members that follow are matched exactly
+// like commodity attachments (same fileRefs map, so the missing-member check and
+// the JSON-before-bytes contract keep working unchanged). The same per-member size
+// cap as location documents applies — the document is parsed whole via io.ReadAll.
+func (w *inbWalker) handleFilesMember(hdr *tar.Header, r io.Reader) error {
+	if hdr.Size < 0 || hdr.Size > maxLocationDocBytes {
+		return errx.Classify(ErrLocationDocTooLarge, errx.Attrs("member", hdr.Name, "size", hdr.Size, "max", maxLocationDocBytes))
+	}
+	data, err := io.ReadAll(io.LimitReader(r, hdr.Size))
+	if err != nil {
+		return errxtrace.Wrap("failed to read files member", err, errx.Attrs("member", hdr.Name))
+	}
+	var doc types.INBFilesDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return errxtrace.Wrap("failed to decode files document", err, errx.Attrs("member", hdr.Name))
+	}
+	w.registerEntityFileRefs(doc.Files)
+	return nil
+}
+
+// registerEntityFileRefs indexes the non-commodity file references by their
+// archive path (issue #2235). Each ref carries its own link, so the later file
+// member recreates the row with the original linked_entity_type / meta instead of
+// assuming a commodity attachment.
+func (w *inbWalker) registerEntityFileRefs(refs []types.INBEntityFileRef) {
+	for _, ref := range refs {
+		key := blobkeys.SanitizeArchivePath(ref.Path)
+		w.fileRefs[key] = inbPendingFile{
+			ref: ref.INBFileRef,
+			link: inbFileLink{
+				linkedType: ref.LinkedEntityType,
+				entityUUID: ref.LinkedEntityID,
+				meta:       ref.LinkedEntityMeta,
+				fileType:   ref.Type,
+				category:   ref.Category,
+			},
+		}
+	}
+}
+
+// resolveLinkedDBID maps a file's archived link to the destination entity's DB id.
+// A standalone file (empty type) resolves to an empty id, which is correct — the
+// row is persisted with no link at all. ok=false when the archive references an
+// entity that never landed (or an entity type this build does not know), in which
+// case the caller drops the file rather than persisting a dangling reference.
+func (w *inbWalker) resolveLinkedDBID(link inbFileLink) (string, bool) {
+	var dbID string
+	var found bool
+	switch link.linkedType {
+	case "":
+		return "", true
+	case "commodity":
+		dbID, found = w.idMapping.Commodities[link.entityUUID]
+	case "location":
+		dbID, found = w.idMapping.Locations[link.entityUUID]
+	case "area":
+		dbID, found = w.idMapping.Areas[link.entityUUID]
+	default:
+		return "", false
+	}
+	if !found || dbID == "" {
+		return "", false
+	}
+	return dbID, true
 }
 
 // handleFileMember streams a file member's bytes into a re-minted tenant blob
@@ -584,11 +765,15 @@ func (w *inbWalker) handleFileMember(hdr *tar.Header, r io.Reader) error {
 	// commodity isn't persisted, still delivers and consumes the member here).
 	delete(w.fileRefs, hdr.Name)
 
-	linkedDBID, resolved := w.idMapping.Commodities[pending.commodityUUID]
-	if !resolved || linkedDBID == "" {
+	// Resolve the archived link (commodity / location / area / standalone) to a
+	// destination DB id. A link whose entity never landed is dropped with a
+	// counted error — a dangling linked_entity_id must never be persisted.
+	linkedDBID, resolved := w.resolveLinkedDBID(pending.link)
+	if !resolved {
 		_, _ = io.Copy(io.Discard, r)
 		w.stats.ErrorCount++
-		w.stats.Errors = append(w.stats.Errors, fmt.Sprintf("file %s references unmapped commodity %s", pending.ref.ID, pending.commodityUUID))
+		w.stats.Errors = append(w.stats.Errors,
+			fmt.Sprintf("file %s references unmapped %s %s", pending.ref.ID, pending.link.linkedType, pending.link.entityUUID))
 		return nil
 	}
 
@@ -608,7 +793,13 @@ func (w *inbWalker) handleFileMember(hdr *tar.Header, r io.Reader) error {
 	// Build the file entity BEFORE streaming the bytes: a malformed timestamp
 	// corrupts the restored metadata, so fail the restore (rather than coercing
 	// to time.Now()) without first writing a doomed blob.
-	fileEntity, err := pending.ref.ConvertToFileEntity(linkedDBID, pending.bucket, blobKey)
+	fileEntity, err := pending.ref.ConvertToFileEntity(types.INBFileLink{
+		Type:     pending.link.linkedType,
+		DBID:     linkedDBID,
+		Meta:     pending.link.meta,
+		FileType: pending.link.fileType,
+		Category: pending.link.category,
+	}, blobKey)
 	if err != nil {
 		// A malformed timestamp is archive corruption — drain the member and
 		// abort the restore (handleFileMember errors already propagate hard).
@@ -660,7 +851,7 @@ func (w *inbWalker) handleFileMember(hdr *tar.Header, r io.Reader) error {
 
 	w.deleteSupersededBlob(staleBlobKey, blobKey)
 
-	w.incBucketStat(pending.bucket)
+	w.incBucketStat(pending.link)
 	return nil
 }
 
@@ -733,9 +924,15 @@ func (w *inbWalker) streamFileBytes(blobKey string, r io.Reader, size int64) (in
 	return n, nil
 }
 
-// incBucketStat increments the per-bucket file counter.
-func (w *inbWalker) incBucketStat(bucket string) {
-	switch bucket {
+// incBucketStat increments the per-bucket file counter. ImageCount/InvoiceCount/
+// ManualCount are legacy COMMODITY-scoped counters, so a location/area file (whose
+// buckets are images/files) or a standalone file must NOT inflate them — those
+// only feed the unified FileCount (issue #2235).
+func (w *inbWalker) incBucketStat(link inbFileLink) {
+	if link.linkedType != "commodity" {
+		return
+	}
+	switch link.meta {
 	case "images":
 		w.stats.ImageCount++
 	case "invoices":

--- a/go/backup/restore/processor/processor_shared.go
+++ b/go/backup/restore/processor/processor_shared.go
@@ -308,10 +308,24 @@ func (l *RestoreOperationProcessor) loadExistingEntities(ctx context.Context, en
 	return nil
 }
 
-// clearExistingData removes all existing data for full replace strategy. See
-// the original comment chain — DeleteLocationRecursive cascades commodities and
-// commodity-linked files; a second sweep removes location-/area-/standalone
-// files (rows + blobs) so nothing orphans or collides on restore.
+// clearExistingData removes all existing data for full replace strategy. Three
+// passes, in this order:
+//
+//  1. DeleteLocationRecursive per location — cascades areas, their commodities,
+//     and the commodity-/area-/location-linked files of that subtree.
+//  2. DeleteCommodityRecursive per SURVIVING commodity. Commodities are
+//     enumerated DIRECTLY because commodity.area_id is nullable since #1986: an
+//     area-less commodity is not reachable through the location → area recursion
+//     above, so before #2236 its row survived a full_replace while the file sweep
+//     below still deleted its attachments (a zombie item with no files) — and its
+//     preserved UUID then collided with the archive's own copy on re-create.
+//  3. A type-agnostic sweep of the remaining files (rows + blobs), which catches
+//     standalone files and any orphan. linked_entity_type='export' is skipped:
+//     that is the archive being restored plus the backup history, not inventory.
+//
+// Pass 2 sits BETWEEN the other two on purpose: DeleteCommodityRecursive cleans a
+// commodity's own files (row + blob + thumbnails) instead of having them yanked
+// out from under a live row by the sweep.
 func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error {
 	// RLS-scoped registry: a full_replace restore must only wipe the restoring
 	// user's own locations. CreateServiceRegistry bypasses RLS and would
@@ -330,6 +344,10 @@ func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error
 		if err := l.entityService.DeleteLocationRecursive(ctx, location.ID); err != nil {
 			return errxtrace.Wrap("failed to delete location recursively", err, errx.Attrs("location_id", location.ID))
 		}
+	}
+
+	if err := l.clearSurvivingCommodities(ctx); err != nil {
+		return err
 	}
 
 	fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
@@ -353,6 +371,35 @@ func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error
 		}
 	}
 
+	return nil
+}
+
+// clearSurvivingCommodities deletes every commodity the location recursion did
+// not reach (issue #2236). Enumerating commodities DIRECTLY — rather than adding
+// an `area_id IS NULL` sweep — needs no new registry API and stays correct for the
+// next nullable-parent change. Most rows are already gone by now, so their
+// recursive delete short-circuits on ErrNotFound.
+//
+// RLS-scoped registry, for the same reason as the location list above: a service
+// registry here would recursively delete EVERY tenant's commodities.
+func (l *RestoreOperationProcessor) clearSurvivingCommodities(ctx context.Context) error {
+	comReg, err := l.factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to create user commodity registry for clear", err)
+	}
+	commodities, err := comReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list commodities for deletion", err)
+	}
+	for _, commodity := range commodities {
+		if err := l.entityService.DeleteCommodityRecursive(ctx, commodity.ID); err != nil {
+			if errors.Is(err, registry.ErrNotFound) {
+				// Already removed by the location recursion.
+				continue
+			}
+			return errxtrace.Wrap("failed to delete commodity recursively", err, errx.Attrs("commodity_id", commodity.ID))
+		}
+	}
 	return nil
 }
 

--- a/go/backup/restore/types/types_inb.go
+++ b/go/backup/restore/types/types_inb.go
@@ -26,6 +26,15 @@ const INBManifestMember = "manifest.json"
 // backup/export.INBUnassignedName. Absent from archives with no unassigned items.
 const INBUnassignedMember = "unassigned-commodities.json"
 
+// INBFilesMember is the inner-tar member name of the non-commodity files document
+// (issue #2235): location-/area-linked and standalone files. Kept in sync with
+// backup/export.INBFilesName. Absent from 2.0 archives and from any archive that
+// carries no such file, so it must be dispatched by name and never required.
+//
+// It lives under the `files/` prefix on purpose (see backup/export.INBFilesName),
+// so the walker MUST match it before the generic `files/` byte-member case.
+const INBFilesMember = "files/_index.json"
+
 // INBManifest is the decoded manifest.json. Restore only reads the statistics
 // and the location index; the signature block is informational (verification
 // uses the server's own key, never this).
@@ -41,8 +50,12 @@ type INBManifest struct {
 	// when the archive carries none. Informational here — restore dispatches by
 	// member name (handleMember), so older archives without this field and the
 	// member round-trip unchanged.
-	UnassignedFile string           `json:"unassignedFile,omitempty"`
-	Statistics     INBManifestStats `json:"statistics"`
+	UnassignedFile string `json:"unassignedFile,omitempty"`
+	// FilesFile names the non-commodity files member (issue #2235), or "" when
+	// the archive carries none. Informational here — restore dispatches by
+	// member name, so a 2.0 archive without this field round-trips unchanged.
+	FilesFile  string           `json:"filesFile,omitempty"`
+	Statistics INBManifestStats `json:"statistics"`
 }
 
 // INBSignatureInfo is the informational signature descriptor.
@@ -167,6 +180,45 @@ type INBFileRef struct {
 	Tags         []string `json:"tags,omitempty"`
 	CreatedAt    string   `json:"createdAt,omitempty"`
 	UpdatedAt    string   `json:"updatedAt,omitempty"`
+}
+
+// INBFilesDoc is the decoded non-commodity files document (issue #2235): the
+// group's location-/area-linked and standalone files. Mirrors
+// backup/export.INBFilesDoc. Commodity attachments are NOT here — they stay
+// nested under their commodity.
+type INBFilesDoc struct {
+	Files []INBEntityFileRef `json:"files"`
+}
+
+// INBEntityFileRef is a file reference carrying its own polymorphic link (issue
+// #2235). LinkedEntityID is the linked location/area's IMMUTABLE UUID, which the
+// processor maps to the destination DB id; "" marks a standalone file. Type and
+// Category are carried verbatim because models.FileCategoryFromContext has no
+// "area" and no standalone branch — re-deriving them would silently rewrite the
+// user-visible category. MUST keep json tags identical to
+// backup/export.INBEntityFileRef.
+type INBEntityFileRef struct {
+	INBFileRef
+
+	LinkedEntityType string `json:"linkedEntityType,omitempty"`
+	LinkedEntityID   string `json:"linkedEntityId,omitempty"`
+	LinkedEntityMeta string `json:"linkedEntityMeta,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Category         string `json:"category,omitempty"`
+}
+
+// INBFileLink is the resolved destination link for a restored file (issue #2235).
+// Type is "commodity" | "location" | "area" | "" (standalone); DBID is the
+// destination entity's DB id (already mapped from the archive UUID) and Meta its
+// bucket. FileType / Category are the archived models values, used verbatim when
+// present and re-derived from the linked context only for older archives that did
+// not carry them.
+type INBFileLink struct {
+	Type     string
+	DBID     string
+	Meta     string
+	FileType string
+	Category string
 }
 
 // ConvertToLocation converts an INBLocation to a models.Location. The ID is the
@@ -305,15 +357,22 @@ func (c *INBCommodity) RestoredAcquisition() (*decimal.Decimal, *models.Currency
 	return price, &currency, nil
 }
 
-// ConvertToFileEntity builds a models.FileEntity from an INBFileRef for a
-// commodity attachment. linkedDBID is the destination commodity DB ID; bucket
-// is the linked_entity_meta (images/invoices/manuals). blobKey is the re-minted
-// destination blob key (under the importing tenant). The file's immutable UUID
-// is preserved. A malformed createdAt/updatedAt timestamp surfaces an error
-// (tagged with the field name and the file UUID) rather than being coerced to
-// time.Now(), so a corrupt archive fails the restore instead of restoring wrong
-// metadata.
-func (r *INBFileRef) ConvertToFileEntity(linkedDBID, bucket, blobKey string) (*models.FileEntity, error) {
+// ConvertToFileEntity builds a models.FileEntity from an INBFileRef. link carries
+// the resolved destination link — a commodity attachment, a location/area
+// attachment, or a standalone file (issue #2235; before it, this always assumed
+// "commodity"). blobKey is the re-minted destination blob key (under the importing
+// tenant). The file's immutable UUID is preserved.
+//
+// A standalone file (link.Type == "") is persisted with linked_entity_type/id/meta
+// ALL empty — model validation requires that triple to be empty together.
+//
+// Type/Category come from the archive when it carried them and fall back to the
+// MIME/linked-context derivation for older archives that did not.
+//
+// A malformed createdAt/updatedAt timestamp surfaces an error (tagged with the
+// field name and the file UUID) rather than being coerced to time.Now(), so a
+// corrupt archive fails the restore instead of restoring wrong metadata.
+func (r *INBFileRef) ConvertToFileEntity(link INBFileLink, blobKey string) (*models.FileEntity, error) {
 	createdAt, err := parseInbTimestamp(r.CreatedAt)
 	if err != nil {
 		return nil, errxtrace.Wrap("invalid createdAt", err, errx.Attrs("file_id", r.ID))
@@ -323,8 +382,19 @@ func (r *INBFileRef) ConvertToFileEntity(linkedDBID, bucket, blobKey string) (*m
 		return nil, errxtrace.Wrap("invalid updatedAt", err, errx.Attrs("file_id", r.ID))
 	}
 
-	fileType := models.FileTypeFromMIME(r.MimeType)
-	category := models.FileCategoryFromContext("commodity", bucket, r.MimeType)
+	fileType := models.FileType(link.FileType)
+	if fileType == "" {
+		fileType = models.FileTypeFromMIME(r.MimeType)
+	}
+	category := models.FileCategory(link.Category)
+	if category == "" {
+		category = models.FileCategoryFromContext(link.Type, link.Meta, r.MimeType)
+	}
+
+	linkedDBID, linkedMeta := link.DBID, link.Meta
+	if link.Type == "" {
+		linkedDBID, linkedMeta = "", ""
+	}
 
 	return &models.FileEntity{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
@@ -335,9 +405,9 @@ func (r *INBFileRef) ConvertToFileEntity(linkedDBID, bucket, blobKey string) (*m
 		Type:             fileType,
 		Category:         category,
 		Tags:             models.StringSlice(r.Tags),
-		LinkedEntityType: "commodity",
+		LinkedEntityType: link.Type,
 		LinkedEntityID:   linkedDBID,
-		LinkedEntityMeta: bucket,
+		LinkedEntityMeta: linkedMeta,
 		CreatedAt:        createdAt,
 		UpdatedAt:        updatedAt,
 		File: &models.File{


### PR DESCRIPTION
Closes #2235. Closes #2236.

## The bug (#2235) — backup → restore silently LOST files

The `.inb` format only carried files nested under commodities (`INBFileRef` under `Images`/`Invoices`/`Manuals`), and the restore side hardcoded `LinkedEntityType="commodity"`. Files attached to **areas**, **locations** (the #2119 surface) or to **nothing at all** were never exported — while `full_replace`'s type-agnostic sweep deleted them from the target *first*. So a restore didn't orphan those files, it **destroyed** them.

## Format change (2.0 → 2.1, purely additive)

- New **optional** member **`files/_index.json`** (`INBFilesDoc`) carrying every non-commodity file as an `INBEntityFileRef`. The ref now knows its own `linked_entity_type` / `linked_entity_id` / `meta`, so restore recreates the original link instead of assuming "commodity".
  - `linked_entity_id` on the wire is the entity's **immutable UUID**, never the volatile `files.linked_entity_id` DB key; restore resolves it through the same `IDMapping` the commodities use, and **drops** a ref whose entity never landed rather than persisting a dangling link.
  - `type` + `category` are carried **explicitly**: `models.FileCategoryFromContext` has no `area` branch and no standalone branch, so re-deriving them on restore would silently rewrite the user-visible category.
- Bytes live under `files/_entity/<type>/<uuid>/<bucket>/<file-uuid>/<name>` and `files/_standalone/<file-uuid>/<name>`, flowing through the **same** sanitised-path + re-minted-tenant-blob-key path as commodity attachments (no new blob mechanism, no attacker-controlled destination).
- **Why under `files/` and not a bare top-level `*.json`:** an old reader dispatches any other top-level `*.json` to the *location* handler → decodes into a zero `Location` → validation fails → **hard restore failure** — and on `full_replace` that happens *after* `clearExistingData` already wiped the target. Under `files/` an old reader degrades to counted "no matching reference" errors and still restores all commodity data.
- Commodity attachments stay nested exactly where they were: no duplication on the wire, no re-plumbing of `registerFileRefs` / the cover-photo patch ordering.

### Version gate (new, and load-bearing)

`INBFormatVersion` was **write-only** — the walker drained `manifest.json` and never looked at it. It is now parsed and enforced: **MAJOR > 2 → `ErrUnsupportedFormatVersion`**, checked **before `prepareRestore`**, so an archive this build cannot read never triggers the `full_replace` wipe. Absent / empty / unparseable versions and any `2.x` still restore (minor bumps are additive-only, dispatched by member name — which is exactly what keeps 2.0 archives working here).

## The bug (#2236) — zombie commodities

`clearExistingData` reached commodities only through the `location → area` recursion, but `commodity.area_id` is nullable since #1986. An area-less commodity therefore **survived** `full_replace` as a stale row while the file sweep still deleted its attachments — and its preserved UUID then collided with the archive's own copy. A second pass now enumerates commodities **directly** (RLS-scoped registry — a service registry there would wipe every tenant), placed between the location recursion and the file sweep so `DeleteCommodityRecursive` cleans each commodity's own files instead of having them yanked out from under a live row.

## Tests (13 new, +1692/-96 overall)

Round-trip of location/area/standalone files asserting **rows *and* blob BYTES**; old-2.0-archive compatibility (hand-built archive still restores its commodity attachment); version-gate table (absent / 2.0 / 2.1 / 2.9 restore, **3.0 rejected with the pre-existing data intact**); missing-byte-member and unmapped-link handling; merge / dry-run strategies; `selected_items` scoping (a file of a merely *implied* parent is excluded); orphan-blob drop; byte-stability (a commodity-only export emits no new member); #2236 end-to-end + unit.

Both confirmed review findings were fixed and **mutation-verified** (reverting the guard reds a test).

## Gates

`go build` (both tags) ✅ · `golangci-lint run` ✅ **0 issues** · `nolintguard` ✅ · `qtlint` ✅ · `go vet` (touched pkgs, both tags) ✅ · `go test ./...` ✅ **146 pkgs, 0 FAIL** · `go test -tags legacy_xml_backup ./backup/...` ✅. **No migration** — the model already accepts `location`/`area`/`""` link types (`models.go:396`) and `commodity.area_id` is already nullable. No frontend/e2e/seeddata/swagger surface touched.

## Known, deliberately out of scope

- **Old reader × new archive**: an old binary handed a 2.1 archive emits one counted error per new member and *completes* (all commodity data intact) rather than hard-failing. That is the designed degradation — the alternative was a hard failure *after* the wipe.
- **Cross-tenant restore** is structurally unreachable on this path (`Process()` guards the export's blob key against the tenant prefix), so no test was written for it.
- **Tag-row hygiene**: `full_replace` still doesn't sweep `tags` rows, and restore only ensures tag rows for *commodity* tags — pre-existing, now slightly more visible since file tags can ride along. Worth a follow-up if it bites.
- **Dangling area** (parent location already gone) still survives `full_replace` in the memory registry; Postgres's FK makes it unreachable there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backups now include files attached to locations and areas, as well as standalone files in full database exports.
  * Selected-item exports include files only from explicitly selected locations or areas.
  * File attachments are restored with their original associations and metadata.

* **Bug Fixes**
  * Improved handling of missing or unavailable files during export and restore.
  * Full replacements now reliably remove leftover records and file data.

* **Compatibility**
  * Existing backup archives remain restorable, while unsupported major formats are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->