### PR TITLE
feat(workers): orphan-file GC sweeper, report-mode by default (#2237)

### DIFF
--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -482,7 +482,7 @@ reconstructed.
 | ---- | ------- | ----- |
 | `--orphan-file-gc-mode` | `report` | `off` \| `report` \| `delete`. An unknown value **fails startup**. |
 | `--orphan-file-gc-min-age` | `72h` | Minimum age of a row (both `created_at` *and* `updated_at`) or a blob (bucket `ModTime`). **Hard floor 24h** — a lower value fails startup. |
-| `--orphan-file-gc-interval` | `24h` | Sweep cadence. |
+| `--orphan-file-gc-interval` | `24h` | Sweep cadence. The worker also sweeps **once at startup**, so a fresh deploy does not wait a full interval for its first report. A restart bypasses nothing: the pause, the in-flight gate and the age gate are all re-evaluated on that first sweep. |
 
 ### `inventario_orphan_gc_blocked_tenants` > 0
 

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -492,6 +492,12 @@ onto the rows it creates, so those rows would otherwise clear the age gate
 instantly). The blocking operation is named in an
 `event=orphan_gc.blocked` log line.
 
+The gauge reports the **last completed evaluation**, so read it only while
+`inventario_orphan_gc_runs_total{result="success"}` is advancing: a tick that
+never evaluated the gate (paused worker, `mode=off`, or a gate-build failure)
+resets it to `0` rather than leaving the previous tick's value standing and
+faking a pinned tenant forever.
+
 There is no heartbeat on exports/restores, so a **crashed** operation stays
 `running` / `in_progress` forever and pins its tenant permanently. That is
 the correct direction (under-collecting forever beats one wrong delete),

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -341,8 +341,8 @@ and the `worker_control.worker_type` column):
 `export`, `import`, `restore`, `thumbnail`, `refresh-token-cleanup`,
 `email-verification-cleanup`, `magic-link-token-cleanup`,
 `operation-slot-cleanup`, `login-event-retention`, `group-purge`,
-`warranty-reminder`, `storage-quota-reminder`, `loan-reminder`,
-`maintenance-reminder`, `currency-migration`.
+`orphan-file-gc`, `warranty-reminder`, `storage-quota-reminder`,
+`loan-reminder`, `maintenance-reminder`, `currency-migration`.
 
 > Email delivery is intentionally **not** in this set — it is a Redis
 > subscriber rather than a polling worker, with a separate pause story.
@@ -405,6 +405,108 @@ The same control is exposed under the back-office-gated admin subtree
   last-known state is **retained** (a DB blip cannot silently un-pause a
   worker an operator deliberately stopped); the failure is logged once
   on the error transition.
+
+---
+
+## 8. Orphan-file GC (#2237)
+
+`orphan-file-gc` is the **only destructive periodic worker** in the
+deployment. It exists as a backstop for residues the delete paths cannot
+close by construction (they are row-first / blob-best-effort and
+multi-transaction, because the file→entity link is polymorphic and cannot
+carry an FK):
+
+1. **Crash window** — a process dies between an entity-row delete and its
+   linked-file sweep, leaving file rows pointing at an entity that no
+   longer exists.
+2. **Concurrent attach** — a file is linked to an entity while that
+   entity's delete is in flight.
+3. **Thumbnail mid-generation race** — a file is deleted while the
+   thumbnail worker sits between its read and its blob writes.
+
+### What it sweeps — and what it will NEVER touch
+
+It sweeps exactly two classes:
+
+- **File ROWS** whose `linked_entity_type` is one of
+  `commodity` / `area` / `location` **and** whose `linked_entity_id`
+  names a row that does not exist anywhere in the database.
+- **THUMBNAIL blobs** under `t/<tenant>/thumbnails/` whose owning file
+  row is gone. Thumbnails are derived and regenerable, and the key
+  embeds the owning row's primary key, so orphan-ness is an exact
+  single-row question.
+
+Everything else is **NEVER-SWEEP** — not filtered out, but never
+enumerated in the first place:
+
+| Class | Why it is never touched |
+| ----- | ----------------------- |
+| Standalone files (`linked_entity_type = ''`) | First-class since #2235; exported in backups. **"No link" is not "orphan."** The candidate predicate is a positive allowlist, so a standalone file cannot enter it. |
+| `export`-linked files | Owned by the backup subsystem's own lifecycle. The exports table is never probed, so a soft-deleted (recoverable) export can never be misread as "gone". |
+| Any unknown / future link type | Fails closed — kept until someone explicitly adds it to the allowlist. |
+| `t/<tenant>/files/` blobs | Upload, restore, and `inventario backfill blobs` are all **blob-first / row-second**, so a rowless blob is a normal transient state. Reclaiming these safely needs a provably-complete global keep-set; the failure mode is irreversible loss of the user's file bytes. Out of scope for an autonomous worker. (Crash-window blobs are still reclaimed — via the row sweep, which deletes the blob and thumbnails with the row.) |
+| `t/<tenant>/exports/` blobs | A failed export leaves its `.inb` referenced by nothing at all. Fix belongs at the source. |
+| `t/<tenant>/restores/` blobs | An uploaded `.inb` awaiting import has **no row of any kind** — and stays rowless forever if the import fails or is never submitted. Deleting one destroys a user's uploaded backup. |
+| Seed blobs, legacy flat (pre-#1793) keys | Not under the swept prefix. |
+
+### Rollout: report → delete
+
+The worker ships in **`report` mode and deletes nothing.** A false
+positive here is irreversible user data loss (`files` has no soft-delete
+column, and the row delete takes the blob and thumbnails with it), so the
+predicate has to be observed against real data before it earns the right
+to delete.
+
+```bash
+# 1. Default. Scan + log + metrics, DELETE NOTHING.
+--orphan-file-gc-mode=report
+
+# 2. Only after watching the candidate stream for a full release cycle.
+--orphan-file-gc-mode=delete
+
+# Or skip the scan entirely (no bucket LIST cost).
+--orphan-file-gc-mode=off
+```
+
+Watch **`inventario_orphan_gc_candidates_total{kind="row"|"thumbnail"}`**
+— it increments in *both* modes. Steady state should be ~0; a small,
+explainable number after a known crash is expected. Every candidate is
+logged (`event=orphan_gc.row` / `event=orphan_gc.thumbnail`) with enough
+detail to hand-verify it against the UI, and — in delete mode — the log
+line is the only artifact from which a destroyed file can be
+reconstructed.
+
+### Knobs
+
+| Flag | Default | Notes |
+| ---- | ------- | ----- |
+| `--orphan-file-gc-mode` | `report` | `off` \| `report` \| `delete`. An unknown value **fails startup**. |
+| `--orphan-file-gc-min-age` | `72h` | Minimum age of a row (both `created_at` *and* `updated_at`) or a blob (bucket `ModTime`). **Hard floor 24h** — a lower value fails startup. |
+| `--orphan-file-gc-interval` | `24h` | Sweep cadence. |
+
+### `inventario_orphan_gc_blocked_tenants` > 0
+
+A tenant is skipped while it has an export or restore in flight — and for
+`min_age` after one finishes (a restore writes the *archive's* timestamps
+onto the rows it creates, so those rows would otherwise clear the age gate
+instantly). The blocking operation is named in an
+`event=orphan_gc.blocked` log line.
+
+There is no heartbeat on exports/restores, so a **crashed** operation stays
+`running` / `in_progress` forever and pins its tenant permanently. That is
+the correct direction (under-collecting forever beats one wrong delete),
+but it needs manual attention: investigate and resolve the stuck operation.
+**Do not add a "stale after N hours → ignore it" escape hatch** — that
+re-opens exactly the race the gate closes.
+
+### Stopping it
+
+```bash
+inventario workers pause --type orphan-file-gc --reason "investigating a candidate" \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+```
+
+The sweep is skipped on the next tick; no restart needed.
 
 ---
 

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -104,6 +104,9 @@ func (c *Command) run() error {
 	stopGroupPurge := bootstrap.StartGroupPurgeWorker(ctx, rs, c.cfg)
 	defer stopGroupPurge()
 
+	stopOrphanFileGC := bootstrap.StartOrphanFileGCWorker(ctx, rs, c.cfg)
+	defer stopOrphanFileGC()
+
 	stopWarrantyReminder := bootstrap.StartWarrantyReminderWorker(ctx, rs, c.cfg)
 	defer stopWarrantyReminder()
 

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -46,8 +46,15 @@ type Config struct {
 	CurrencyMigrationInterval        string `yaml:"currency_migration_interval" env:"CURRENCY_MIGRATION_INTERVAL" env-default:""`
 	BusinessMetricsInterval          string `yaml:"business_metrics_interval" env:"BUSINESS_METRICS_INTERVAL" env-default:""`
 	WorkerControlRefreshInterval     string `yaml:"worker_control_refresh_interval" env:"WORKER_CONTROL_REFRESH_INTERVAL" env-default:""`
-	JWTSecret                        string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
-	FileSigningKey                   string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
+	// Orphan-file GC (#2237). Mode is off | report | delete and is validated
+	// at startup — an unknown value fails fast rather than silently defaulting
+	// a destructive knob.
+	OrphanFileGCInterval string `yaml:"orphan_file_gc_interval" env:"ORPHAN_FILE_GC_INTERVAL" env-default:""`
+	OrphanFileGCMinAge   string `yaml:"orphan_file_gc_min_age" env:"ORPHAN_FILE_GC_MIN_AGE" env-default:""`
+	OrphanFileGCMode     string `yaml:"orphan_file_gc_mode" env:"ORPHAN_FILE_GC_MODE" env-default:""`
+
+	JWTSecret      string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
+	FileSigningKey string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	// BackupSigningKey is the Ed25519 seed used to sign `.inb` backup
 	// archives (issue #534). Unlike the HMAC keys above it must decode to
 	// EXACTLY 32 bytes (the Ed25519 seed size): supply 64 hex characters
@@ -388,6 +395,26 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.WorkerControlRefreshInterval == "" {
 		c.WorkerControlRefreshInterval = defaults.GetWorkerControlRefreshInterval()
+	}
+	c.setOrphanFileGCDefaults()
+}
+
+// setOrphanFileGCDefaults applies defaults to the orphan-file GC knobs (#2237).
+// Split out of setWorkerDefaults so the destructive worker's three safety knobs
+// sit together (and so setWorkerDefaults stays inside the cyclomatic budget).
+//
+// The mode default is itself a safety property: the worker ships as `report`,
+// which evaluates the full predicate and deletes nothing. It must never default
+// to `delete`.
+func (c *Config) setOrphanFileGCDefaults() {
+	if c.OrphanFileGCInterval == "" {
+		c.OrphanFileGCInterval = defaults.GetOrphanFileGCInterval()
+	}
+	if c.OrphanFileGCMinAge == "" {
+		c.OrphanFileGCMinAge = defaults.GetOrphanFileGCMinAge()
+	}
+	if c.OrphanFileGCMode == "" {
+		c.OrphanFileGCMode = defaults.GetOrphanFileGCMode()
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/denisvmedia/inventario/services"
 )
 
 // WorkerDurations holds the parsed time.Duration values for every duration-
@@ -26,6 +28,8 @@ type WorkerDurations struct {
 	CurrencyMigrationInterval        time.Duration
 	BusinessMetricsInterval          time.Duration
 	WorkerControlRefreshInterval     time.Duration
+	OrphanFileGCInterval             time.Duration
+	OrphanFileGCMinAge               time.Duration
 	ThumbnailPollInterval            time.Duration
 	ThumbnailCleanupInterval         time.Duration
 	ThumbnailJobRetentionPeriod      time.Duration
@@ -71,6 +75,8 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		{"maintenance-reminder-interval", cfg.MaintenanceReminderInterval, &out.MaintenanceReminderInterval},
 		{"currency-migration-interval", cfg.CurrencyMigrationInterval, &out.CurrencyMigrationInterval},
 		{"business-metrics-interval", cfg.BusinessMetricsInterval, &out.BusinessMetricsInterval},
+		{"orphan-file-gc-interval", cfg.OrphanFileGCInterval, &out.OrphanFileGCInterval},
+		{"orphan-file-gc-min-age", cfg.OrphanFileGCMinAge, &out.OrphanFileGCMinAge},
 		{"thumbnail-poll-interval", cfg.ThumbnailPollInterval, &out.ThumbnailPollInterval},
 		{"thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, &out.ThumbnailCleanupInterval},
 		{"thumbnail-job-retention-period", cfg.ThumbnailJobRetentionPeriod, &out.ThumbnailJobRetentionPeriod},
@@ -84,6 +90,27 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 			return WorkerDurations{}, err
 		}
 		*spec.dst = d
+	}
+
+	// The orphan-file GC min-age (#2237) has a HARD FLOOR on top of the
+	// positive-value check every other duration gets. The GC is the only
+	// destructive periodic worker in the tree and the age gate is one of its
+	// load-bearing safety properties, so a too-short window is a startup
+	// failure, not a warning an operator can miss in a log.
+	if out.OrphanFileGCMinAge < services.MinOrphanFileGCMinAge {
+		err := fmt.Errorf("invalid --orphan-file-gc-min-age %q: must be at least %s",
+			cfg.OrphanFileGCMinAge, services.MinOrphanFileGCMinAge)
+		slog.Error("Refusing to start the orphan-file GC with an unsafe min-age", "error", err)
+		return WorkerDurations{}, err
+	}
+
+	// The orphan-file GC mode (#2237) is validated here too, alongside the
+	// durations, so every knob the destructive worker reads is checked before
+	// a single goroutine starts.
+	if _, ok := services.ParseOrphanFileGCMode(cfg.OrphanFileGCMode); !ok {
+		err := fmt.Errorf("invalid --orphan-file-gc-mode %q: must be one of off, report, delete", cfg.OrphanFileGCMode)
+		slog.Error("Refusing to start with an unknown orphan-file GC mode", "error", err)
+		return WorkerDurations{}, err
 	}
 
 	// The soft-pause refresh interval (#1308) is parsed tolerantly rather

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -27,6 +27,9 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 		MaintenanceReminderInterval:      "55m",
 		CurrencyMigrationInterval:        "8s",
 		BusinessMetricsInterval:          "90s",
+		OrphanFileGCInterval:             "12h",
+		OrphanFileGCMinAge:               "48h",
+		OrphanFileGCMode:                 "report",
 		ThumbnailPollInterval:            "7s",
 		ThumbnailCleanupInterval:         "6m",
 		ThumbnailJobRetentionPeriod:      "48h",
@@ -53,6 +56,8 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.MaintenanceReminderInterval, qt.Equals, 55*time.Minute)
 	c.Assert(got.CurrencyMigrationInterval, qt.Equals, 8*time.Second)
 	c.Assert(got.BusinessMetricsInterval, qt.Equals, 90*time.Second)
+	c.Assert(got.OrphanFileGCInterval, qt.Equals, 12*time.Hour)
+	c.Assert(got.OrphanFileGCMinAge, qt.Equals, 48*time.Hour)
 	c.Assert(got.ThumbnailPollInterval, qt.Equals, 7*time.Second)
 	c.Assert(got.ThumbnailCleanupInterval, qt.Equals, 6*time.Minute)
 	c.Assert(got.ThumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)
@@ -140,4 +145,73 @@ func TestParseWorkerDurations_FailsOnInvalidFlag(t *testing.T) {
 			c.Assert(got, qt.Equals, bootstrap.WorkerDurations{})
 		})
 	}
+}
+
+// The orphan-file GC is the only DESTRUCTIVE periodic worker in the tree, so
+// both of its safety knobs are validated at startup and a bad value is a hard
+// failure, not a warning an operator can miss in a log (#2237).
+func TestParseWorkerDurations_OrphanFileGCSafetyKnobs(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(*bootstrap.Config)
+		wantMessage string
+	}{
+		{
+			name:        "min-age below the 24h hard floor is rejected",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCMinAge = "1h" },
+			wantMessage: "must be at least",
+		},
+		{
+			name:        "min-age exactly one second below the floor is rejected",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCMinAge = "23h59m59s" },
+			wantMessage: "must be at least",
+		},
+		{
+			name:        "non-positive interval is rejected",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCInterval = "0s" },
+			wantMessage: "must be positive",
+		},
+		{
+			name:        "malformed interval is rejected",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCInterval = "nope" },
+			wantMessage: "invalid",
+		},
+		{
+			name:        "unknown mode is rejected",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCMode = "purge" },
+			wantMessage: "must be one of off, report, delete",
+		},
+		{
+			name:        "mode is case-sensitive",
+			mutate:      func(c *bootstrap.Config) { c.OrphanFileGCMode = "DELETE" },
+			wantMessage: "must be one of off, report, delete",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg := &bootstrap.Config{}
+			cfg.SetDefaults()
+			tc.mutate(cfg)
+
+			_, err := bootstrap.ParseWorkerDurations(cfg)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tc.wantMessage)
+		})
+	}
+}
+
+// The floor itself is accepted — it is a floor, not an exclusive bound.
+func TestParseWorkerDurations_OrphanFileGCMinAgeFloorIsInclusive(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &bootstrap.Config{}
+	cfg.SetDefaults()
+	cfg.OrphanFileGCMinAge = "24h"
+
+	got, err := bootstrap.ParseWorkerDurations(cfg)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.OrphanFileGCMinAge, qt.Equals, 24*time.Hour)
 }

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -38,6 +38,11 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.MaintenanceReminderInterval, "maintenance-reminder-interval", cfg.MaintenanceReminderInterval, "Interval between maintenance reminder sweeps (14/7/1-day + overdue maintenance emails; e.g., 1h)")
 	flags.StringVar(&cfg.CurrencyMigrationInterval, "currency-migration-interval", cfg.CurrencyMigrationInterval, "Currency migration worker active-poll interval (when pending rows exist; idle cadence is fixed at 1m). Values like 5s, 10s.")
 	flags.StringVar(&cfg.BusinessMetricsInterval, "business-metrics-interval", cfg.BusinessMetricsInterval, "Interval between installation-wide business-metrics collection sweeps (#843; e.g., 60s)")
+	flags.StringVar(&cfg.OrphanFileGCInterval, "orphan-file-gc-interval", cfg.OrphanFileGCInterval, "Interval between orphan-file GC sweeps (#2237; e.g., 24h)")
+
+	flags.StringVar(&cfg.OrphanFileGCMinAge, "orphan-file-gc-min-age", cfg.OrphanFileGCMinAge, "Minimum age a file row / thumbnail blob must reach before the orphan-file GC considers it (#2237; default 72h, hard floor 24h)")
+	//nolint:lll
+	flags.StringVar(&cfg.OrphanFileGCMode, "orphan-file-gc-mode", cfg.OrphanFileGCMode, "Orphan-file GC mode: off (no scan), report (scan + log + metrics, DELETES NOTHING; the default) or delete (enforce). Deletion is irreversible — watch inventario_orphan_gc_candidates_total in report mode for a full release cycle before enabling delete.")
 	flags.IntVar(&cfg.ThumbnailBatchSize, "thumbnail-batch-size", cfg.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
 	flags.StringVar(&cfg.ThumbnailPollInterval, "thumbnail-poll-interval", cfg.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")
 	flags.StringVar(&cfg.ThumbnailCleanupInterval, "thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, "Interval between thumbnail job cleanup runs (e.g., 5m)")

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -206,6 +206,79 @@ func StartGroupPurgeWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) fun
 	return worker.Stop
 }
 
+// StartOrphanFileGCWorker wires and starts the orphan-file GC sweeper (#2237)
+// and returns its stop function.
+//
+// This is the only DESTRUCTIVE periodic worker in the tree. Two things about
+// the wiring are load-bearing:
+//
+//  1. Every registry it reads is a SERVICE (RLS-bypassing) registry, and every
+//     one of them is read-only. In particular the linked-entity existence
+//     probes MUST be service-mode and match BY ID ONLY: PUT /files/{id} does
+//     not validate the link target's group, so a file legitimately linked to an
+//     entity in ANOTHER group exists in production, and a group-scoped probe
+//     would read that LIVE entity as missing and hand the GC a live file.
+//  2. Deletion goes exclusively through services.FileService.DeleteFileWithPhysical,
+//     which internally creates a USER-scoped registry. The worker impersonates
+//     the file's own creator + group, so the DELETE statement executes under RLS
+//     bound to the file's own (tenant, group): discovery is broad, destruction
+//     is narrow.
+//
+// It ships in report mode (see Config.OrphanFileGCMode) and therefore deletes
+// nothing until an operator explicitly opts in.
+func StartOrphanFileGCWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
+	fs := rs.FactorySet
+	fileService := services.NewFileService(fs, rs.Params.UploadLocation)
+
+	// Service-mode (RLS-bypassing), read-only. Held for the process lifetime,
+	// matching StartOperationSlotCleanupWorker.
+	commodityReg := fs.CommodityRegistryFactory.CreateServiceRegistry()
+	areaReg := fs.AreaRegistryFactory.CreateServiceRegistry()
+	locationReg := fs.LocationRegistryFactory.CreateServiceRegistry()
+
+	deps := services.OrphanFileGCDeps{
+		Files: fs.FileRegistryFactory.CreateServiceRegistry(),
+		Probes: services.OrphanFileGCProbes{
+			Commodity: func(ctx context.Context, id string) error {
+				_, err := commodityReg.Get(ctx, id)
+				return err
+			},
+			Area: func(ctx context.Context, id string) error {
+				_, err := areaReg.Get(ctx, id)
+				return err
+			},
+			Location: func(ctx context.Context, id string) error {
+				_, err := locationReg.Get(ctx, id)
+				return err
+			},
+		},
+		Exports:        fs.ExportRegistryFactory.CreateServiceRegistry(),
+		Restores:       fs.RestoreOperationRegistryFactory.CreateServiceRegistry(),
+		Tenants:        fs.TenantRegistry,
+		Groups:         fs.LocationGroupRegistry,
+		Users:          fs.UserRegistry,
+		Deleter:        fileService,
+		UploadLocation: rs.Params.UploadLocation,
+	}
+
+	// Both values were already validated in ParseWorkerDurations (positive
+	// interval, min-age at or above the hard floor, known mode), so the
+	// options here cannot silently fall back.
+	mode, _ := services.ParseOrphanFileGCMode(cfg.OrphanFileGCMode)
+	opts := []services.OrphanFileGCOption{
+		services.WithOrphanFileGCInterval(rs.WorkerDurations.OrphanFileGCInterval),
+		services.WithOrphanFileGCMinAge(rs.WorkerDurations.OrphanFileGCMinAge),
+		services.WithOrphanFileGCMode(mode),
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithOrphanFileGCPauseController(rs.PauseController))
+	}
+
+	worker := services.NewOrphanFileGCWorker(deps, opts...)
+	worker.Start(ctx)
+	return worker.Stop
+}
+
 // StartWarrantyReminderWorker wires and starts the warranty reminder
 // worker (#1367). Mirrors the group-purge wiring: takes the configured
 // interval from rs.WorkerDurations and pulls the public URL from cfg

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -158,6 +158,7 @@ func (c *Command) run() error {
 			bootstrap.StartOperationSlotCleanupWorker,
 			bootstrap.StartLoginEventRetentionWorker,
 			bootstrap.StartGroupPurgeWorker,
+			bootstrap.StartOrphanFileGCWorker,
 			bootstrap.StartWarrantyReminderWorker,
 			bootstrap.StartStorageQuotaReminderWorker,
 			bootstrap.StartLoanReminderWorker,

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -41,6 +41,9 @@ type Workers struct {
 	CurrencyMigrationInterval        string // Currency migration worker active-poll interval (e.g., "5s")
 	BusinessMetricsInterval          string // Business-metrics collector interval (e.g., "60s")
 	WorkerControlRefreshInterval     string // Worker soft-pause control poll interval (e.g., "10s")
+	OrphanFileGCInterval             string // Orphan-file GC sweep interval (e.g., "24h")
+	OrphanFileGCMinAge               string // Minimum age before an orphan row/blob is eligible (e.g., "72h"; hard floor 24h)
+	OrphanFileGCMode                 string // Orphan-file GC mode: off | report | delete. Ships as "report" — it deletes nothing.
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -112,6 +115,15 @@ func New() Config {
 			CurrencyMigrationInterval:        "5s",
 			BusinessMetricsInterval:          "60s",
 			WorkerControlRefreshInterval:     "10s",
+			// Orphan-file GC (#2237). Ships in REPORT mode: it evaluates the
+			// full predicate, logs every candidate and increments
+			// inventario_orphan_gc_candidates_total — and deletes nothing.
+			// A false positive here is irreversible user data loss, so the
+			// predicate has to be observed against real data before an
+			// operator opts into --orphan-file-gc-mode=delete.
+			OrphanFileGCInterval: "24h",
+			OrphanFileGCMinAge:   "72h",
+			OrphanFileGCMode:     "report",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -217,6 +229,25 @@ func GetOperationSlotCleanupInterval() string {
 // GetGroupPurgeInterval returns the default interval between group purge sweeps.
 func GetGroupPurgeInterval() string {
 	return defaultConfig.Workers.GroupPurgeInterval
+}
+
+// GetOrphanFileGCInterval returns the default interval between orphan-file GC
+// sweeps (#2237).
+func GetOrphanFileGCInterval() string {
+	return defaultConfig.Workers.OrphanFileGCInterval
+}
+
+// GetOrphanFileGCMinAge returns the default minimum age a file row / thumbnail
+// blob must reach before the orphan-file GC will consider it (#2237).
+func GetOrphanFileGCMinAge() string {
+	return defaultConfig.Workers.OrphanFileGCMinAge
+}
+
+// GetOrphanFileGCMode returns the default orphan-file GC mode (#2237) —
+// "report", i.e. observe-only. Enforcement requires an explicit operator
+// opt-in.
+func GetOrphanFileGCMode() string {
+	return defaultConfig.Workers.OrphanFileGCMode
 }
 
 // GetWarrantyReminderInterval returns the default interval between

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -35,6 +35,11 @@ func TestDefaults(t *testing.T) {
 	c.Assert(cfg.Workers.GroupPurgeInterval, qt.Equals, "5m")
 	c.Assert(cfg.Workers.CurrencyMigrationInterval, qt.Equals, "5s")
 	c.Assert(cfg.Workers.WorkerControlRefreshInterval, qt.Equals, "10s")
+	// Orphan-file GC (#2237). The mode default is a SAFETY property: the
+	// worker ships observe-only and must never default to deleting.
+	c.Assert(cfg.Workers.OrphanFileGCInterval, qt.Equals, "24h")
+	c.Assert(cfg.Workers.OrphanFileGCMinAge, qt.Equals, "72h")
+	c.Assert(cfg.Workers.OrphanFileGCMode, qt.Equals, "report")
 
 	// Test thumbnail generation defaults
 	c.Assert(cfg.ThumbnailGeneration.MaxConcurrentPerUser, qt.Equals, 5)
@@ -65,6 +70,9 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetGroupPurgeInterval(), qt.Equals, "5m")
 	c.Assert(defaults.GetCurrencyMigrationInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetWorkerControlRefreshInterval(), qt.Equals, "10s")
+	c.Assert(defaults.GetOrphanFileGCInterval(), qt.Equals, "24h")
+	c.Assert(defaults.GetOrphanFileGCMinAge(), qt.Equals, "72h")
+	c.Assert(defaults.GetOrphanFileGCMode(), qt.Equals, "report")
 	c.Assert(defaults.GetThumbnailBatchSize(), qt.Equals, 10)
 	c.Assert(defaults.GetThumbnailPollInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetThumbnailCleanupInterval(), qt.Equals, "5m")

--- a/go/models/worker_control.go
+++ b/go/models/worker_control.go
@@ -45,6 +45,12 @@ const (
 	WorkerTypeMaintenanceReminder WorkerType = "maintenance-reminder"
 	// WorkerTypeCurrencyMigration pauses the currency migration worker.
 	WorkerTypeCurrencyMigration WorkerType = "currency-migration"
+	// WorkerTypeOrphanFileGC pauses the orphan-file GC sweeper (#2237).
+	// This is the only DESTRUCTIVE periodic worker in the set: pausing it
+	// is the operator's emergency stop, so the constant MUST also appear
+	// in allWorkerTypes and IsValid below — workerpause fails OPEN for
+	// unknown types, which would make the sweeper unpausable.
+	WorkerTypeOrphanFileGC WorkerType = "orphan-file-gc"
 )
 
 // allWorkerTypes is the canonical ordered set of pausable worker types.
@@ -67,6 +73,7 @@ var allWorkerTypes = []WorkerType{
 	WorkerTypeLoanReminder,
 	WorkerTypeMaintenanceReminder,
 	WorkerTypeCurrencyMigration,
+	WorkerTypeOrphanFileGC,
 }
 
 // AllWorkerTypes returns a copy of the canonical ordered worker-type set.
@@ -96,7 +103,8 @@ func (w WorkerType) IsValid() bool {
 		WorkerTypeStorageQuotaReminder,
 		WorkerTypeLoanReminder,
 		WorkerTypeMaintenanceReminder,
-		WorkerTypeCurrencyMigration:
+		WorkerTypeCurrencyMigration,
+		WorkerTypeOrphanFileGC:
 		return true
 	}
 	return false

--- a/go/models/worker_control_test.go
+++ b/go/models/worker_control_test.go
@@ -13,7 +13,7 @@ import (
 // it does not know about (IsPaused returns false for an unknown key), so a
 // constant that is declared but omitted from allWorkerTypes would make the
 // only DESTRUCTIVE periodic worker in the tree impossible for an operator to
-// stop with `inventario workers pause orphan-file-gc`. Assert the whole
+// stop with `inventario workers pause --type orphan-file-gc`. Assert the whole
 // round-trip: the const is canonical, parses, validates, and is enumerated.
 func TestWorkerTypeOrphanFileGC_IsPausable(t *testing.T) {
 	c := qt.New(t)

--- a/go/models/worker_control_test.go
+++ b/go/models/worker_control_test.go
@@ -1,0 +1,61 @@
+package models_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+// TestWorkerTypeOrphanFileGC_IsPausable is the highest-value guard on the
+// #2237 orphan-file GC: workerpause.Controller fails OPEN for worker types
+// it does not know about (IsPaused returns false for an unknown key), so a
+// constant that is declared but omitted from allWorkerTypes would make the
+// only DESTRUCTIVE periodic worker in the tree impossible for an operator to
+// stop with `inventario workers pause orphan-file-gc`. Assert the whole
+// round-trip: the const is canonical, parses, validates, and is enumerated.
+func TestWorkerTypeOrphanFileGC_IsPausable(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(string(models.WorkerTypeOrphanFileGC), qt.Equals, "orphan-file-gc")
+	c.Assert(models.WorkerTypeOrphanFileGC.IsValid(), qt.IsTrue)
+
+	parsed, ok := models.ParseWorkerType("orphan-file-gc")
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(parsed, qt.Equals, models.WorkerTypeOrphanFileGC)
+
+	c.Assert(models.AllWorkerTypes(), qt.Contains, models.WorkerTypeOrphanFileGC)
+}
+
+// TestAllWorkerTypes_AreValidAndParseable keeps the three sources of truth in
+// worker_control.go (the const block, allWorkerTypes, IsValid) from drifting:
+// every enumerated type must validate and round-trip through ParseWorkerType.
+func TestAllWorkerTypes_AreValidAndParseable(t *testing.T) {
+	c := qt.New(t)
+
+	all := models.AllWorkerTypes()
+	c.Assert(all, qt.Not(qt.HasLen), 0)
+
+	seen := make(map[models.WorkerType]bool, len(all))
+	for _, wt := range all {
+		c.Assert(wt.IsValid(), qt.IsTrue, qt.Commentf("worker type %q is enumerated but not accepted by IsValid", wt))
+
+		parsed, ok := models.ParseWorkerType(string(wt))
+		c.Assert(ok, qt.IsTrue, qt.Commentf("worker type %q does not round-trip through ParseWorkerType", wt))
+		c.Assert(parsed, qt.Equals, wt)
+
+		c.Assert(seen[wt], qt.IsFalse, qt.Commentf("worker type %q is listed twice", wt))
+		seen[wt] = true
+	}
+}
+
+func TestParseWorkerType_Unknown(t *testing.T) {
+	c := qt.New(t)
+
+	for _, s := range []string{"", "orphan-file-gc ", "orphan_file_gc", "email", "nope"} {
+		parsed, ok := models.ParseWorkerType(s)
+		c.Assert(ok, qt.IsFalse, qt.Commentf("input %q", s))
+		c.Assert(parsed, qt.Equals, models.WorkerType(""))
+	}
+}

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -454,23 +454,28 @@ func (r *FileRegistry) CountByOriginalPath(_ context.Context, originalPath strin
 	return count, nil
 }
 
-// ListIDsByTenant mirrors the postgres method — the ids of every file row
-// owned by tenantID, across all its groups (#2237). Service-mode only.
-func (r *FileRegistry) ListIDsByTenant(_ context.Context, tenantID string) ([]string, error) {
-	if tenantID == "" {
-		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+// ExistingIDs mirrors the postgres method — the subset of ids that still have a
+// file row (#2237). Service-mode only.
+func (r *FileRegistry) ExistingIDs(_ context.Context, ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
 	}
-	var ids []string
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+
+	var existing []string
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
 		file := pair.Value
-		if file == nil || file.TenantID != tenantID {
+		if file == nil || !want[file.ID] {
 			continue
 		}
-		ids = append(ids, file.ID)
+		existing = append(existing, file.ID)
 	}
-	return ids, nil
+	return existing, nil
 }
 
 // SumSizeBreakdown mirrors the postgres aggregator: per-category byte

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -2,11 +2,13 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 
@@ -18,6 +20,18 @@ import (
 // FileRegistryFactory creates FileRegistry instances with proper context
 type FileRegistryFactory struct {
 	baseFileRegistry *Registry[models.FileEntity, *models.FileEntity]
+
+	// Sibling factories used ONLY by ListOrphanCandidates (#2237) to answer
+	// "does the entity this file is linked to still exist?". Postgres asks
+	// that with a SQL anti-join; the memory backend has no planner, so it
+	// has to hold the other registries. Wired by NewFactorySet via
+	// SetLinkedEntityFactories; nil for a bare NewFileRegistryFactory()
+	// (unit tests that only exercise the file table), in which case
+	// ListOrphanCandidates FAILS CLOSED with an error rather than
+	// reporting "the entity is gone" on no evidence.
+	commodityFactory *CommodityRegistryFactory
+	areaFactory      *AreaRegistryFactory
+	locationFactory  *LocationRegistryFactory
 }
 
 // FileRegistry is a context-aware registry that can only be created through the factory
@@ -25,6 +39,12 @@ type FileRegistry struct {
 	*Registry[models.FileEntity, *models.FileEntity]
 
 	userID string
+
+	// Carried from the factory; see FileRegistryFactory. Only read by
+	// ListOrphanCandidates.
+	commodityFactory *CommodityRegistryFactory
+	areaFactory      *AreaRegistryFactory
+	locationFactory  *LocationRegistryFactory
 }
 
 var _ registry.FileRegistry = (*FileRegistry)(nil)
@@ -34,6 +54,20 @@ func NewFileRegistryFactory() *FileRegistryFactory {
 	return &FileRegistryFactory{
 		baseFileRegistry: NewRegistry[models.FileEntity, *models.FileEntity](),
 	}
+}
+
+// SetLinkedEntityFactories wires the sibling registries the orphan-candidate
+// scan (#2237) probes for existence. Called once from NewFactorySet, after
+// all three factories exist. Leaving them unset is safe: ListOrphanCandidates
+// refuses to run rather than mis-report a live entity as missing.
+func (f *FileRegistryFactory) SetLinkedEntityFactories(
+	commodity *CommodityRegistryFactory,
+	area *AreaRegistryFactory,
+	location *LocationRegistryFactory,
+) {
+	f.commodityFactory = commodity
+	f.areaFactory = area
+	f.locationFactory = location
 }
 
 // Factory methods implementing registry.FileRegistryFactory
@@ -58,8 +92,11 @@ func (f *FileRegistryFactory) CreateUserRegistry(ctx context.Context) (registry.
 	}
 
 	return &FileRegistry{
-		Registry: userRegistry,
-		userID:   user.ID,
+		Registry:         userRegistry,
+		userID:           user.ID,
+		commodityFactory: f.commodityFactory,
+		areaFactory:      f.areaFactory,
+		locationFactory:  f.locationFactory,
 	}, nil
 }
 
@@ -72,8 +109,11 @@ func (f *FileRegistryFactory) CreateServiceRegistry() registry.FileRegistry {
 	}
 
 	return &FileRegistry{
-		Registry: serviceRegistry,
-		userID:   "", // Clear userID to bypass user filtering
+		Registry:         serviceRegistry,
+		userID:           "", // Clear userID to bypass user filtering
+		commodityFactory: f.commodityFactory,
+		areaFactory:      f.areaFactory,
+		locationFactory:  f.locationFactory,
 	}
 }
 
@@ -262,6 +302,175 @@ func (r *FileRegistry) ListPendingSizeBackfill(_ context.Context, limit int) ([]
 		}
 	}
 	return pending, nil
+}
+
+// orphanCandidateLinkTypes is the positive ALLOWLIST of linked_entity_type
+// values the orphan-file GC (#2237) understands. It mirrors the IN (...) list
+// in the postgres ListOrphanCandidates query verbatim, and it is an allowlist
+// on purpose:
+//
+//   - ""       → a STANDALONE file. First-class since #2235 — it has no link,
+//     so it can never have a DANGLING one. Excluded structurally.
+//   - "export" → the backup subsystem's own artifact, with its own lifecycle.
+//     Excluded structurally, so the `deleted_at IS NULL` filter on the exports
+//     registry can never be misread as "the export is gone".
+//   - anything else (a future link type; the registries do NOT enforce
+//     models.FileEntity.ValidateWithContext, so the DB is a superset of the
+//     validator's enumeration) → excluded, fails closed.
+var orphanCandidateLinkTypes = map[string]bool{
+	"commodity": true,
+	"area":      true,
+	"location":  true,
+}
+
+// ListOrphanCandidates mirrors the postgres method — file rows in the
+// linked-entity allowlist whose target no longer exists and whose BOTH
+// timestamps are older than olderThan (#2237). The memory backend has no SQL
+// planner, so the anti-join is three Get probes against the sibling service
+// registries.
+//
+// Runs in service mode (the GC is RLS-blind by necessity: a file may be
+// legitimately linked to an entity in another group, and a group-scoped probe
+// would read that LIVE entity as missing). Fails closed when the sibling
+// factories were never wired.
+func (r *FileRegistry) ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if r.commodityFactory == nil || r.areaFactory == nil || r.locationFactory == nil {
+		// No evidence available ⇒ no deletions. Never guess.
+		return nil, errxtrace.Classify(registry.ErrFieldRequired,
+			errx.Attrs("field_name", "linkedEntityFactories"))
+	}
+
+	// Snapshot the shape-eligible rows under the read lock, then probe the
+	// sibling registries with the lock released (they own their own mutexes;
+	// this just keeps the critical section short and honest).
+	var shortlist []*models.FileEntity
+	r.lock.RLock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		file := pair.Value
+		if file == nil {
+			continue
+		}
+		if !orphanCandidateLinkTypes[file.LinkedEntityType] {
+			continue // allowlist: standalone (#2235), export, and unknown types are never candidates
+		}
+		if file.LinkedEntityID == "" {
+			continue // malformed link, not garbage — the worker reports it, never deletes it
+		}
+		if !file.CreatedAt.Before(olderThan) || !file.UpdatedAt.Before(olderThan) {
+			continue // BOTH timestamps must clear the age gate
+		}
+		if !afterOrphanCursor(file, after) {
+			continue // already covered by an earlier page of this scan
+		}
+		v := *file
+		shortlist = append(shortlist, &v)
+	}
+	r.lock.RUnlock()
+
+	// (created_at, id) ascending — the same total order the postgres keyset
+	// query produces, so a cursor handed back by one backend means the same
+	// thing in the other.
+	sort.SliceStable(shortlist, func(i, j int) bool {
+		return lessOrphanKeyset(shortlist[i], shortlist[j])
+	})
+
+	comReg := r.commodityFactory.CreateServiceRegistry()
+	areaReg := r.areaFactory.CreateServiceRegistry()
+	locReg := r.locationFactory.CreateServiceRegistry()
+
+	var orphans []*models.FileEntity
+	for _, file := range shortlist {
+		var err error
+		switch file.LinkedEntityType {
+		case "commodity":
+			_, err = comReg.Get(ctx, file.LinkedEntityID)
+		case "area":
+			_, err = areaReg.Get(ctx, file.LinkedEntityID)
+		case "location":
+			_, err = locReg.Get(ctx, file.LinkedEntityID)
+		default:
+			continue // unreachable: the allowlist above already filtered
+		}
+		switch {
+		case err == nil:
+			continue // the entity is alive — not an orphan
+		case errors.Is(err, registry.ErrNotFound):
+			orphans = append(orphans, file)
+		default:
+			// A transient probe failure must never read as "gone".
+			return nil, errxtrace.Wrap("failed to probe linked entity existence", err)
+		}
+		if len(orphans) >= limit {
+			break
+		}
+	}
+	return orphans, nil
+}
+
+// lessOrphanKeyset orders two candidates by the (created_at, id) keyset the
+// paged scan resumes on.
+func lessOrphanKeyset(a, b *models.FileEntity) bool {
+	if a.CreatedAt.Equal(b.CreatedAt) {
+		return a.ID < b.ID
+	}
+	return a.CreatedAt.Before(b.CreatedAt)
+}
+
+// afterOrphanCursor reports whether file sorts strictly after the cursor in the
+// (created_at, id) keyset order. A zero cursor accepts every row.
+func afterOrphanCursor(file *models.FileEntity, after registry.OrphanCandidateCursor) bool {
+	if after.IsZero() {
+		return true
+	}
+	if file.CreatedAt.Equal(after.CreatedAt) {
+		return file.ID > after.ID
+	}
+	return file.CreatedAt.After(after.CreatedAt)
+}
+
+// CountByOriginalPath mirrors the postgres method — how many file rows, across
+// EVERY tenant and group, reference the given blob key (#2237). Service-mode
+// only: it reads the shared item map directly rather than through the
+// visibility filter, because the whole point is to see rows the caller cannot.
+func (r *FileRegistry) CountByOriginalPath(_ context.Context, originalPath string) (int, error) {
+	if originalPath == "" {
+		return 0, nil
+	}
+	count := 0
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		file := pair.Value
+		if file == nil || file.File == nil {
+			continue
+		}
+		if file.OriginalPath == originalPath {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// ListIDsByTenant mirrors the postgres method — the ids of every file row
+// owned by tenantID, across all its groups (#2237). Service-mode only.
+func (r *FileRegistry) ListIDsByTenant(_ context.Context, tenantID string) ([]string, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	var ids []string
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		file := pair.Value
+		if file == nil || file.TenantID != tenantID {
+			continue
+		}
+		ids = append(ids, file.ID)
+	}
+	return ids, nil
 }
 
 // SumSizeBreakdown mirrors the postgres aggregator: per-category byte

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -357,7 +357,7 @@ func (r *FileRegistry) ListOrphanCandidates(ctx context.Context, olderThan time.
 			continue // allowlist: standalone (#2235), export, and unknown types are never candidates
 		}
 		if file.LinkedEntityID == "" {
-			continue // malformed link, not garbage — the worker reports it, never deletes it
+			continue // malformed link, not garbage: EXCLUDED here, so it is kept and never surfaced
 		}
 		if !file.CreatedAt.Before(olderThan) || !file.UpdatedAt.Before(olderThan) {
 			continue // BOTH timestamps must clear the age gate

--- a/go/registry/memory/files_orphan_candidates_test.go
+++ b/go/registry/memory/files_orphan_candidates_test.go
@@ -221,7 +221,7 @@ func TestMemoryFileRegistry_CountByOriginalPath(t *testing.T) {
 	c.Assert(n, qt.Equals, 0)
 }
 
-func TestMemoryFileRegistry_ListIDsByTenant(t *testing.T) {
+func TestMemoryFileRegistry_ExistingIDs(t *testing.T) {
 	c := qt.New(t)
 	fs := memory.NewFactorySet()
 
@@ -230,7 +230,11 @@ func TestMemoryFileRegistry_ListIDsByTenant(t *testing.T) {
 	b1 := seedOrphanFile(c, fs, "tenant-2", "group-3", "", "", time.Hour)
 
 	reg := fs.FileRegistryFactory.CreateServiceRegistry()
-	ids, err := reg.ListIDsByTenant(context.Background(), "tenant-1")
+
+	// Service mode answers by ID ALONE: an id is "live" wherever it lives, so a
+	// thumbnail whose owning row sits in another group is never mistaken for an
+	// orphan.
+	ids, err := reg.ExistingIDs(context.Background(), []string{a1, a2, b1, "no-such-file"})
 	c.Assert(err, qt.IsNil)
 
 	set := make(map[string]bool, len(ids))
@@ -238,9 +242,13 @@ func TestMemoryFileRegistry_ListIDsByTenant(t *testing.T) {
 		set[id] = true
 	}
 	c.Assert(set[a1], qt.IsTrue)
-	c.Assert(set[a2], qt.IsTrue, qt.Commentf("the set must span every group in the tenant"))
-	c.Assert(set[b1], qt.IsFalse, qt.Commentf("another tenant's file leaked into the membership set"))
+	c.Assert(set[a2], qt.IsTrue, qt.Commentf("a live row in another group of the tenant was reported missing"))
+	c.Assert(set[b1], qt.IsTrue, qt.Commentf("a live row in another tenant was reported missing"))
+	c.Assert(set["no-such-file"], qt.IsFalse)
+	c.Assert(ids, qt.HasLen, 3)
 
-	_, err = reg.ListIDsByTenant(context.Background(), "")
-	c.Assert(err, qt.ErrorIs, registry.ErrFieldRequired)
+	// Empty input never queries.
+	ids, err = reg.ExistingIDs(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ids, qt.HasLen, 0)
 }

--- a/go/registry/memory/files_orphan_candidates_test.go
+++ b/go/registry/memory/files_orphan_candidates_test.go
@@ -1,0 +1,246 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// noCursor starts a candidate scan at the oldest row.
+var noCursor registry.OrphanCandidateCursor
+
+// seedOrphanFile plants a file row through the service registry so the test
+// controls tenant/group/creator/timestamps exactly.
+func seedOrphanFile(c *qt.C, fs *registry.FactorySet, tenantID, groupID, linkType, linkID string, age time.Duration) string {
+	c.Helper()
+	return seedOrphanFileWithPath(c, fs, tenantID, groupID, linkType, linkID, age, "s.jpg")
+}
+
+// seedOrphanFileWithPath is seedOrphanFile with control over the blob key, so a
+// test can plant two DISTINCT rows that share one original_path (the collision
+// that makes a key-scoped blob delete destroy a live file's bytes).
+func seedOrphanFileWithPath(c *qt.C, fs *registry.FactorySet, tenantID, groupID, linkType, linkID string, age time.Duration, originalPath string) string {
+	c.Helper()
+	now := time.Now()
+	f, err := fs.FileRegistryFactory.CreateServiceRegistry().Create(context.Background(), models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: tenantID, GroupID: groupID, CreatedByUserID: "user-1",
+		},
+		Title:            "seeded",
+		Type:             models.FileTypeImage,
+		LinkedEntityType: linkType,
+		LinkedEntityID:   linkID,
+		CreatedAt:        now.Add(-age),
+		UpdatedAt:        now.Add(-age),
+		File:             &models.File{Path: "s", OriginalPath: originalPath, Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+	return f.ID
+}
+
+// The memory backend must apply the SAME positive allowlist as the postgres
+// anti-join (#2237). It is an allowlist, not a negation, precisely so that a
+// STANDALONE file (linked_entity_type = "", first-class since #2235), an
+// export-linked file, and any unknown/future link type can never enter the
+// candidate set a destructive worker consumes.
+func TestMemoryFileRegistry_ListOrphanCandidates_Allowlist(t *testing.T) {
+	tests := []struct {
+		name     string
+		linkType string
+		linkID   string
+		want     bool
+	}{
+		{"commodity orphan is a candidate", "commodity", "gone", true},
+		{"area orphan is a candidate", "area", "gone", true},
+		{"location orphan is a candidate", "location", "gone", true},
+		{"standalone file is NEVER a candidate (#2235)", "", "", false},
+		{"standalone with a stray id is NEVER a candidate", "", "gone", false},
+		{"export-linked file is NEVER a candidate", "export", "gone", false},
+		{"unknown link type fails closed", "widget", "gone", false},
+		{"malformed link (empty id) is data, not garbage", "commodity", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			fs := memory.NewFactorySet()
+
+			id := seedOrphanFile(c, fs, "tenant-1", "group-1", tt.linkType, tt.linkID, 30*24*time.Hour)
+
+			got, err := fs.FileRegistryFactory.CreateServiceRegistry().
+				ListOrphanCandidates(context.Background(), time.Now().Add(-72*time.Hour), noCursor, 100)
+			c.Assert(err, qt.IsNil)
+
+			found := false
+			for _, f := range got {
+				if f.ID == id {
+					found = true
+				}
+			}
+			c.Assert(found, qt.Equals, tt.want)
+		})
+	}
+}
+
+// BOTH timestamps must clear the age gate. updated_at is the load-bearing one:
+// PUT /files/{id} stamps it with the app wall clock, so a file attached
+// concurrently with an entity delete is immune for the whole window.
+func TestMemoryFileRegistry_ListOrphanCandidates_AgeGate(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	oldID := seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour)
+	youngID := seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", time.Hour)
+
+	got, err := fs.FileRegistryFactory.CreateServiceRegistry().
+		ListOrphanCandidates(context.Background(), time.Now().Add(-72*time.Hour), noCursor, 100)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 1)
+	c.Assert(got[0].ID, qt.Equals, oldID)
+	c.Assert(got[0].ID, qt.Not(qt.Equals), youngID)
+}
+
+// The tick is bounded so a pathological install cannot blow memory; the
+// remainder is picked up on the next tick, so the ordering must be stable
+// (oldest first).
+func TestMemoryFileRegistry_ListOrphanCandidates_LimitAndOrdering(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	// Oldest last on insertion, so a naive implementation that skips the sort
+	// would return them in the wrong order.
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 10*24*time.Hour)
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour)
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 20*24*time.Hour)
+
+	reg := fs.FileRegistryFactory.CreateServiceRegistry()
+	ctx := context.Background()
+	cutoff := time.Now().Add(-72 * time.Hour)
+
+	got, err := reg.ListOrphanCandidates(ctx, cutoff, noCursor, 2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 2)
+	c.Assert(got[0].CreatedAt.After(got[1].CreatedAt), qt.IsFalse)
+
+	none, err := reg.ListOrphanCandidates(ctx, cutoff, noCursor, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(none, qt.HasLen, 0)
+}
+
+// A bare NewFileRegistryFactory() has no sibling registries to probe, so it
+// cannot tell whether a linked entity exists. It must FAIL CLOSED — returning
+// an error rather than reporting "the entity is gone" on no evidence.
+func TestMemoryFileRegistry_ListOrphanCandidates_FailsClosedWithoutSiblings(t *testing.T) {
+	c := qt.New(t)
+
+	reg := memory.NewFileRegistryFactory().CreateServiceRegistry()
+	_, err := reg.ListOrphanCandidates(context.Background(), time.Now(), noCursor, 100)
+	c.Assert(err, qt.IsNotNil)
+}
+
+// The scan must be RESUMABLE from a (created_at, id) keyset cursor. Most
+// candidates a tick looks at are KEPT, not deleted, and several keep-reasons
+// never clear (a tenant pinned by a crashed restore, a suspended tenant, a
+// purged owner), so a non-resumable oldest-first window is squatted on by those
+// rows forever and no other orphan is ever enumerated — and in report mode,
+// where nothing is ever deleted, EVERY row is a kept row.
+func TestMemoryFileRegistry_ListOrphanCandidates_KeysetCursor(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour)
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 20*24*time.Hour)
+	seedOrphanFile(c, fs, "tenant-1", "group-1", "commodity", "gone", 10*24*time.Hour)
+
+	reg := fs.FileRegistryFactory.CreateServiceRegistry()
+	ctx := context.Background()
+	cutoff := time.Now().Add(-72 * time.Hour)
+
+	// Page through the whole set one row at a time, deleting nothing — exactly
+	// what report mode does.
+	var seen []string
+	cursor := noCursor
+	for range 3 {
+		page, err := reg.ListOrphanCandidates(ctx, cutoff, cursor, 1)
+		c.Assert(err, qt.IsNil)
+		c.Assert(page, qt.HasLen, 1)
+		seen = append(seen, page[0].ID)
+		cursor = registry.OrphanCandidateCursor{CreatedAt: page[0].CreatedAt, ID: page[0].ID}
+	}
+
+	// Three DISTINCT rows, oldest first — not the same row three times.
+	c.Assert(seen[0], qt.Not(qt.Equals), seen[1])
+	c.Assert(seen[1], qt.Not(qt.Equals), seen[2])
+	c.Assert(seen[0], qt.Not(qt.Equals), seen[2])
+
+	// The scan is now exhausted, which is how the worker knows to rewind.
+	empty, err := reg.ListOrphanCandidates(ctx, cutoff, cursor, 10)
+	c.Assert(err, qt.IsNil)
+	c.Assert(empty, qt.HasLen, 0)
+}
+
+// A blob key is NOT row-unique — there is no unique index on original_path, and
+// an upload key carries only a sanitized filename plus a unix SECOND. Two rows
+// in one tenant can legitimately share one key, and deleting one row's blob by
+// key destroys the other row's bytes. CountByOriginalPath is what lets the GC
+// see that, so it must count rows the caller cannot otherwise see: every tenant,
+// every group.
+func TestMemoryFileRegistry_CountByOriginalPath(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	const shared = "t/tenant-1/files/receipt-1783824560.jpg"
+	seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour, shared)
+	seedOrphanFileWithPath(c, fs, "tenant-1", "group-2", "", "", 30*24*time.Hour, shared)
+	seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "", "", 30*24*time.Hour, "t/tenant-1/files/sole-1783824560.jpg")
+
+	reg := fs.FileRegistryFactory.CreateServiceRegistry()
+	ctx := context.Background()
+
+	n, err := reg.CountByOriginalPath(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 2, qt.Commentf("a key shared by two rows must not look sole-owned"))
+
+	n, err = reg.CountByOriginalPath(ctx, "t/tenant-1/files/sole-1783824560.jpg")
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 1)
+
+	n, err = reg.CountByOriginalPath(ctx, "t/tenant-1/files/never-uploaded.jpg")
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 0)
+
+	// An empty path must never be read as "nobody references this".
+	n, err = reg.CountByOriginalPath(ctx, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 0)
+}
+
+func TestMemoryFileRegistry_ListIDsByTenant(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	a1 := seedOrphanFile(c, fs, "tenant-1", "group-1", "", "", time.Hour)
+	a2 := seedOrphanFile(c, fs, "tenant-1", "group-2", "", "", time.Hour)
+	b1 := seedOrphanFile(c, fs, "tenant-2", "group-3", "", "", time.Hour)
+
+	reg := fs.FileRegistryFactory.CreateServiceRegistry()
+	ids, err := reg.ListIDsByTenant(context.Background(), "tenant-1")
+	c.Assert(err, qt.IsNil)
+
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	c.Assert(set[a1], qt.IsTrue)
+	c.Assert(set[a2], qt.IsTrue, qt.Commentf("the set must span every group in the tenant"))
+	c.Assert(set[b1], qt.IsFalse, qt.Commentf("another tenant's file leaked into the membership set"))
+
+	_, err = reg.ListIDsByTenant(context.Background(), "")
+	c.Assert(err, qt.ErrorIs, registry.ErrFieldRequired)
+}

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -34,6 +34,14 @@ func NewFactorySet() *registry.FactorySet {
 	userConcurrencySlotFactory := NewUserConcurrencySlotRegistryFactory()
 	operationSlotFactory := NewOperationSlotRegistryFactory()
 
+	// Wire the sibling registries the orphan-file GC's candidate scan probes
+	// for existence (#2237). Postgres does this with a SQL anti-join; the
+	// memory backend has no planner, so the file registry has to hold the
+	// three linked-entity factories. Deliberately a post-construction setter:
+	// commodityFactory depends on areaFactory which depends on
+	// locationFactory, and fileFactory is constructed before all of them.
+	fileFactory.SetLinkedEntityFactories(commodityFactory, areaFactory, locationFactory)
+
 	fs := &registry.FactorySet{}
 	fs.LocationRegistryFactory = locationFactory
 	fs.AreaRegistryFactory = areaFactory

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -551,7 +551,7 @@ func (r *FileRegistry) ListPendingSizeBackfill(ctx context.Context, limit int) (
 // The candidate predicate is a positive ALLOWLIST on linked_entity_type, never
 // a negation:
 //
-//   - ”        → a STANDALONE file. First-class since #2235 (exported in
+//   - ""       → a STANDALONE file. First-class since #2235 (exported in
 //     backups, swept as inventory by a full_replace restore). NOT an orphan,
 //     never a candidate.
 //   - 'export'  → owned by the backup subsystem's own lifecycle
@@ -643,20 +643,21 @@ func (r *FileRegistry) ListOrphanCandidates(ctx context.Context, olderThan time.
 	return files, nil
 }
 
-// ListIDsByTenant returns the ids of every file row owned by tenantID, across
-// every group (#2237). Service-mode only; backs the orphan-file GC's thumbnail
-// sweep membership set. Ids only — the sweep never needs the rows.
-func (r *FileRegistry) ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error) {
-	if tenantID == "" {
-		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+// ExistingIDs returns the subset of ids that still have a file row, in ONE
+// `id = ANY($1)` round-trip (#2237). Service-mode only; backs the orphan-file
+// GC's thumbnail sweep. Missing ids are simply absent from the result — see the
+// interface doc in registry.FileRegistry for the full contract.
+func (r *FileRegistry) ExistingIDs(ctx context.Context, ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
 	}
-	var ids []string
+	var existing []string
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		query := fmt.Sprintf(`SELECT id FROM %s WHERE tenant_id = $1`, r.tableNames.Files())
-		rows, err := tx.QueryxContext(ctx, query, tenantID)
-		if err != nil {
-			return errxtrace.Wrap("failed to list file ids by tenant", err)
+		query := fmt.Sprintf(`SELECT id FROM %s WHERE id = ANY($1)`, r.tableNames.Files())
+		rows, qerr := tx.QueryxContext(ctx, query, ids)
+		if qerr != nil {
+			return errxtrace.Wrap("failed to batch-check file ids", qerr)
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -664,14 +665,14 @@ func (r *FileRegistry) ListIDsByTenant(ctx context.Context, tenantID string) ([]
 			if scanErr := rows.Scan(&id); scanErr != nil {
 				return errxtrace.Wrap("failed to scan file id", scanErr)
 			}
-			ids = append(ids, id)
+			existing = append(existing, id)
 		}
 		return rows.Err()
 	})
 	if err != nil {
-		return nil, errxtrace.Wrap("failed to list file ids by tenant", err)
+		return nil, errxtrace.Wrap("failed to batch-check file ids", err)
 	}
-	return ids, nil
+	return existing, nil
 }
 
 // CountByOriginalPath counts the file rows that reference the given blob key,

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
@@ -541,6 +542,163 @@ func (r *FileRegistry) ListPendingSizeBackfill(ctx context.Context, limit int) (
 		return nil, errxtrace.Wrap("failed to list pending size-backfill files", err)
 	}
 	return files, nil
+}
+
+// ListOrphanCandidates returns up to limit file rows whose linked entity no
+// longer exists (#2237). Discovery half of the orphan-file GC; see the
+// interface doc in registry.FileRegistry for the full contract.
+//
+// The candidate predicate is a positive ALLOWLIST on linked_entity_type, never
+// a negation:
+//
+//   - ”        → a STANDALONE file. First-class since #2235 (exported in
+//     backups, swept as inventory by a full_replace restore). NOT an orphan,
+//     never a candidate.
+//   - 'export'  → owned by the backup subsystem's own lifecycle
+//     (DeleteExportWithFile / group purge). Never a candidate — and because
+//     the exports table is never probed at all, the `deleted_at IS NULL`
+//     filter on ExportRegistry.Get can never be mistaken for "gone".
+//   - anything else (including a future link type the model validator does
+//     not yet know about — the registries do NOT run ValidateWithContext, so
+//     the DB is a superset of the validator's enumeration) → kept, fails
+//     closed.
+//
+// The three NOT EXISTS anti-joins run under whatever role reg.Do selects. This
+// method is SERVICE-MODE ONLY on purpose: PUT /files/{id} does not validate the
+// link target's group, so a cross-group link is reachable in production and a
+// group-scoped probe would read a LIVE entity as missing.
+//
+// The scan is KEYSET-PAGINATED on (created_at, id): most re-verified candidates
+// are KEPT rather than deleted, and several keep-reasons never clear (a tenant
+// pinned by a crashed restore, a suspended tenant, a purged owner), so a
+// non-resumable oldest-first window would be squatted on by exactly those rows
+// forever and no other orphan in the installation would ever be enumerated.
+//
+// Backed by the existing files_linked_entity_idx / idx_files_tenant_linked_entity
+// — no new index, no migration.
+func (r *FileRegistry) ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	// $1 = olderThan; the cursor (when set) takes $2/$3, so the LIMIT
+	// placeholder index has to follow the arg list rather than be hardcoded.
+	args := []any{olderThan}
+	keyset := ""
+	if !after.IsZero() {
+		args = append(args, after.CreatedAt, after.ID)
+		keyset = "AND (f.created_at, f.id) > ($2, $3)"
+	}
+	args = append(args, limit)
+	limitPlaceholder := fmt.Sprintf("$%d", len(args))
+
+	var files []*models.FileEntity
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`
+			SELECT f.* FROM %s f
+			WHERE f.linked_entity_type IN ('commodity', 'area', 'location')
+			  AND f.linked_entity_id <> ''
+			  AND f.created_at < $1
+			  AND f.updated_at < $1
+			  %s
+			  AND NOT EXISTS (
+			      SELECT 1 FROM %s c
+			      WHERE f.linked_entity_type = 'commodity' AND c.id = f.linked_entity_id
+			  )
+			  AND NOT EXISTS (
+			      SELECT 1 FROM %s a
+			      WHERE f.linked_entity_type = 'area' AND a.id = f.linked_entity_id
+			  )
+			  AND NOT EXISTS (
+			      SELECT 1 FROM %s l
+			      WHERE f.linked_entity_type = 'location' AND l.id = f.linked_entity_id
+			  )
+			ORDER BY f.created_at ASC, f.id ASC
+			LIMIT %s`,
+			r.tableNames.Files(),
+			keyset,
+			r.tableNames.Commodities(),
+			r.tableNames.Areas(),
+			r.tableNames.Locations(),
+			limitPlaceholder,
+		)
+		rows, err := tx.QueryxContext(ctx, query, args...)
+		if err != nil {
+			return errxtrace.Wrap("failed to list orphan file candidates", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var file models.FileEntity
+			if scanErr := rows.StructScan(&file); scanErr != nil {
+				return errxtrace.Wrap("failed to scan file", scanErr)
+			}
+			files = append(files, &file)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list orphan file candidates", err)
+	}
+	return files, nil
+}
+
+// ListIDsByTenant returns the ids of every file row owned by tenantID, across
+// every group (#2237). Service-mode only; backs the orphan-file GC's thumbnail
+// sweep membership set. Ids only — the sweep never needs the rows.
+func (r *FileRegistry) ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	var ids []string
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`SELECT id FROM %s WHERE tenant_id = $1`, r.tableNames.Files())
+		rows, err := tx.QueryxContext(ctx, query, tenantID)
+		if err != nil {
+			return errxtrace.Wrap("failed to list file ids by tenant", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if scanErr := rows.Scan(&id); scanErr != nil {
+				return errxtrace.Wrap("failed to scan file id", scanErr)
+			}
+			ids = append(ids, id)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list file ids by tenant", err)
+	}
+	return ids, nil
+}
+
+// CountByOriginalPath counts the file rows that reference the given blob key,
+// across EVERY tenant and group (#2237). Service-mode only.
+//
+// The count is deliberately NOT tenant-scoped. Post-#1793 keys carry a
+// `t/<tenant>/` prefix, but legacy flat keys (rows whose blob predates the
+// backfill) do not, so two rows in DIFFERENT tenants can reference one legacy
+// key. The orphan-file GC treats any key referenced by more than one row as
+// shared and keeps the row rather than destroy another row's bytes.
+//
+// An empty path counts as zero rather than matching every row whose blob is
+// unset — a caller must never conclude "nobody else references this" from it.
+func (r *FileRegistry) CountByOriginalPath(ctx context.Context, originalPath string) (int, error) {
+	if originalPath == "" {
+		return 0, nil
+	}
+	var count int
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE original_path = $1`, r.tableNames.Files())
+		return tx.QueryRowxContext(ctx, query, originalPath).Scan(&count)
+	})
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count files by original path", err)
+	}
+	return count, nil
 }
 
 // SumSizeBreakdownByGroup mirrors SumSizeBreakdown but for an explicit

--- a/go/registry/postgres/files_orphan_candidates_test.go
+++ b/go/registry/postgres/files_orphan_candidates_test.go
@@ -22,7 +22,7 @@ import (
 // This worker DELETES USER DATA, so the assertions that matter are the ones
 // about what must NOT come back:
 //
-//   - a STANDALONE file (linked_entity_type = ”) — first-class since #2235;
+//   - a STANDALONE file (linked_entity_type = "") — first-class since #2235;
 //     "no link" must never mean "orphan";
 //   - an 'export'-linked file — the backup subsystem owns its lifecycle, and
 //     because the exports table is never probed, the `deleted_at IS NULL`
@@ -241,10 +241,10 @@ func TestFileRegistry_Postgres_CountByOriginalPath(t *testing.T) {
 	})
 }
 
-// TestFileRegistry_Postgres_ListIDsByTenant checks the membership set that
-// backs the thumbnail sweep: ids for the requested tenant only, across all its
-// groups.
-func TestFileRegistry_Postgres_ListIDsByTenant(t *testing.T) {
+// TestFileRegistry_Postgres_ExistingIDs checks the membership query that backs
+// the thumbnail sweep: a single ANY($1) round-trip answering, BY ID ALONE,
+// which of the ids the listed keys named still have a row.
+func TestFileRegistry_Postgres_ExistingIDs(t *testing.T) {
 	c := qt.New(t)
 
 	_, cleanup := setupTestRegistrySet(t)
@@ -286,21 +286,27 @@ func TestFileRegistry_Postgres_ListIDsByTenant(t *testing.T) {
 	a2 := mk(tenantA, groupA2, userA.ID)
 	b1 := mk(tenantB, groupB, userB.ID)
 
-	ids, err := svc.ListIDsByTenant(ctx, tenantA)
+	ids, err := svc.ExistingIDs(ctx, []string{a1, a2, b1, "no-such-file"})
 	c.Assert(err, qt.IsNil)
 
 	set := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		set[id] = true
 	}
+	// The service registry sees every row, so an id is "live" wherever it
+	// lives. That is the point: a thumbnail whose owning row sits in another
+	// group (or tenant) must never be read as an orphan.
 	c.Assert(set[a1], qt.IsTrue)
-	c.Assert(set[a2], qt.IsTrue, qt.Commentf("the set must span every group in the tenant"))
-	c.Assert(set[b1], qt.IsFalse, qt.Commentf("another tenant's file leaked into the membership set"))
+	c.Assert(set[a2], qt.IsTrue, qt.Commentf("a live row in another group was reported missing"))
+	c.Assert(set[b1], qt.IsTrue, qt.Commentf("a live row in another tenant was reported missing"))
+	c.Assert(set["no-such-file"], qt.IsFalse)
+	c.Assert(ids, qt.HasLen, 3)
 
-	t.Run("an empty tenant id is rejected", func(t *testing.T) {
+	t.Run("an empty id list never queries", func(t *testing.T) {
 		c := qt.New(t)
-		_, err := svc.ListIDsByTenant(ctx, "")
-		c.Assert(err, qt.ErrorIs, registry.ErrFieldRequired)
+		got, err := svc.ExistingIDs(ctx, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
 	})
 }
 

--- a/go/registry/postgres/files_orphan_candidates_test.go
+++ b/go/registry/postgres/files_orphan_candidates_test.go
@@ -1,0 +1,342 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestFileRegistry_Postgres_ListOrphanCandidates exercises the SQL anti-join
+// that backs the orphan-file GC (#2237) against a real PostgreSQL schema.
+//
+// This worker DELETES USER DATA, so the assertions that matter are the ones
+// about what must NOT come back:
+//
+//   - a STANDALONE file (linked_entity_type = ”) — first-class since #2235;
+//     "no link" must never mean "orphan";
+//   - an 'export'-linked file — the backup subsystem owns its lifecycle, and
+//     because the exports table is never probed, the `deleted_at IS NULL`
+//     soft-delete trap on ExportRegistry.Get is structurally unreachable;
+//   - an unknown/future link type — the registries do NOT enforce
+//     models.FileEntity.ValidateWithContext, so the DB is a superset of the
+//     validator's enumeration and the allowlist has to fail closed;
+//   - a file whose link target is ALIVE IN ANOTHER GROUP — PUT /files/{id}
+//     never validates the target's group, so this row is reachable in
+//     production, and it is the one a group-scoped (RLS) query would wrongly
+//     report as an orphan. The anti-join therefore has to run in SERVICE mode.
+//
+// Self-skips when POSTGRES_TEST_DSN is unset (via setupTestRegistrySet).
+func TestFileRegistry_Postgres_ListOrphanCandidates(t *testing.T) {
+	c := qt.New(t)
+
+	_, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	fs := postgres.NewFactorySet(dbx)
+
+	ctx := context.Background()
+
+	// Two tenants, each with a group — the cross-group / cross-tenant cases are
+	// the ones a group-scoped query would get catastrophically wrong.
+	tenantA := mustCreateTenant(c, ctx, fs, "orphan-gc-tenant-a")
+	userA := mustCreateUser(c, ctx, fs, tenantA, "a@orphan-gc.example")
+	groupA := mustCreateActiveGroup(c, ctx, fs, tenantA, userA.ID)
+
+	tenantB := mustCreateTenant(c, ctx, fs, "orphan-gc-tenant-b")
+	userB := mustCreateUser(c, ctx, fs, tenantB, "b@orphan-gc.example")
+	groupB := mustCreateActiveGroup(c, ctx, fs, tenantB, userB.ID)
+
+	// A second group inside tenant A, holding the LIVE commodity that a file in
+	// group A will legitimately point at.
+	groupA2 := mustCreateActiveGroup(c, ctx, fs, tenantA, userA.ID)
+	liveCommodityID := mustCreateLiveCommodity(c, ctx, fs, userA, groupA2)
+
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	fresh := time.Now().Add(-time.Hour)
+
+	seed := func(tenantID, groupID, userID, linkType, linkID string, createdAt, updatedAt time.Time) string {
+		c.Helper()
+		row, err := fs.FileRegistryFactory.CreateServiceRegistry().Create(ctx, models.FileEntity{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				TenantID: tenantID, GroupID: groupID, CreatedByUserID: userID,
+			},
+			Title:            "seeded",
+			Type:             models.FileTypeImage,
+			Category:         models.FileCategoryImages,
+			LinkedEntityType: linkType,
+			LinkedEntityID:   linkID,
+			CreatedAt:        createdAt,
+			UpdatedAt:        updatedAt,
+			File: &models.File{
+				Path: "seeded", OriginalPath: "seeded.jpg", Ext: ".jpg", MIMEType: "image/jpeg",
+			},
+		})
+		c.Assert(err, qt.IsNil)
+		return row.ID
+	}
+
+	orphanCommodity := seed(tenantA, groupA, userA.ID, "commodity", "no-such-commodity", old, old)
+	orphanArea := seed(tenantA, groupA, userA.ID, "area", "no-such-area", old, old)
+	orphanLocation := seed(tenantA, groupA, userA.ID, "location", "no-such-location", old, old)
+
+	standalone := seed(tenantA, groupA, userA.ID, "", "", old, old)
+	exportLinked := seed(tenantA, groupA, userA.ID, "export", "no-such-export", old, old)
+	unknownType := seed(tenantA, groupA, userA.ID, "widget", "no-such-widget", old, old)
+	emptyLinkID := seed(tenantA, groupA, userA.ID, "commodity", "", old, old)
+	freshUpdated := seed(tenantA, groupA, userA.ID, "commodity", "no-such-commodity", old, fresh)
+	freshCreated := seed(tenantA, groupA, userA.ID, "commodity", "no-such-commodity", fresh, old)
+	crossGroupLive := seed(tenantA, groupA, userA.ID, "commodity", liveCommodityID, old, old)
+	otherTenantOrphan := seed(tenantB, groupB, userB.ID, "commodity", "no-such-commodity", old, old)
+
+	// The service registry is what the worker uses — it must see across every
+	// tenant and group.
+	svc := fs.FileRegistryFactory.CreateServiceRegistry()
+	got, err := svc.ListOrphanCandidates(ctx, time.Now().Add(-72*time.Hour), registry.OrphanCandidateCursor{}, 100)
+	c.Assert(err, qt.IsNil)
+
+	ids := make(map[string]bool, len(got))
+	for _, f := range got {
+		ids[f.ID] = true
+	}
+
+	// Positive: the genuine crash-window residues, in EVERY tenant.
+	c.Assert(ids[orphanCommodity], qt.IsTrue)
+	c.Assert(ids[orphanArea], qt.IsTrue)
+	c.Assert(ids[orphanLocation], qt.IsTrue)
+	c.Assert(ids[otherTenantOrphan], qt.IsTrue,
+		qt.Commentf("the anti-join must run RLS-free: a service-mode scan sees every tenant"))
+
+	// Negative: everything that must never be handed to a destructive worker.
+	c.Assert(ids[standalone], qt.IsFalse, qt.Commentf("#2235 standalone file entered the candidate set"))
+	c.Assert(ids[exportLinked], qt.IsFalse, qt.Commentf("export-linked file entered the candidate set"))
+	c.Assert(ids[unknownType], qt.IsFalse, qt.Commentf("unknown link type must fail closed"))
+	c.Assert(ids[emptyLinkID], qt.IsFalse, qt.Commentf("malformed link (empty id) is data, not garbage"))
+	c.Assert(ids[freshUpdated], qt.IsFalse, qt.Commentf("updated_at inside the age window (concurrent attach)"))
+	c.Assert(ids[freshCreated], qt.IsFalse, qt.Commentf("created_at inside the age window"))
+	c.Assert(ids[crossGroupLive], qt.IsFalse,
+		qt.Commentf("a file linked ACROSS GROUPS to a LIVE commodity was reported as an orphan"))
+
+	t.Run("ordering is oldest-first and the limit is honoured", func(t *testing.T) {
+		c := qt.New(t)
+		limited, err := svc.ListOrphanCandidates(ctx, time.Now().Add(-72*time.Hour), registry.OrphanCandidateCursor{}, 2)
+		c.Assert(err, qt.IsNil)
+		c.Assert(limited, qt.HasLen, 2)
+		c.Assert(limited[0].CreatedAt.After(limited[1].CreatedAt), qt.IsFalse)
+	})
+
+	t.Run("a non-positive limit returns nothing", func(t *testing.T) {
+		c := qt.New(t)
+		none, err := svc.ListOrphanCandidates(ctx, time.Now(), registry.OrphanCandidateCursor{}, 0)
+		c.Assert(err, qt.IsNil)
+		c.Assert(none, qt.HasLen, 0)
+	})
+
+	// The keyset must resume STRICTLY after the cursor, tie-breaking on id —
+	// every orphan seeded above shares one created_at, so a cursor that only
+	// compared timestamps would re-serve the same row forever (the head-of-line
+	// livelock the cursor exists to prevent) or skip its peers.
+	t.Run("the scan resumes strictly after the (created_at, id) cursor", func(t *testing.T) {
+		c := qt.New(t)
+		cutoff := time.Now().Add(-72 * time.Hour)
+
+		first, err := svc.ListOrphanCandidates(ctx, cutoff, registry.OrphanCandidateCursor{}, 1)
+		c.Assert(err, qt.IsNil)
+		c.Assert(first, qt.HasLen, 1)
+
+		cursor := registry.OrphanCandidateCursor{CreatedAt: first[0].CreatedAt, ID: first[0].ID}
+		rest, err := svc.ListOrphanCandidates(ctx, cutoff, cursor, 100)
+		c.Assert(err, qt.IsNil)
+
+		seen := map[string]bool{first[0].ID: true}
+		for _, f := range rest {
+			c.Assert(f.ID, qt.Not(qt.Equals), first[0].ID,
+				qt.Commentf("the cursor re-served the row it was built from — the scan cannot make progress"))
+			seen[f.ID] = true
+		}
+
+		// Paging with the cursor still covers the whole candidate set.
+		for _, want := range []string{orphanCommodity, orphanArea, orphanLocation, otherTenantOrphan} {
+			c.Assert(seen[want], qt.IsTrue, qt.Commentf("a candidate was skipped by the keyset paging"))
+		}
+	})
+}
+
+// TestFileRegistry_Postgres_CountByOriginalPath pins the guard that stops the
+// orphan-file GC from destroying a LIVE file's bytes.
+//
+// files.original_path has NO unique index, and an upload key is
+// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>` — no group segment, no
+// row segment, no randomness. Two rows in one tenant can therefore legitimately
+// share one blob key, while the blob delete inside DeleteFileWithPhysical is
+// key-scoped: deleting the orphan would take the live row's bytes with it,
+// irreversibly (`files` has no soft-delete).
+func TestFileRegistry_Postgres_CountByOriginalPath(t *testing.T) {
+	c := qt.New(t)
+
+	_, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	fs := postgres.NewFactorySet(dbx)
+
+	ctx := context.Background()
+
+	tenant := mustCreateTenant(c, ctx, fs, "count-by-path")
+	user := mustCreateUser(c, ctx, fs, tenant, "a@count.example")
+	group1 := mustCreateActiveGroup(c, ctx, fs, tenant, user.ID)
+	group2 := mustCreateActiveGroup(c, ctx, fs, tenant, user.ID)
+
+	svc := fs.FileRegistryFactory.CreateServiceRegistry()
+	mk := func(groupID, originalPath string) {
+		c.Helper()
+		_, err := svc.Create(ctx, models.FileEntity{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				TenantID: tenant, GroupID: groupID, CreatedByUserID: user.ID,
+			},
+			Title: "seeded", Type: models.FileTypeImage, Category: models.FileCategoryImages,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			File: &models.File{Path: "s", OriginalPath: originalPath, Ext: ".jpg", MIMEType: "image/jpeg"},
+		})
+		c.Assert(err, qt.IsNil)
+	}
+
+	// Two members of two different groups upload `receipt.jpg` in the same
+	// second: two rows, one key. Nothing in the system rejects this today.
+	const shared = "t/count-by-path/files/receipt-1783824560.jpg"
+	const sole = "t/count-by-path/files/sole-1783824560.jpg"
+	mk(group1, shared)
+	mk(group2, shared)
+	mk(group1, sole)
+
+	n, err := svc.CountByOriginalPath(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 2, qt.Commentf("a key shared by two rows must not look sole-owned to the GC"))
+
+	n, err = svc.CountByOriginalPath(ctx, sole)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 1)
+
+	t.Run("an empty path never reads as unreferenced", func(t *testing.T) {
+		c := qt.New(t)
+		n, err := svc.CountByOriginalPath(ctx, "")
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, 0)
+	})
+}
+
+// TestFileRegistry_Postgres_ListIDsByTenant checks the membership set that
+// backs the thumbnail sweep: ids for the requested tenant only, across all its
+// groups.
+func TestFileRegistry_Postgres_ListIDsByTenant(t *testing.T) {
+	c := qt.New(t)
+
+	_, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	fs := postgres.NewFactorySet(dbx)
+
+	ctx := context.Background()
+
+	tenantA := mustCreateTenant(c, ctx, fs, "ids-by-tenant-a")
+	userA := mustCreateUser(c, ctx, fs, tenantA, "a@ids.example")
+	groupA1 := mustCreateActiveGroup(c, ctx, fs, tenantA, userA.ID)
+	groupA2 := mustCreateActiveGroup(c, ctx, fs, tenantA, userA.ID)
+
+	tenantB := mustCreateTenant(c, ctx, fs, "ids-by-tenant-b")
+	userB := mustCreateUser(c, ctx, fs, tenantB, "b@ids.example")
+	groupB := mustCreateActiveGroup(c, ctx, fs, tenantB, userB.ID)
+
+	svc := fs.FileRegistryFactory.CreateServiceRegistry()
+	mk := func(tenantID, groupID, userID string) string {
+		c.Helper()
+		f, err := svc.Create(ctx, models.FileEntity{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				TenantID: tenantID, GroupID: groupID, CreatedByUserID: userID,
+			},
+			Title: "seeded", Type: models.FileTypeImage, Category: models.FileCategoryImages,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			File: &models.File{Path: "s", OriginalPath: "s.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+		})
+		c.Assert(err, qt.IsNil)
+		return f.ID
+	}
+
+	a1 := mk(tenantA, groupA1, userA.ID)
+	a2 := mk(tenantA, groupA2, userA.ID)
+	b1 := mk(tenantB, groupB, userB.ID)
+
+	ids, err := svc.ListIDsByTenant(ctx, tenantA)
+	c.Assert(err, qt.IsNil)
+
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	c.Assert(set[a1], qt.IsTrue)
+	c.Assert(set[a2], qt.IsTrue, qt.Commentf("the set must span every group in the tenant"))
+	c.Assert(set[b1], qt.IsFalse, qt.Commentf("another tenant's file leaked into the membership set"))
+
+	t.Run("an empty tenant id is rejected", func(t *testing.T) {
+		c := qt.New(t)
+		_, err := svc.ListIDsByTenant(ctx, "")
+		c.Assert(err, qt.ErrorIs, registry.ErrFieldRequired)
+	})
+}
+
+// mustCreateLiveCommodity builds a real location → area → commodity chain in
+// the given group and returns the commodity id.
+func mustCreateLiveCommodity(c *qt.C, ctx context.Context, fs *registry.FactorySet, user *models.User, groupID string) string {
+	c.Helper()
+
+	group, err := fs.LocationGroupRegistry.Get(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	uctx := appctx.WithGroup(appctx.WithUser(ctx, user), group)
+
+	loc, err := fs.LocationRegistryFactory.MustCreateUserRegistry(uctx).Create(uctx, models.Location{
+		Name: "Live Location", Address: "1 Live St",
+	})
+	c.Assert(err, qt.IsNil)
+
+	area, err := fs.AreaRegistryFactory.MustCreateUserRegistry(uctx).Create(uctx, models.Area{
+		Name: "Live Area", LocationID: loc.ID,
+	})
+	c.Assert(err, qt.IsNil)
+
+	com, err := fs.CommodityRegistryFactory.MustCreateUserRegistry(uctx).Create(uctx, models.Commodity{
+		Name:                   "Live Commodity",
+		ShortName:              "LC",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 new(area.ID),
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromInt(10),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.Zero,
+		CurrentPrice:           decimal.Zero,
+		Status:                 models.CommodityStatusInUse,
+		PurchaseDate:           models.ToPDate("2023-01-01"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	return com.ID
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -431,7 +431,14 @@ type FileRegistry interface {
 	//      EXISTS(...)` would silently eat every standalone file in the
 	//      installation.
 	//   2. linked_entity_id <> '' — a set type with an empty id is
-	//      malformed data, not garbage; it is kept and reported.
+	//      malformed data, not garbage. It is EXCLUDED here, which means
+	//      KEPT and never surfaced to the worker: no probe can prove an
+	//      empty id absent, so such a row must never enter a candidate
+	//      set a destructive worker consumes. (The worker re-asserts the
+	//      same rule as defence-in-depth — the query is a filter, never
+	//      an authorization — so its malformed_link skip reason is
+	//      unreachable while this predicate holds, and stays correct if
+	//      the predicate is ever relaxed.)
 	//   3. BOTH created_at < olderThan AND updated_at < olderThan.
 	//      updated_at is the load-bearing one: PUT /files/{id} stamps it
 	//      with the app wall clock, so a file attached concurrently with

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -412,6 +412,93 @@ type FileRegistry interface {
 	// and group, bypassing RLS. Implementations may return fewer rows
 	// than limit (the queue is exhausted) but must never return more.
 	ListPendingSizeBackfill(ctx context.Context, limit int) ([]*models.FileEntity, error)
+
+	// ListOrphanCandidates streams up to limit file rows that *may* be
+	// orphans — rows whose linked_entity_type/linked_entity_id points at
+	// an entity that no longer exists (#2237). It is the discovery half
+	// of the orphan-file GC; the worker independently re-verifies every
+	// candidate before deleting anything, so this is a filter, never an
+	// authorization to delete.
+	//
+	// The predicate implementations MUST honour, exactly:
+	//
+	//   1. linked_entity_type IN ('commodity', 'area', 'location') — a
+	//      positive ALLOWLIST, never a negation. The empty string is a
+	//      legitimate STANDALONE file (#2235: first-class, exported in
+	//      backups) and 'export' belongs to the backup subsystem's own
+	//      lifecycle; both — and any unknown/future link type — MUST be
+	//      excluded. A predicate shaped `linked_entity_id IS NULL OR NOT
+	//      EXISTS(...)` would silently eat every standalone file in the
+	//      installation.
+	//   2. linked_entity_id <> '' — a set type with an empty id is
+	//      malformed data, not garbage; it is kept and reported.
+	//   3. BOTH created_at < olderThan AND updated_at < olderThan.
+	//      updated_at is the load-bearing one: PUT /files/{id} stamps it
+	//      with the app wall clock, so a file attached concurrently with
+	//      an entity delete is immune for the whole age window.
+	//   4. No row with id = linked_entity_id exists in the table named by
+	//      linked_entity_type.
+	//
+	// SERVICE-MODE ONLY. The existence check must see every tenant and
+	// group: PUT /files/{id} does not validate the link target's group,
+	// so a file legitimately linked to an entity in ANOTHER group exists
+	// in production. A group-scoped (RLS) implementation would read that
+	// live entity as nonexistent and hand the GC a live file to delete.
+	//
+	// Implementations may return fewer rows than limit but never more,
+	// and must order deterministically by the (created_at, id) KEYSET,
+	// ascending, resuming strictly AFTER the `after` cursor when it is
+	// non-zero.
+	//
+	// The cursor is not an optimization, it is a liveness requirement.
+	// Most rows the GC re-verifies are KEPT, not deleted (a blocked
+	// tenant, a suspended tenant, a pending_deletion group, an
+	// unresolvable owner — several of which never clear), and a kept row
+	// stays in the result set forever. Without a cursor, a bounded
+	// oldest-first window is squatted on by those rows and no other
+	// orphan in the installation is ever enumerated again — and in the
+	// shipping report mode, where NOTHING is ever deleted, the very same
+	// window would be re-reported on every tick.
+	ListOrphanCandidates(ctx context.Context, olderThan time.Time, after OrphanCandidateCursor, limit int) ([]*models.FileEntity, error)
+
+	// ListIDsByTenant returns the ids of every file row belonging to the
+	// given tenant, across all its groups (#2237). Service-mode only;
+	// backs the orphan-file GC's thumbnail sweep, which needs a cheap
+	// membership set to test a listed `t/<tenant>/thumbnails/<fileID>_...`
+	// key against. Ids only — the sweep never needs the rows themselves.
+	ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error)
+
+	// CountByOriginalPath returns how many file rows — across EVERY
+	// tenant and group — carry the given files.original_path (#2237).
+	// Service-mode only.
+	//
+	// It exists because a blob key is NOT row-unique and there is no
+	// unique index on original_path. An upload's key is
+	// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`, which has
+	// no group segment, no row segment and no randomness: two uploads of
+	// the same filename inside one tenant in the same second (two members
+	// of different groups; one user multi-selecting two same-named files)
+	// legitimately produce two DISTINCT rows that share one key. Deleting
+	// a file row's blob by key therefore destroys the bytes of every other
+	// row pointing at it, and `files` has no soft-delete. The orphan-file
+	// GC calls this before any destructive step and KEEPS anything whose
+	// key is shared.
+	CountByOriginalPath(ctx context.Context, originalPath string) (int, error)
+}
+
+// OrphanCandidateCursor is the keyset position a paged
+// FileRegistry.ListOrphanCandidates scan resumes from: the last
+// (created_at, id) the caller has already seen. The zero value means
+// "start at the oldest row".
+type OrphanCandidateCursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
+// IsZero reports whether the cursor names no position, i.e. the scan
+// starts from the oldest candidate.
+func (c OrphanCandidateCursor) IsZero() bool {
+	return c.ID == "" && c.CreatedAt.IsZero()
 }
 
 // StorageBreakdown is the per-bucket byte count returned by

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -461,12 +461,19 @@ type FileRegistry interface {
 	// window would be re-reported on every tick.
 	ListOrphanCandidates(ctx context.Context, olderThan time.Time, after OrphanCandidateCursor, limit int) ([]*models.FileEntity, error)
 
-	// ListIDsByTenant returns the ids of every file row belonging to the
-	// given tenant, across all its groups (#2237). Service-mode only;
-	// backs the orphan-file GC's thumbnail sweep, which needs a cheap
-	// membership set to test a listed `t/<tenant>/thumbnails/<fileID>_...`
-	// key against. Ids only — the sweep never needs the rows themselves.
-	ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error)
+	// ExistingIDs returns the subset of ids that still have a file row,
+	// in ONE `WHERE id = ANY($1)` round-trip (#2237). Service-mode only.
+	//
+	// It backs the orphan-file GC's thumbnail sweep, which needs to know
+	// which of the file ids embedded in the keys it just listed are still
+	// live. It is deliberately id-driven rather than tenant-driven: a
+	// tenant-wide id dump would cost (and hold in memory) one entry per
+	// file row in the installation's largest tenant to answer a question
+	// about at most a few thousand listed keys.
+	//
+	// Missing / already-deleted ids are simply absent from the result; an
+	// empty input returns (nil, nil) without a query.
+	ExistingIDs(ctx context.Context, ids []string) ([]string, error)
 
 	// CountByOriginalPath returns how many file rows — across EVERY
 	// tenant and group — carry the given files.original_path (#2237).

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -188,11 +188,25 @@ func (s *FileService) DeleteFileWithPhysical(ctx context.Context, fileID string)
 // that never had a job) matches zero rows and returns nil. Each job's slots are
 // cleared first because the slots.job_id -> jobs(id) FK is NO ACTION and must
 // be gone before the job row can be removed.
+//
+// The teardown runs through SERVICE (RLS-bypassing) registries, and that is
+// load-bearing: a thumbnail job is owned by the user who REQUESTED generation,
+// not by the file's creator (ThumbnailGenerationService.RequestThumbnailGeneration
+// stamps UserID = the requesting user on purpose, so one member cannot spend
+// another's rate limit), and merely VIEWING a not-yet-generated thumbnail
+// enqueues one (servePlaceholderThumbnail). The jobs table's RLS policy is
+// `tenant_id = ... AND user_id = get_current_user_id()`, so a user-scoped
+// teardown cannot SEE — let alone delete — a job another group member created
+// for the same file. The job row then survives and the file delete trips
+// fk_thumbnail_job_file (NO ACTION; PostgreSQL's RI check bypasses row
+// security, so an invisible child still blocks the parent).
+//
+// Caller-side authorization is unaffected: DeleteFileWithPhysical has already
+// resolved the file through a USER registry, so by the time the chain is torn
+// down the caller has been proven to own it. Widening only the job/slot
+// teardown deletes strictly the rows that reference THIS file id.
 func (s *FileService) deleteThumbnailGenerationChain(ctx context.Context, fileID string) error {
-	jobReg, err := s.factorySet.ThumbnailGenerationJobRegistryFactory.CreateUserRegistry(ctx)
-	if err != nil {
-		return errxtrace.Wrap("failed to create thumbnail generation job registry", err)
-	}
+	jobReg := s.factorySet.ThumbnailGenerationJobRegistryFactory.CreateServiceRegistry()
 
 	// Resolve every job for this file so each job's slots can be cleared before
 	// the job rows are deleted. No job is not an error — the file may never
@@ -203,10 +217,7 @@ func (s *FileService) deleteThumbnailGenerationChain(ctx context.Context, fileID
 	}
 
 	if len(jobs) > 0 {
-		slotReg, slotErr := s.factorySet.UserConcurrencySlotRegistryFactory.CreateUserRegistry(ctx)
-		if slotErr != nil {
-			return errxtrace.Wrap("failed to create user concurrency slot registry", slotErr)
-		}
+		slotReg := s.factorySet.UserConcurrencySlotRegistryFactory.CreateServiceRegistry()
 		for _, job := range jobs {
 			if slotErr := slotReg.DeleteByJobID(ctx, job.ID); slotErr != nil {
 				return errxtrace.Wrap("failed to delete concurrency slots for thumbnail job", slotErr, errx.Attrs("file_id", fileID, "job_id", job.ID))

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -106,6 +106,7 @@ const (
 	orphanGCSkipProbeError        = "probe_error"
 	orphanGCSkipMalformedLink     = "malformed_link"
 	orphanGCSkipDisallowedLink    = "disallowed_link_type"
+	orphanGCSkipMissingProbe      = "missing_probe"
 	orphanGCSkipAge               = "age"
 	orphanGCSkipInflight          = "inflight"
 	orphanGCSkipGroupInactive     = "group_inactive"
@@ -929,7 +930,14 @@ func (w *OrphanFileGCWorker) verifyRowCandidate(ctx context.Context, file *model
 	// registry.ErrNotFound; anything else aborts the tick.
 	probe := w.deps.Probes.forLinkType(file.LinkedEntityType)
 	if probe == nil {
-		return orphanRowVerdict{reason: orphanGCSkipDisallowedLink}, nil
+		// NOT disallowed_link_type: screenRowCandidate already rejected every
+		// non-allowlisted type above, so reaching here means the type IS
+		// allowlisted and the worker was handed a nil probe for it — a MISWIRING,
+		// not a policy decision. Both outcomes keep the file (fail closed), which
+		// is exactly why they must not share a label: a miswired worker reports
+		// zero candidates forever, and "disallowed_link_type" makes that look like
+		// the intended handling of an unknown type instead of the bug it is.
+		return orphanRowVerdict{reason: orphanGCSkipMissingProbe}, nil
 	}
 	switch err := probe(ctx, file.LinkedEntityID); {
 	case err == nil:

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -1000,7 +1000,12 @@ func screenRowCandidate(file *models.FileEntity, gate orphanGCGate, cutoff time.
 	if !orphanGCLinkAllowlist[file.LinkedEntityType] {
 		return orphanGCSkipDisallowedLink
 	}
-	// A set link type with an empty id is malformed DATA, not garbage.
+	// A set link type with an empty id is malformed DATA, not garbage: no probe
+	// can prove an empty id absent. The registry predicate already excludes such
+	// rows, so this branch is unreachable today and malformed_link never fires —
+	// deliberately. The candidate query is a FILTER, never an authorization, and
+	// this worker must remain correct against any predicate it is handed,
+	// including a future relaxed one.
 	if file.LinkedEntityID == "" {
 		return orphanGCSkipMalformedLink
 	}

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/internal/blobkeys"
@@ -1330,23 +1331,29 @@ func (w *OrphanFileGCWorker) listAgedThumbnails(
 }
 
 // deleteThumbnail removes the REBUILT key — never the raw string the bucket
-// listing handed us. Exists-guarded and not-found-tolerant, so two `run workers`
-// replicas racing the same orphan produce one delete and one no-op.
+// listing handed us.
+//
+// There is deliberately NO Exists() pre-check. A stat-then-delete pair does not
+// make the delete safer (the key is rebuilt, so it can only ever name a
+// thumbnail of a file we just proved gone) — it only opens a window: with two
+// `run workers` replicas, the other one can remove the key between our stat and
+// our delete, and the resulting NotFound would be counted as a FAILURE and
+// logged at error level. That is a lie in exactly the race this worker is
+// expected to run in, and it would make delete-mode runs noisy enough to hide a
+// real failure.
+//
+// So: one round trip, and a NotFound from Delete is a no-op, not a failure —
+// the same tolerance the row path applies to registry.ErrNotFound. Returns
+// whether THIS call is the one that removed the key.
 func (w *OrphanFileGCWorker) deleteThumbnail(ctx context.Context, bucket *blob.Bucket, tenantID, fileID, size string) bool {
 	key := blobkeys.BuildThumbnailBlobKey(tenantID, fileID, size)
 
-	exists, err := bucket.Exists(ctx, key)
-	if err != nil {
-		orphanGCFailuresTotal.Inc()
-		slog.Error("Orphan file GC: failed to stat orphan thumbnail",
-			"event", "orphan_gc.thumbnail", "action", "failed",
-			"blob_key", key, "tenant_id", tenantID, "error", err.Error())
-		return false
-	}
-	if !exists {
-		return false
-	}
 	if err := bucket.Delete(ctx, key); err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			// Already gone: another replica won the race, or it was removed
+			// between the listing and here. Nothing to report.
+			return false
+		}
 		orphanGCFailuresTotal.Inc()
 		slog.Error("Orphan file GC: failed to delete orphan thumbnail",
 			"event", "orphan_gc.thumbnail", "action", "failed",

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -515,12 +515,21 @@ func (w *OrphanFileGCWorker) runCleanup(ctx context.Context) {
 func (w *OrphanFileGCWorker) RunOnce(ctx context.Context) {
 	// Soft-pause (#1308) FIRST, before any registry or bucket call. The ticker
 	// keeps running so resume takes effect on the next tick without a restart.
+	// The blocked-tenant gauge asserts something about the LAST EVALUATION. A
+	// tick that never evaluates the gate must not leave the previous tick's
+	// value standing: the runbook reads a persistently-positive gauge as "a
+	// tenant is pinned by a stuck operation", and a paused or disabled worker
+	// would otherwise fake exactly that signal forever. Zero is the honest
+	// value for "not measured this tick" — it is only meaningful while
+	// inventario_orphan_gc_runs_total{result="success"} is advancing.
 	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeOrphanFileGC) {
 		orphanGCRunsTotal.WithLabelValues("skipped_paused").Inc()
+		orphanGCBlockedTenants.Set(0)
 		return
 	}
 	if w.mode == OrphanFileGCModeOff {
 		orphanGCRunsTotal.WithLabelValues("skipped_disabled").Inc()
+		orphanGCBlockedTenants.Set(0)
 		return
 	}
 
@@ -534,6 +543,7 @@ func (w *OrphanFileGCWorker) RunOnce(ctx context.Context) {
 	if err != nil {
 		slog.Error("Orphan file GC: failed to build the in-flight concurrency gate; aborting tick", "error", err)
 		orphanGCRunsTotal.WithLabelValues("error").Inc()
+		orphanGCBlockedTenants.Set(0) // the gate was never evaluated — assert nothing
 		return
 	}
 	orphanGCBlockedTenants.Set(float64(len(gate.blocked)))
@@ -754,6 +764,15 @@ func (w *OrphanFileGCWorker) sweepRows(ctx context.Context, gate orphanGCGate, c
 	var stats orphanGCStats
 
 	cursor := w.rowCursor
+	// Persist the scan position even when the tick ABORTS. A probe failure that
+	// keeps recurring on the same row (a poison row, a permanently unhealthy
+	// replica) would otherwise replay the identical page every tick, forever,
+	// and no other orphan in the installation would ever be enumerated. The
+	// cursor was already advanced past that row, so the next tick resumes AFTER
+	// it: the failing row is simply KEPT until the scan wraps and comes back to
+	// it — the safe direction, and the only one that still makes progress.
+	defer func() { w.rowCursor = cursor }()
+
 	for stats.scanned < w.rowBudget {
 		page, err := w.deps.Files.ListOrphanCandidates(ctx, cutoff, cursor, w.rowPageSize)
 		if err != nil {
@@ -788,7 +807,6 @@ func (w *OrphanFileGCWorker) sweepRows(ctx context.Context, gate orphanGCGate, c
 			break
 		}
 	}
-	w.rowCursor = cursor
 
 	return stats, nil
 }
@@ -1196,36 +1214,43 @@ func (w *OrphanFileGCWorker) sweepTenantThumbnails(
 			// The one and only path to a delete.
 		default:
 			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipProbeError).Inc()
+			// Persist the position BEFORE aborting, for the same reason as the
+			// row cursor: a recurring failure on one key would otherwise make
+			// every tick re-list and re-probe the identical head of this
+			// tenant's prefix forever, and no thumbnail past it would ever be
+			// reached. Resuming after the failed key KEEPS it (the safe
+			// direction) and revisits it when the cycle wraps.
+			w.thumbCursor[tenantID] = cand.key
 			return stats, err
 		}
 
 		stats.candidates++
 		orphanGCCandidatesTotal.WithLabelValues("thumbnail").Inc()
-		logOrphanThumbnail(slog.LevelWarn, w.mode, candidateAction(w.mode), tenantID, fileID, size, cand)
 
 		if w.mode != OrphanFileGCModeDelete {
 			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipReportMode).Inc()
+			logOrphanThumbnail(slog.LevelWarn, w.mode, "candidate", tenantID, fileID, size, cand)
 			continue
 		}
 		// T5 — re-assert the in-flight gate immediately before this delete.
 		if gate.isBlocked(tenantID) {
 			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipInflight).Inc()
+			logOrphanThumbnail(slog.LevelWarn, w.mode, "skipped", tenantID, fileID, size, cand)
 			continue
 		}
+		// Two-phase, exactly like the row path: "deleting" is the pre-image,
+		// "deleted" is only ever written after the delete actually succeeded.
+		// A record claiming a destruction that never happened is worse than no
+		// record — the log IS the recovery artifact.
+		logOrphanThumbnail(slog.LevelInfo, w.mode, "deleting", tenantID, fileID, size, cand)
 		if w.deleteThumbnail(ctx, bucket, tenantID, fileID, size) {
 			stats.deleted++
 			orphanGCDeletedTotal.WithLabelValues("thumbnail").Inc()
+			logOrphanThumbnail(slog.LevelInfo, w.mode, "deleted", tenantID, fileID, size, cand)
 		}
 	}
 
 	return stats, nil
-}
-
-func candidateAction(mode OrphanFileGCMode) string {
-	if mode == OrphanFileGCModeDelete {
-		return "deleted"
-	}
-	return "candidate"
 }
 
 // listAgedThumbnails enumerates ONE tenant's thumbnail prefix and keeps only the

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -1,0 +1,1379 @@
+// OrphanFileGCWorker mirrors the OperationSlotCleanupWorker /
+// EmailVerificationCleanupWorker lifecycle by design — same
+// Start/Stop/runCleanup/sweepOnce shape and the same soft-pause skip
+// (#1308). It is deliberately NOT folded into a shared generic base: this
+// is the only DESTRUCTIVE periodic worker in the tree, and keeping its
+// lifecycle spelled out in full is what lets a reviewer read the delete
+// path top-to-bottom without chasing a base class.
+package services
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+const (
+	// defaultOrphanFileGCInterval is how often the sweep runs. The row scan
+	// is a single indexed anti-join and the blob scan is one bucket LIST per
+	// tenant, so a daily cadence is plenty: orphans do not decay, and waiting
+	// costs nothing while being wrong is irreversible.
+	defaultOrphanFileGCInterval = 24 * time.Hour
+
+	// defaultOrphanFileGCMinAge is how old a row/blob must be before it can
+	// even be considered. It is measured against every bounded in-flight
+	// window in the system with four-to-five orders of magnitude to spare:
+	// an upload's blob-before-row window is the HTTP handler (seconds), the
+	// thumbnail worker's Get→write window is bounded at 2 minutes by the
+	// detached-job timeout, and blobbackfill's copy→repoint window is one
+	// copy plus one UPDATE. The one UNBOUNDED window — a restore — is not
+	// covered by the age gate at all; the concurrency gate covers it.
+	defaultOrphanFileGCMinAge = 72 * time.Hour
+
+	// MinOrphanFileGCMinAge is the hard floor an operator may not configure
+	// below. Startup fails rather than accepting a shorter window.
+	MinOrphanFileGCMinAge = 24 * time.Hour
+
+	// defaultOrphanRowPageSize bounds ONE candidate query so a pathological
+	// install cannot blow memory in a single fetch. It is a page size, not a
+	// budget: sweepRows keeps paging with a (created_at, id) keyset cursor
+	// until the per-tick row budget is spent or the scan is exhausted.
+	defaultOrphanRowPageSize = 500
+
+	// defaultOrphanRowBudgetPerTick bounds how many candidate rows one tick
+	// re-verifies in total. Whatever is left is picked up on the NEXT tick,
+	// resuming from the cursor — never from the top of the scan, because most
+	// candidates are KEPT rather than deleted and several keep-reasons never
+	// clear (see OrphanFileGCWorker.rowCursor).
+	defaultOrphanRowBudgetPerTick = 5000
+
+	// defaultOrphanThumbnailBudgetPerTenant bounds the number of thumbnail
+	// keys listed for ONE tenant in one tick. Per-TENANT on purpose: a single
+	// shared budget is spent by whichever tenant is enumerated first (its LIVE
+	// thumbnails count against it, and they outnumber orphans by orders of
+	// magnitude), which silently disables the blob sweep for every tenant
+	// after it — permanently, since the listing is lexicographic and no key is
+	// ever removed.
+	defaultOrphanThumbnailBudgetPerTenant = 5000
+)
+
+// orphanGCThumbnailSizes is the exhaustive set of thumbnail size suffixes the
+// file service ever writes (see FileService.thumbnailSizes). A key whose size
+// segment is not in this set does not round-trip and is KEPT.
+var orphanGCThumbnailSizes = map[string]bool{
+	"small":  true,
+	"medium": true,
+}
+
+// orphanGCLinkAllowlist is the positive allowlist of linked_entity_type values
+// the GC understands, re-asserted in Go on every candidate even though the
+// registry query already applied it. It excludes, structurally:
+//
+//   - ""       — a STANDALONE file (#2235). First-class, exported in backups.
+//     "No link" is NOT "orphan"; an orphan is a file whose link points at a
+//     NONEXISTENT entity.
+//   - "export" — owned by the backup subsystem (#2121 and friends). Never
+//     probed, so the `deleted_at IS NULL` filter on the exports registry can
+//     never be misread as "the export is gone".
+//   - anything else — including a link type added in a future release. The
+//     registries do not enforce models.FileEntity.ValidateWithContext, so the
+//     DB is a superset of the validator's enumeration; an unknown type is kept
+//     unconditionally until someone adds it here AND gives it a probe.
+var orphanGCLinkAllowlist = map[string]bool{
+	"commodity": true,
+	"area":      true,
+	"location":  true,
+}
+
+// Skip reasons, used both as the Prometheus label value and as the `reason`
+// field on the forensic log record so a metric spike is greppable in the logs.
+const (
+	orphanGCSkipTargetExists      = "target_exists"
+	orphanGCSkipProbeError        = "probe_error"
+	orphanGCSkipMalformedLink     = "malformed_link"
+	orphanGCSkipDisallowedLink    = "disallowed_link_type"
+	orphanGCSkipAge               = "age"
+	orphanGCSkipInflight          = "inflight"
+	orphanGCSkipGroupInactive     = "group_inactive"
+	orphanGCSkipTenantInactive    = "tenant_inactive"
+	orphanGCSkipOwnerUnresolvable = "owner_unresolvable"
+	orphanGCSkipUnparseableKey    = "unparseable_key"
+	orphanGCSkipReportMode        = "report_mode"
+	orphanGCSkipSharedBlobKey     = "shared_blob_key"
+	orphanGCSkipBudgetExhausted   = "budget_exhausted"
+)
+
+// Prometheus instrumentation for the orphan-file GC (#2237). Worker-local
+// promauto counters, following group_purge_worker.go — internal/metrics is
+// reserved for the cross-cutting HTTP/DB/auth/email/business series.
+//
+// inventario_orphan_gc_candidates_total is THE signal for the report→delete
+// rollout: it increments in BOTH modes, so an operator can watch the predicate
+// against real production data for a full release cycle before ever enabling
+// deletion.
+var (
+	orphanGCRunsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_runs_total",
+		Help: "Orphan-file GC ticks by outcome (success, error, skipped_paused, skipped_disabled).",
+	}, []string{"result"})
+	orphanGCRowsScannedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_rows_scanned_total",
+		Help: "File rows returned by the orphan-candidate query (before per-candidate re-verification).",
+	})
+	orphanGCBlobsScannedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_blobs_scanned_total",
+		Help: "Thumbnail blob keys enumerated by the orphan-file GC.",
+	})
+	orphanGCCandidatesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_candidates_total",
+		Help: "Orphans that passed every safety gate, by kind (row, thumbnail). Incremented in report AND delete mode.",
+	}, []string{"kind"})
+	orphanGCDeletedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_deleted_total",
+		Help: "Orphans actually deleted by the orphan-file GC, by kind (row, thumbnail). Delete mode only.",
+	}, []string{"kind"})
+	orphanGCSkippedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_skipped_total",
+		Help: "Orphan-file GC candidates deliberately KEPT, by reason.",
+	}, []string{"reason"})
+	orphanGCFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_orphan_gc_failures_total",
+		Help: "Orphan-file GC deletions that raised an error (retried next tick).",
+	})
+	orphanGCBlockedTenants = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_orphan_gc_blocked_tenants",
+		Help: "Tenants skipped this tick because an export/restore is in flight (or recently finished). A value that stays >0 means a stuck operation is pinning a tenant — investigate the operation, do not bypass the gate.",
+	})
+	orphanGCLastSuccessTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_orphan_gc_last_success_timestamp_seconds",
+		Help: "Unix timestamp of the last orphan-file GC tick that completed without error.",
+	})
+)
+
+// OrphanFileGCMode selects what a tick is allowed to do.
+type OrphanFileGCMode string
+
+const (
+	// OrphanFileGCModeOff skips the tick entirely — no candidate query, no
+	// bucket LIST. For operators who do not want to pay the listing cost.
+	OrphanFileGCModeOff OrphanFileGCMode = "off"
+
+	// OrphanFileGCModeReport is the SHIPPING DEFAULT and the mandatory dry
+	// run. It evaluates the identical predicate, applies the identical gates,
+	// emits the identical forensic log record and increments
+	// inventario_orphan_gc_candidates_total — and stops one line short of the
+	// delete. A false positive here is irreversible user data loss with no
+	// undo (files has no soft-delete column and DeleteFileWithPhysical takes
+	// the blob and thumbnails with it), so the predicate has to earn the right
+	// to delete by being observed against real data first.
+	OrphanFileGCModeReport OrphanFileGCMode = "report"
+
+	// OrphanFileGCModeDelete enforces. Explicit operator opt-in only.
+	OrphanFileGCModeDelete OrphanFileGCMode = "delete"
+)
+
+// ParseOrphanFileGCMode validates s. The second return reports whether s named
+// a known mode — callers fail startup on false rather than silently defaulting
+// a destructive knob.
+func ParseOrphanFileGCMode(s string) (OrphanFileGCMode, bool) {
+	m := OrphanFileGCMode(s)
+	switch m {
+	case OrphanFileGCModeOff, OrphanFileGCModeReport, OrphanFileGCModeDelete:
+		return m, true
+	}
+	return "", false
+}
+
+// EntityExistenceProbe answers "does an entity with this id exist, anywhere in
+// the database?".
+//
+// It MUST be backed by an RLS-BYPASSING service registry and match BY ID ONLY
+// — never by (tenant, group, id). PUT /files/{id} performs no existence,
+// tenant, or group check on the link target, so a file legitimately linked to
+// an entity in ANOTHER group is reachable in production; a group-scoped probe
+// would return ErrNotFound for that LIVE entity and hand the GC a live file to
+// delete. That is the single easiest catastrophic bug in this feature and it
+// is closed by construction here.
+//
+// "Does not exist" means EXACTLY registry.ErrNotFound. Any other error (a DB
+// timeout, a connection reset) is a transient failure, never evidence of
+// absence.
+type EntityExistenceProbe func(ctx context.Context, id string) error
+
+// OrphanFileGCProbes bundles one probe per allowlisted link type. A missing
+// probe means the corresponding link type is never swept (fail closed).
+type OrphanFileGCProbes struct {
+	Commodity EntityExistenceProbe
+	Area      EntityExistenceProbe
+	Location  EntityExistenceProbe
+}
+
+func (p OrphanFileGCProbes) forLinkType(linkType string) EntityExistenceProbe {
+	switch linkType {
+	case "commodity":
+		return p.Commodity
+	case "area":
+		return p.Area
+	case "location":
+		return p.Location
+	}
+	return nil
+}
+
+// OrphanFileGCFileRegistry is the (service-mode) slice of registry.FileRegistry
+// the GC reads. Read-only: the worker adds no new write path anywhere.
+type OrphanFileGCFileRegistry interface {
+	ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error)
+	ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error)
+	CountByOriginalPath(ctx context.Context, originalPath string) (int, error)
+	Get(ctx context.Context, id string) (*models.FileEntity, error)
+}
+
+// OrphanFileGCExportRegistry is the export-side half of the concurrency gate.
+// ListWithDeleted (not List) because a soft-deleted export still owns its
+// artifacts, and an in-flight import is an export row too (Imported=true,
+// Status=pending — see backup/import/worker.go), so one read covers export
+// generation AND import ingestion.
+type OrphanFileGCExportRegistry interface {
+	ListWithDeleted(ctx context.Context) ([]*models.Export, error)
+}
+
+// OrphanFileGCRestoreOperationRegistry is the restore-side half of the
+// concurrency gate.
+type OrphanFileGCRestoreOperationRegistry interface {
+	List(ctx context.Context) ([]*models.RestoreOperation, error)
+}
+
+// OrphanFileGCTenantRegistry enumerates tenants for the thumbnail sweep and
+// resolves a candidate row's owning tenant for the lifecycle gate.
+type OrphanFileGCTenantRegistry interface {
+	List(ctx context.Context) ([]*models.Tenant, error)
+	Get(ctx context.Context, id string) (*models.Tenant, error)
+}
+
+// OrphanFileGCGroupRegistry resolves a candidate row's owning group.
+type OrphanFileGCGroupRegistry interface {
+	Get(ctx context.Context, id string) (*models.LocationGroup, error)
+}
+
+// OrphanFileGCUserRegistry resolves a candidate row's creator so the delete can
+// run under that user's own RLS scope.
+type OrphanFileGCUserRegistry interface {
+	Get(ctx context.Context, id string) (*models.User, error)
+}
+
+// OrphanFileDeleter is the destructive half — satisfied by *FileService. The
+// GC never deletes a row itself: it calls DeleteFileWithPhysical under a
+// USER-scoped (RLS-enforcing) context bound to the file's own tenant+group, so
+// discovery is broad but destruction is narrow. That also tears down the
+// thumbnail_generation_jobs → user_concurrency_slots NO ACTION FK chain, which
+// a raw `DELETE FROM files` would trip.
+type OrphanFileDeleter interface {
+	DeleteFileWithPhysical(ctx context.Context, fileID string) error
+}
+
+// OrphanFileGCDeps is the narrow dependency set the sweeper needs. Every
+// registry here is SERVICE-MODE (RLS-bypassing) and READ-ONLY except Deleter.
+type OrphanFileGCDeps struct {
+	Files          OrphanFileGCFileRegistry
+	Probes         OrphanFileGCProbes
+	Exports        OrphanFileGCExportRegistry
+	Restores       OrphanFileGCRestoreOperationRegistry
+	Tenants        OrphanFileGCTenantRegistry
+	Groups         OrphanFileGCGroupRegistry
+	Users          OrphanFileGCUserRegistry
+	Deleter        OrphanFileDeleter
+	UploadLocation string
+}
+
+// OrphanFileGCWorker periodically reclaims the residues the delete paths cannot
+// close by construction (#2237): file ROWS whose linked entity no longer
+// exists (crash between an entity-row delete and its DeleteLinkedFiles), and
+// THUMBNAIL blobs whose owning file row is gone (the thumbnail worker's
+// Get→write race).
+//
+// It sweeps EXACTLY those two classes. It never enumerates t/<tenant>/files/,
+// t/<tenant>/exports/, t/<tenant>/restores/, seed keys, or anything outside the
+// t/ prefix — see sweepTenantThumbnails for why each of those is a NEVER-SWEEP.
+// Every field below the config block is owned by the sweep goroutine: RunOnce
+// is called from the ticker loop only (and, in tests, serially), never
+// concurrently with itself.
+type OrphanFileGCWorker struct {
+	deps        OrphanFileGCDeps
+	interval    time.Duration
+	minAge      time.Duration
+	mode        OrphanFileGCMode
+	pause       PauseChecker
+	rowPageSize int
+	rowBudget   int
+	thumbBudget int
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	wg          sync.WaitGroup
+
+	// rowCursor is where the NEXT tick's candidate scan resumes, in the
+	// (created_at, id) keyset order the registry guarantees.
+	//
+	// It is a liveness requirement, not an optimization. Re-verification KEEPS
+	// far more rows than it deletes, and several keep-reasons never clear on a
+	// later tick: a tenant pinned by a crashed export/restore (there is no
+	// heartbeat — see logBlocked), a suspended tenant, a pending_deletion
+	// group, a purged owner. Those rows are also, by construction, among the
+	// OLDEST orphans in the installation, so a non-resumable oldest-first
+	// window would be squatted on by exactly them and no other orphan would
+	// ever be enumerated again. In the shipping REPORT mode nothing is ever
+	// deleted at all, so without the cursor every tick would re-report the
+	// identical page forever and the rollout signal would be meaningless.
+	//
+	// Reset to the zero value when a scan runs out of candidates, so the next
+	// tick starts a fresh cycle from the oldest row.
+	rowCursor registry.OrphanCandidateCursor
+
+	// thumbCursor is the per-tenant resume point for the thumbnail listing:
+	// the last key examined by a tick that ran out of per-tenant budget. The
+	// next tick skips everything up to and including it, so a tenant whose
+	// LIVE thumbnails exceed the budget still has the REST of its prefix
+	// examined over successive ticks instead of re-listing the same head
+	// forever. Cleared for a tenant as soon as its listing reaches the end.
+	thumbCursor map[string]string
+}
+
+// OrphanFileGCOption customizes an OrphanFileGCWorker.
+type OrphanFileGCOption func(*orphanFileGCOptions)
+
+type orphanFileGCOptions struct {
+	interval    time.Duration
+	minAge      time.Duration
+	mode        OrphanFileGCMode
+	pause       PauseChecker
+	rowPageSize int
+	rowBudget   int
+	thumbBudget int
+}
+
+// WithOrphanFileGCInterval overrides the sweep interval. Non-positive values
+// are ignored.
+func WithOrphanFileGCInterval(d time.Duration) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if d > 0 {
+			o.interval = d
+		}
+	}
+}
+
+// WithOrphanFileGCMinAge overrides the minimum age a row/blob must reach before
+// it is eligible. Values below MinOrphanFileGCMinAge are REJECTED (the default
+// is retained and the attempt is logged) — bootstrap already fails fast on
+// them, and this is the defence-in-depth so a programmatic caller cannot shrink
+// the window either.
+func WithOrphanFileGCMinAge(d time.Duration) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if d < MinOrphanFileGCMinAge {
+			slog.Warn("Ignoring orphan-file GC min-age below the hard floor",
+				"requested", d, "floor", MinOrphanFileGCMinAge, "using", o.minAge)
+			return
+		}
+		o.minAge = d
+	}
+}
+
+// WithOrphanFileGCMode sets the enforcement mode. An unknown mode is ignored
+// (the safe default, report, is retained) — bootstrap fails fast on it.
+func WithOrphanFileGCMode(m OrphanFileGCMode) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if _, ok := ParseOrphanFileGCMode(string(m)); !ok {
+			slog.Warn("Ignoring unknown orphan-file GC mode", "requested", m, "using", o.mode)
+			return
+		}
+		o.mode = m
+	}
+}
+
+// WithOrphanFileGCPauseController wires the soft-pause controller so the worker
+// skips its sweep while the orphan-file-gc worker type is paused (#1308). This
+// is the operator's emergency stop for the only destructive worker in the tree.
+// A nil checker leaves the worker unpaused.
+func WithOrphanFileGCPauseController(pc PauseChecker) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
+// WithOrphanFileGCRowBudget bounds the row sweep's work per tick: pageSize rows
+// per candidate query, perTick rows re-verified in total before the tick stops
+// and hands the rest to the next one (resuming from the keyset cursor, never
+// from the top). Non-positive values are ignored.
+func WithOrphanFileGCRowBudget(pageSize, perTick int) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if pageSize > 0 {
+			o.rowPageSize = pageSize
+		}
+		if perTick > 0 {
+			o.rowBudget = perTick
+		}
+	}
+}
+
+// WithOrphanFileGCThumbnailBudget bounds how many thumbnail keys are listed for
+// ONE TENANT in one tick. The remainder of that tenant's prefix is examined on
+// subsequent ticks (see OrphanFileGCWorker.thumbCursor); other tenants are never
+// starved, because the budget is not shared between them. Non-positive values
+// are ignored.
+func WithOrphanFileGCThumbnailBudget(perTenant int) OrphanFileGCOption {
+	return func(o *orphanFileGCOptions) {
+		if perTenant > 0 {
+			o.thumbBudget = perTenant
+		}
+	}
+}
+
+// NewOrphanFileGCWorker creates the sweeper with safe defaults: a 24h interval,
+// a 72h min age, and report mode (deletes nothing).
+func NewOrphanFileGCWorker(deps OrphanFileGCDeps, opts ...OrphanFileGCOption) *OrphanFileGCWorker {
+	options := orphanFileGCOptions{
+		interval:    defaultOrphanFileGCInterval,
+		minAge:      defaultOrphanFileGCMinAge,
+		mode:        OrphanFileGCModeReport,
+		rowPageSize: defaultOrphanRowPageSize,
+		rowBudget:   defaultOrphanRowBudgetPerTick,
+		thumbBudget: defaultOrphanThumbnailBudgetPerTenant,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &OrphanFileGCWorker{
+		deps:        deps,
+		interval:    options.interval,
+		minAge:      options.minAge,
+		mode:        options.mode,
+		pause:       options.pause,
+		rowPageSize: options.rowPageSize,
+		rowBudget:   options.rowBudget,
+		thumbBudget: options.thumbBudget,
+		stopCh:      make(chan struct{}),
+		thumbCursor: make(map[string]string),
+	}
+}
+
+// Start launches the background sweep goroutine. No-op when the file registry
+// or the deleter is missing.
+func (w *OrphanFileGCWorker) Start(ctx context.Context) {
+	if w.deps.Files == nil || w.deps.Deleter == nil {
+		slog.Warn("OrphanFileGCWorker: incomplete dependencies, skipping startup")
+		return
+	}
+	w.wg.Go(func() {
+		w.runCleanup(ctx)
+	})
+	slog.Info("Orphan file GC worker started",
+		"interval", w.interval, "min_age", w.minAge, "mode", w.mode)
+}
+
+// Stop signals the worker to stop and waits for it to finish.
+func (w *OrphanFileGCWorker) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
+	w.wg.Wait()
+	slog.Info("Orphan file GC worker stopped")
+}
+
+func (w *OrphanFileGCWorker) runCleanup(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.RunOnce(ctx)
+		}
+	}
+}
+
+// RunOnce performs exactly one sweep. Exported so an operator-facing one-shot
+// (and the test suite) can drive the identical code path the ticker drives —
+// there is no separate, less-guarded route into the delete.
+func (w *OrphanFileGCWorker) RunOnce(ctx context.Context) {
+	// Soft-pause (#1308) FIRST, before any registry or bucket call. The ticker
+	// keeps running so resume takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeOrphanFileGC) {
+		orphanGCRunsTotal.WithLabelValues("skipped_paused").Inc()
+		return
+	}
+	if w.mode == OrphanFileGCModeOff {
+		orphanGCRunsTotal.WithLabelValues("skipped_disabled").Inc()
+		return
+	}
+
+	start := time.Now()
+	cutoff := start.Add(-w.minAge)
+
+	// Fail closed: any error building the gate aborts the WHOLE tick. A
+	// partially-built gate would let a tenant with an in-flight restore
+	// through, which is the one thing the gate exists to prevent.
+	gate, err := w.buildConcurrencyGate(ctx, start)
+	if err != nil {
+		slog.Error("Orphan file GC: failed to build the in-flight concurrency gate; aborting tick", "error", err)
+		orphanGCRunsTotal.WithLabelValues("error").Inc()
+		return
+	}
+	orphanGCBlockedTenants.Set(float64(len(gate.blocked)))
+	gate.logBlocked()
+
+	rows, err := w.sweepRows(ctx, gate, cutoff)
+	if err != nil {
+		slog.Error("Orphan file GC: row sweep aborted", "error", err)
+		orphanGCRunsTotal.WithLabelValues("error").Inc()
+		return
+	}
+
+	blobs, err := w.sweepThumbnails(ctx, gate, cutoff)
+	if err != nil {
+		slog.Error("Orphan file GC: thumbnail sweep aborted", "error", err)
+		orphanGCRunsTotal.WithLabelValues("error").Inc()
+		return
+	}
+
+	orphanGCRunsTotal.WithLabelValues("success").Inc()
+	orphanGCLastSuccessTimestamp.Set(float64(time.Now().Unix()))
+
+	attrs := []any{
+		"event", "orphan_gc.tick",
+		"mode", string(w.mode),
+		"min_age", w.minAge.String(),
+		"rows_scanned", rows.scanned,
+		"row_candidates", rows.candidates,
+		"rows_deleted", rows.deleted,
+		"blobs_scanned", blobs.scanned,
+		"blob_candidates", blobs.candidates,
+		"blobs_deleted", blobs.deleted,
+		"blocked_tenants", len(gate.blocked),
+		"duration_ms", time.Since(start).Milliseconds(),
+	}
+	if rows.candidates > 0 || blobs.candidates > 0 {
+		slog.Info("Orphan file GC tick found candidates", attrs...)
+		return
+	}
+	slog.Debug("Orphan file GC tick clean", attrs...)
+}
+
+// orphanGCStats is the per-sweep tally reported on the tick log line.
+type orphanGCStats struct {
+	scanned    int
+	candidates int
+	deleted    int
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency gate
+// ---------------------------------------------------------------------------
+
+// orphanGCBlocker records why a tenant is off-limits this tick.
+type orphanGCBlocker struct {
+	kind   string // "export" | "restore"
+	id     string
+	status string
+	age    time.Duration
+}
+
+// orphanGCGate is the per-TENANT in-flight gate, built once per tick from
+// RLS-bypassing service registries and re-asserted immediately before every
+// individual delete.
+//
+// It has to be DB-backed, not in-process: `run workers --workers-only=housekeeping`
+// puts this worker in a DIFFERENT PROCESS from the export/restore/import workers
+// (they live in the `archive` group), so any in-memory flag or semaphore would
+// be wrong by construction. The operation_slots / user_concurrency_slots tables
+// are NOT usable here either — they are per-user upload/thumbnail concurrency
+// limiters with a 30–300s expiry and cannot answer "is a restore live for this
+// tenant".
+type orphanGCGate struct {
+	blocked map[string]orphanGCBlocker
+}
+
+func (g orphanGCGate) isBlocked(tenantID string) bool {
+	_, ok := g.blocked[tenantID]
+	return ok
+}
+
+// logBlocked surfaces the stuck-operation fail-safe. There is no heartbeat
+// anywhere in the system: a crashed restore stays `running` forever and a
+// crashed export stays `in_progress`, which under this gate PERMANENTLY
+// disables the GC for that tenant. That is the correct direction (under-collect
+// forever beats one wrong delete), but it must be diagnosable rather than a
+// silent no-op — hence the warn plus inventario_orphan_gc_blocked_tenants.
+//
+// Do NOT "fix" this with a "stale after N hours → ignore it" rule: that
+// re-opens the exact race the gate closes.
+func (g orphanGCGate) logBlocked() {
+	for tenantID, b := range g.blocked {
+		slog.Warn("Orphan file GC: tenant skipped, operation in flight or recently finished",
+			"event", "orphan_gc.blocked",
+			"tenant_id", tenantID,
+			"blocker", b.kind,
+			"blocker_id", b.id,
+			"blocker_status", b.status,
+			"blocker_age_hours", b.age.Hours(),
+		)
+	}
+}
+
+func (w *OrphanFileGCWorker) buildConcurrencyGate(ctx context.Context, now time.Time) (orphanGCGate, error) {
+	gate := orphanGCGate{blocked: make(map[string]orphanGCBlocker)}
+
+	exports, err := w.deps.Exports.ListWithDeleted(ctx)
+	if err != nil {
+		return orphanGCGate{}, err
+	}
+	for _, e := range exports {
+		if e == nil {
+			continue
+		}
+		status := string(e.Status)
+		switch e.Status {
+		case models.ExportStatusPending, models.ExportStatusInProgress:
+			// Covers the export worker AND import ingestion: a pending import
+			// is an export row with Imported=true, Status=pending.
+			gate.block(e.TenantID, orphanGCBlocker{kind: "export", id: e.ID, status: status})
+		case models.ExportStatusCompleted, models.ExportStatusFailed:
+			if age, recent := orphanGCTerminalAge(now, e.CompletedDate, e.CreatedDate, w.minAge); recent {
+				gate.block(e.TenantID, orphanGCBlocker{kind: "export", id: e.ID, status: status, age: age})
+			}
+		}
+	}
+
+	restores, err := w.deps.Restores.List(ctx)
+	if err != nil {
+		return orphanGCGate{}, err
+	}
+	for _, r := range restores {
+		if r == nil {
+			continue
+		}
+		status := string(r.Status)
+		switch r.Status {
+		case models.RestoreStatusPending, models.RestoreStatusRunning:
+			gate.block(r.TenantID, orphanGCBlocker{kind: "restore", id: r.ID, status: status})
+		case models.RestoreStatusCompleted, models.RestoreStatusFailed:
+			if age, recent := orphanGCTerminalAge(now, r.CompletedDate, r.CreatedDate, w.minAge); recent {
+				gate.block(r.TenantID, orphanGCBlocker{kind: "restore", id: r.ID, status: status, age: age})
+			}
+		}
+	}
+
+	return gate, nil
+}
+
+func (g orphanGCGate) block(tenantID string, b orphanGCBlocker) {
+	if tenantID == "" {
+		return
+	}
+	if _, exists := g.blocked[tenantID]; exists {
+		return // first blocker wins; one reason is enough to skip the tenant
+	}
+	g.blocked[tenantID] = b
+}
+
+// orphanGCTerminalAge implements the COOLDOWN half of the gate: a tenant stays
+// off-limits for minAge after any export/restore reaches a terminal state.
+//
+// This is what closes the archive-timestamp hole. A restore persists the
+// ARCHIVE's created_at/updated_at verbatim onto the rows it writes (see
+// backup/restore/types ConvertToFileEntity — the registry Create overrides only
+// ID/UUID/tenant/group), so a file row written ten seconds ago can carry
+// created_at = 2019 and would clear a naive age gate instantly. The row age
+// gate is therefore NOT load-bearing for restore; this wall-clock cooldown is.
+//
+// A terminal operation with no completed_date falls back to created_date, and a
+// terminal operation with neither is treated as RECENT (fail closed).
+func orphanGCTerminalAge(now time.Time, completed, created models.PTimestamp, minAge time.Duration) (age time.Duration, recent bool) {
+	// Timestamp.ToTime is nil-safe and returns the zero time for a nil or
+	// unparseable value.
+	t := completed.ToTime()
+	if t.IsZero() {
+		t = created.ToTime()
+	}
+	if t.IsZero() {
+		return 0, true // no usable timestamp at all ⇒ assume it just happened
+	}
+	age = now.Sub(t)
+	return age, age < minAge
+}
+
+// ---------------------------------------------------------------------------
+// Row sweep
+// ---------------------------------------------------------------------------
+
+// orphanRowVerdict is the outcome of re-verifying one candidate row.
+type orphanRowVerdict struct {
+	proceed bool
+	reason  string
+	user    *models.User
+	group   *models.LocationGroup
+}
+
+// sweepRows deletes file ROWS whose linked entity no longer exists.
+//
+// Non-existence of an entity id is MONOTONE and IRREVERSIBLE, which is the
+// backbone of the safety argument: entity IDs are server-minted on every
+// Create (registry/postgres/store/rlsgroup.go runs SetID(generateID())
+// unconditionally, including in service mode; the memory registry does the
+// same), there is no raw INSERT with a caller-supplied id anywhere in non-test
+// code, and a restore mints fresh ids rather than preserving archive ones. So
+// once "entity X does not exist" is true it is true forever — no live
+// operation, present or future, can make the file reachable again, and the
+// TOCTOU window between the re-verification and the delete cannot invert.
+// The scan is KEYSET-PAGINATED and the cursor SURVIVES THE TICK (w.rowCursor).
+// Re-verification keeps far more rows than it deletes, and several
+// keep-reasons never clear — a tenant pinned by a crashed restore, a suspended
+// tenant, a pending_deletion group, a purged owner — so those rows would
+// otherwise squat on a non-resumable oldest-first window forever and starve
+// every other orphan in the installation (and, in report mode, where nothing is
+// ever deleted, the tick would re-report the identical page for eternity).
+// Running out of candidates rewinds the cursor and starts a fresh cycle.
+func (w *OrphanFileGCWorker) sweepRows(ctx context.Context, gate orphanGCGate, cutoff time.Time) (orphanGCStats, error) {
+	var stats orphanGCStats
+
+	cursor := w.rowCursor
+	for stats.scanned < w.rowBudget {
+		page, err := w.deps.Files.ListOrphanCandidates(ctx, cutoff, cursor, w.rowPageSize)
+		if err != nil {
+			return stats, err // fail closed: abort the tick, never sweep a partial result
+		}
+		if len(page) == 0 {
+			cursor = registry.OrphanCandidateCursor{} // exhausted — next tick starts over
+			break
+		}
+
+		for _, file := range page {
+			if file == nil {
+				continue
+			}
+			// Advance the cursor for every row we LOOK at, whether or not it is
+			// deleted. A kept row must not be re-examined ahead of everything
+			// behind it on the next tick.
+			cursor = registry.OrphanCandidateCursor{CreatedAt: file.CreatedAt, ID: file.ID}
+			stats.scanned++
+			orphanGCRowsScannedTotal.Inc()
+
+			if err := w.sweepRowCandidate(ctx, file, gate, cutoff, &stats); err != nil {
+				return stats, err
+			}
+			if stats.scanned >= w.rowBudget {
+				break
+			}
+		}
+
+		if len(page) < w.rowPageSize {
+			cursor = registry.OrphanCandidateCursor{} // the scan is exhausted
+			break
+		}
+	}
+	w.rowCursor = cursor
+
+	return stats, nil
+}
+
+// sweepRowCandidate re-verifies one candidate and, in delete mode, deletes it.
+// A non-nil error is a transient failure that aborts the whole tick.
+func (w *OrphanFileGCWorker) sweepRowCandidate(
+	ctx context.Context,
+	file *models.FileEntity,
+	gate orphanGCGate,
+	cutoff time.Time,
+	stats *orphanGCStats,
+) error {
+	verdict, err := w.verifyRowCandidate(ctx, file, gate, cutoff)
+	if err != nil {
+		// A non-ErrNotFound probe failure must never read as "gone".
+		orphanGCSkippedTotal.WithLabelValues(orphanGCSkipProbeError).Inc()
+		return err
+	}
+	if !verdict.proceed {
+		orphanGCSkippedTotal.WithLabelValues(verdict.reason).Inc()
+		logOrphanRow(slog.LevelWarn, w.mode, "skipped", verdict.reason, file)
+		return nil
+	}
+
+	stats.candidates++
+	orphanGCCandidatesTotal.WithLabelValues("row").Inc()
+
+	if w.mode != OrphanFileGCModeDelete {
+		orphanGCSkippedTotal.WithLabelValues(orphanGCSkipReportMode).Inc()
+		logOrphanRow(slog.LevelWarn, w.mode, "candidate", orphanGCSkipReportMode, file)
+		return nil
+	}
+
+	// The forensic record is written BEFORE the delete: it is the only artifact
+	// from which a destroyed file can be reconstructed. It is logged as
+	// "deleting", NOT "deleted" — the delete can still fail (and did, for every
+	// orphan whose thumbnail-job chain could not be torn down), and a log that
+	// claims a destruction that never happened is worse than no log at all.
+	// Success is confirmed by its own record; failure by deleteRow's.
+	logOrphanRow(slog.LevelInfo, w.mode, "deleting", "", file)
+	if w.deleteRow(ctx, file, verdict) {
+		stats.deleted++
+		orphanGCDeletedTotal.WithLabelValues("row").Inc()
+		logOrphanRow(slog.LevelInfo, w.mode, "deleted", "", file)
+	}
+	return nil
+}
+
+// verifyRowCandidate re-asserts every gate in Go, immediately before the
+// delete — the candidate query is a filter, never an authorization.
+//
+// Returns a non-nil error ONLY for a transient probe failure, which aborts the
+// whole tick. Everything else is expressed as proceed=false + a reason, i.e.
+// KEEP the file.
+func (w *OrphanFileGCWorker) verifyRowCandidate(ctx context.Context, file *models.FileEntity, gate orphanGCGate, cutoff time.Time) (orphanRowVerdict, error) {
+	// R1/R2/R4/R5 — the cheap, purely local gates (allowlist, malformed link,
+	// age, in-flight tenant). Split out so this function stays inside the
+	// gocyclo bound; the ordering is unchanged and each rule keeps its own
+	// skip reason.
+	if reason := screenRowCandidate(file, gate, cutoff); reason != "" {
+		return orphanRowVerdict{reason: reason}, nil
+	}
+
+	// R6 — lifecycle of the owning group/tenant.
+	group, reason := w.resolveOwnerLifecycle(ctx, file)
+	if reason != "" {
+		return orphanRowVerdict{reason: reason}, nil
+	}
+
+	// R3 — EXISTENCE. Service-mode, by ID only. "Gone" means EXACTLY
+	// registry.ErrNotFound; anything else aborts the tick.
+	probe := w.deps.Probes.forLinkType(file.LinkedEntityType)
+	if probe == nil {
+		return orphanRowVerdict{reason: orphanGCSkipDisallowedLink}, nil
+	}
+	switch err := probe(ctx, file.LinkedEntityID); {
+	case err == nil:
+		return orphanRowVerdict{reason: orphanGCSkipTargetExists}, nil
+	case errors.Is(err, registry.ErrNotFound):
+		// The one and only path to a delete.
+	default:
+		return orphanRowVerdict{}, err
+	}
+
+	// R7 — executability. Deletion runs through FileService.DeleteFileWithPhysical
+	// under the file's OWN owner, so a raw service-mode row delete (which would
+	// also FK-fail on the thumbnail job chain) is never needed as a fallback.
+	user, err := w.deps.Users.Get(ctx, file.CreatedByUserID)
+	if err != nil || user == nil {
+		return orphanRowVerdict{reason: orphanGCSkipOwnerUnresolvable}, nil
+	}
+
+	// R8 — SOLE OWNERSHIP OF THE BLOB. The row delete is RLS-narrow, but the
+	// blob delete that follows it inside DeleteFileWithPhysical is KEY-scoped —
+	// and a blob key is NOT row-unique. An upload key is
+	// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`: no group segment,
+	// no row segment, no randomness (internal/filekit.UploadFileName), and there
+	// is no unique index on files.original_path. Two uploads of the same
+	// filename inside one tenant in the same second — two members of different
+	// groups; one user multi-selecting two same-named files — produce two
+	// DISTINCT rows sharing one key. Deleting the orphan's blob would then
+	// destroy the bytes of a LIVE row (a standalone file, #2235, is not even
+	// reachable by any other gate here), irreversibly: `files` has no
+	// soft-delete and there is no trash.
+	//
+	// So: unless this row is the ONLY one referencing its key, the file is KEPT
+	// whole. Under-collecting a rare same-second filename collision is free;
+	// destroying a live file's bytes is not. There is no TOCTOU here — the key
+	// embeds the SECOND it was minted in, and a candidate must be at least
+	// MinOrphanFileGCMinAge old, so a fresh upload can never mint a colliding
+	// key while the tick runs; a restore, the only other writer that can
+	// re-introduce one, blocks the whole tenant via the concurrency gate.
+	if file.File != nil && file.OriginalPath != "" {
+		refs, cerr := w.deps.Files.CountByOriginalPath(ctx, file.OriginalPath)
+		if cerr != nil {
+			return orphanRowVerdict{}, cerr // transient: abort the tick, never guess
+		}
+		if refs != 1 {
+			return orphanRowVerdict{reason: orphanGCSkipSharedBlobKey}, nil
+		}
+	}
+
+	return orphanRowVerdict{proceed: true, user: user, group: group}, nil
+}
+
+// screenRowCandidate applies the gates that need no I/O: R1 (positive
+// allowlist), R2 (malformed link), R4 (age, BOTH timestamps) and R5 (in-flight
+// tenant). Returns the skip reason, or "" when the candidate survives them all.
+//
+// R1 is re-asserted here even though the candidate query already applied it, so
+// a future registry bug cannot widen the blast radius: ” (standalone, #2235),
+// 'export', and any unknown/future link type are KEPT.
+func screenRowCandidate(file *models.FileEntity, gate orphanGCGate, cutoff time.Time) string {
+	if !orphanGCLinkAllowlist[file.LinkedEntityType] {
+		return orphanGCSkipDisallowedLink
+	}
+	// A set link type with an empty id is malformed DATA, not garbage.
+	if file.LinkedEntityID == "" {
+		return orphanGCSkipMalformedLink
+	}
+	// BOTH timestamps. updated_at is the load-bearing one: PUT /files/{id}
+	// stamps it with the app wall clock, so a file attached concurrently with
+	// an entity delete is immune for the whole window.
+	if !file.CreatedAt.Before(cutoff) || !file.UpdatedAt.Before(cutoff) {
+		return orphanGCSkipAge
+	}
+	// Re-checked per candidate rather than only once per tick.
+	if gate.isBlocked(file.TenantID) {
+		return orphanGCSkipInflight
+	}
+	return ""
+}
+
+// resolveOwnerLifecycle is R6: the file's group and tenant must both exist and
+// be ACTIVE. A pending_deletion group belongs to GroupPurgeWorker and a
+// non-active tenant may be mid-administrative-operation (#2115 hard delete), so
+// the GC keeps its hands off both. Under-collection is free; a wrong delete is
+// not. Returns the resolved group (needed for the impersonated delete) or a
+// skip reason.
+func (w *OrphanFileGCWorker) resolveOwnerLifecycle(ctx context.Context, file *models.FileEntity) (*models.LocationGroup, string) {
+	group, err := w.deps.Groups.Get(ctx, file.GroupID)
+	if err != nil || group == nil {
+		return nil, orphanGCSkipOwnerUnresolvable
+	}
+	if group.Status != models.LocationGroupStatusActive {
+		return nil, orphanGCSkipGroupInactive
+	}
+	tenant, err := w.deps.Tenants.Get(ctx, file.TenantID)
+	if err != nil || tenant == nil {
+		return nil, orphanGCSkipOwnerUnresolvable
+	}
+	if tenant.Status != models.TenantStatusActive {
+		return nil, orphanGCSkipTenantInactive
+	}
+	return group, ""
+}
+
+// deleteRow executes the delete under an impersonated (user, group) context so
+// the DELETE statement runs under RLS bound to the file's own tenant+group:
+// even a catastrophic bug in the candidate query cannot reach a row outside
+// that tuple — a wrong candidate simply matches zero rows.
+//
+// Reports whether a row was actually removed. registry.ErrNotFound is tolerated
+// (idempotent under multiple `run workers` replicas: two replicas racing the
+// same orphan produce one delete and one tolerated not-found).
+func (w *OrphanFileGCWorker) deleteRow(ctx context.Context, file *models.FileEntity, verdict orphanRowVerdict) bool {
+	dctx := appctx.WithUser(ctx, verdict.user)
+	dctx = appctx.WithGroup(dctx, verdict.group)
+
+	err := w.deps.Deleter.DeleteFileWithPhysical(dctx, file.ID)
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, registry.ErrNotFound):
+		return false // another replica won the race
+	default:
+		orphanGCFailuresTotal.Inc()
+		slog.Error("Orphan file GC: failed to delete orphan file row",
+			"event", "orphan_gc.row", "action", "failed",
+			"file_id", file.ID, "tenant_id", file.TenantID, "error", err.Error())
+		return false
+	}
+}
+
+// logOrphanRow writes the forensic record. Because deletion is irreversible and
+// `files` has no soft-delete column, THIS LINE IS THE RECOVERY ARTIFACT: an
+// operator must be able to reconstruct what was destroyed, and hand-verify a
+// report-mode candidate against the UI, from the log alone. The field set is
+// identical in both modes so grepping is mode-independent.
+//
+// The action vocabulary is exact, because an operator reconciling a data-loss
+// report reads these as fact:
+//
+//	skipped   — evaluated and KEPT (reason says why)
+//	candidate — would be deleted; report mode, so it was kept
+//	deleting  — about to be deleted; the pre-image, written while the row still exists
+//	deleted   — the delete RETURNED SUCCESS. Never emitted speculatively.
+//	failed    — the delete raised (deleteRow); the row is still there and is retried
+func logOrphanRow(level slog.Level, mode OrphanFileGCMode, action, reason string, file *models.FileEntity) {
+	attrs := []any{
+		"event", "orphan_gc.row",
+		"mode", string(mode),
+		"action", action,
+		"reason", reason,
+		"file_id", file.ID,
+		"file_uuid", file.GetUUID(),
+		"tenant_id", file.TenantID,
+		"group_id", file.GroupID,
+		"created_by_user_id", file.CreatedByUserID,
+		"linked_entity_type", file.LinkedEntityType,
+		"linked_entity_id", file.LinkedEntityID,
+		"linked_entity_meta", file.LinkedEntityMeta,
+		"title", file.Title,
+		"tags", strings.Join(file.Tags, ","),
+		"created_at", file.CreatedAt,
+		"updated_at", file.UpdatedAt,
+	}
+	if file.File != nil {
+		attrs = append(attrs,
+			"path", file.Path,
+			"original_path", file.OriginalPath,
+			"ext", file.Ext,
+			"mime_type", file.MIMEType,
+			"size_bytes", file.SizeBytes,
+		)
+	}
+	slog.Log(context.Background(), level, "Orphan file GC: orphan file row", attrs...)
+}
+
+// ---------------------------------------------------------------------------
+// Thumbnail (blob) sweep
+// ---------------------------------------------------------------------------
+
+// sweepThumbnails reclaims derived thumbnail blobs whose owning file row is
+// gone (the thumbnail worker's Get→write race: the worker Gets the row through
+// an RLS-bypassing registry and then writes the blobs from a detached
+// goroutine, so a file deleted inside that window leaves thumbnails behind).
+//
+// Thumbnails are the ONLY blob class this worker touches, and the only one it
+// safely can:
+//
+//   - a thumbnail key EMBEDS the owning row's primary key, so orphan-ness is an
+//     EXACT single-row existence question — no assumption about the
+//     completeness of a globally-scanned keep-set is needed anywhere; and
+//   - thumbnails are DERIVED and REGENERABLE, so even a hypothetical false
+//     positive costs a re-render, not data.
+func (w *OrphanFileGCWorker) sweepThumbnails(ctx context.Context, gate orphanGCGate, cutoff time.Time) (orphanGCStats, error) {
+	var stats orphanGCStats
+
+	tenants, err := w.deps.Tenants.List(ctx)
+	if err != nil {
+		return stats, err
+	}
+
+	b, err := blob.OpenBucket(ctx, w.deps.UploadLocation)
+	if err != nil {
+		return stats, err
+	}
+	defer b.Close()
+
+	// The listing budget is PER TENANT, never shared. A shared budget is spent
+	// by whichever tenant is enumerated first — by its LIVE thumbnails, which
+	// outnumber orphans by orders of magnitude — and every tenant after it is
+	// then skipped, on this tick and on every future one (the listing is
+	// lexicographic from the top and nothing removes those keys). That would
+	// make the blob half of the GC a permanent no-op for most of the
+	// installation, invisibly.
+	for _, tenant := range tenants {
+		if tenant == nil {
+			continue
+		}
+		if tenant.Status != models.TenantStatusActive {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipTenantInactive).Inc()
+			continue
+		}
+		if gate.isBlocked(tenant.ID) {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipInflight).Inc()
+			continue
+		}
+		tstats, terr := w.sweepTenantThumbnails(ctx, b, tenant.ID, gate, cutoff)
+		if terr != nil {
+			return stats, terr
+		}
+		stats.scanned += tstats.scanned
+		stats.candidates += tstats.candidates
+		stats.deleted += tstats.deleted
+	}
+
+	return stats, nil
+}
+
+// orphanThumbKey is one aged-out thumbnail key awaiting the row probe.
+type orphanThumbKey struct {
+	key     string
+	modTime time.Time
+}
+
+// sweepTenantThumbnails sweeps exactly ONE prefix: t/<tenant>/thumbnails/.
+//
+// Everything else in the bucket is NEVER-SWEEP — not filtered out, but never
+// passed to bucket.List in the first place, so no bug in a predicate can reach
+// it:
+//
+//   - t/<tenant>/files/    — two incompatible key shapes (a sanitized basename
+//     from the upload path, a file UUID from the restore path), so a key cannot
+//     be resolved back to a row; the only correct test is set-membership against
+//     a COMPLETE global snapshot of files.original_path, whose completeness
+//     cannot be proven under concurrency. Three writers are blob-first with no
+//     coordination (upload, restore, the blobbackfill CLI). The failure mode is
+//     irreversible loss of the user's file BYTES. NOT SWEPT. (The crash-window
+//     blobs #2237 cares about are still reclaimed — by the ROW sweep, because
+//     DeleteFileWithPhysical removes the original blob and its thumbnails.)
+//   - t/<tenant>/exports/  — a FAILED export leaves its .inb referenced by NO
+//     file row AND NO export row (export.FilePath is only assigned on the
+//     success path), indistinguishable from an in-flight export's partial
+//     artifact. The fix belongs at the source, not in a GC.
+//   - t/<tenant>/restores/ — THE most dangerous case (#2121). POST /uploads/restores
+//     writes the blob and creates NO ROW OF ANY KIND; it stays rowless until
+//     POST /exports/import, rowless forever if the user never submits, and
+//     rowless forever if the import FAILS. A "blobs with no owning file row"
+//     sweep here would destroy a user's uploaded backup.
+//   - t/<tenant>/seed-*    — sits directly under the tenant root; owned by real
+//     file rows.
+//   - anything outside t/  — legacy flat keys (pre-#1793) are still live
+//     wherever `inventario backfill blobs` was never run.
+func (w *OrphanFileGCWorker) sweepTenantThumbnails(
+	ctx context.Context,
+	bucket *blob.Bucket,
+	tenantID string,
+	gate orphanGCGate,
+	cutoff time.Time,
+) (orphanGCStats, error) {
+	var stats orphanGCStats
+
+	prefix := blobkeys.TenantPrefix(tenantID) + blobkeys.ThumbnailsSegment + "/"
+
+	// Step 1+2 — LIST, and AGE-FILTER BEFORE ANY DB READ. This ordering is what
+	// protects the thumbnail worker's detached Get→write window and any
+	// regeneration in flight; reading the DB snapshot first and listing second
+	// would re-open it.
+	aged, err := w.listAgedThumbnails(ctx, bucket, tenantID, prefix, cutoff, &stats)
+	if err != nil {
+		return stats, err
+	}
+	if len(aged) == 0 {
+		return stats, nil
+	}
+
+	// Step 3 — only NOW read the DB. A row created during the listing is in the
+	// set, which is the safe direction.
+	ids, err := w.deps.Files.ListIDsByTenant(ctx, tenantID)
+	if err != nil {
+		return stats, err
+	}
+	live := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		live[id] = true
+	}
+
+	for _, cand := range aged {
+		fileID, size, ok := parseThumbnailBlobKey(tenantID, cand.key)
+		if !ok {
+			// T1/T2 — anything that does not parse-and-round-trip exactly is
+			// KEPT. This is the structural anti-traversal / anti-confusion
+			// guard: we only ever delete a key we REBUILT ourselves.
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipUnparseableKey).Inc()
+			slog.Warn("Orphan file GC: unparseable thumbnail key, keeping",
+				"event", "orphan_gc.thumbnail", "action", "skipped",
+				"reason", orphanGCSkipUnparseableKey, "blob_key", cand.key, "tenant_id", tenantID)
+			continue
+		}
+		// T3 — the double check. The membership set alone can never cause a
+		// delete: a fresh service-mode Get must independently return EXACTLY
+		// registry.ErrNotFound.
+		if live[fileID] {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipTargetExists).Inc()
+			continue
+		}
+		switch _, err := w.deps.Files.Get(ctx, fileID); {
+		case err == nil:
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipTargetExists).Inc()
+			continue
+		case errors.Is(err, registry.ErrNotFound):
+			// The one and only path to a delete.
+		default:
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipProbeError).Inc()
+			return stats, err
+		}
+
+		stats.candidates++
+		orphanGCCandidatesTotal.WithLabelValues("thumbnail").Inc()
+		logOrphanThumbnail(slog.LevelWarn, w.mode, candidateAction(w.mode), tenantID, fileID, size, cand)
+
+		if w.mode != OrphanFileGCModeDelete {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipReportMode).Inc()
+			continue
+		}
+		// T5 — re-assert the in-flight gate immediately before this delete.
+		if gate.isBlocked(tenantID) {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipInflight).Inc()
+			continue
+		}
+		if w.deleteThumbnail(ctx, bucket, tenantID, fileID, size) {
+			stats.deleted++
+			orphanGCDeletedTotal.WithLabelValues("thumbnail").Inc()
+		}
+	}
+
+	return stats, nil
+}
+
+func candidateAction(mode OrphanFileGCMode) string {
+	if mode == OrphanFileGCModeDelete {
+		return "deleted"
+	}
+	return "candidate"
+}
+
+// listAgedThumbnails enumerates ONE tenant's thumbnail prefix and keeps only the
+// keys whose bucket ModTime is comfortably older than cutoff.
+//
+// ModTime is the authoritative freshness signal on the blob side precisely
+// because it is set by the storage backend (S3 LastModified / filesystem
+// mtime) and no application or user input can set it — unlike files.created_at,
+// which a restore writes verbatim from the archive. A zero/unavailable ModTime
+// or one in the FUTURE is KEPT (never compute a negative age and wrap).
+//
+// The per-tenant budget bounds the listing (blob.List is documented to walk
+// keys in lexicographic order), and a tenant that runs out of it RESUMES on the
+// next tick from the last key it examined instead of re-listing the same head
+// forever: live thumbnails are never deleted, so a truncated window would
+// otherwise never advance and every orphan past the cutoff key would be
+// unreachable for good. Truncation is recorded (orphanGCSkipBudgetExhausted +
+// a warn) so it is never a silent no-op.
+func (w *OrphanFileGCWorker) listAgedThumbnails(
+	ctx context.Context,
+	bucket *blob.Bucket,
+	tenantID, prefix string,
+	cutoff time.Time,
+	stats *orphanGCStats,
+) ([]orphanThumbKey, error) {
+	var aged []orphanThumbKey
+
+	resume := w.thumbCursor[tenantID]
+	budget := w.thumbBudget
+	lastKey := ""
+	truncated := false
+
+	iter := bucket.List(&blob.ListOptions{Prefix: prefix})
+	for {
+		obj, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if obj.IsDir {
+			continue
+		}
+		if resume != "" && obj.Key <= resume {
+			continue // covered by an earlier tick of this cycle
+		}
+		if budget <= 0 {
+			truncated = true
+			break
+		}
+		budget--
+		lastKey = obj.Key
+		stats.scanned++
+		orphanGCBlobsScannedTotal.Inc()
+
+		if obj.ModTime.IsZero() || !obj.ModTime.Before(cutoff) {
+			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipAge).Inc()
+			continue
+		}
+		aged = append(aged, orphanThumbKey{key: obj.Key, modTime: obj.ModTime})
+	}
+
+	if truncated && lastKey != "" {
+		w.thumbCursor[tenantID] = lastKey
+		orphanGCSkippedTotal.WithLabelValues(orphanGCSkipBudgetExhausted).Inc()
+		slog.Warn("Orphan file GC: thumbnail listing truncated, resuming next tick",
+			"event", "orphan_gc.thumbnail", "action", "skipped",
+			"reason", orphanGCSkipBudgetExhausted, "tenant_id", tenantID,
+			"budget", w.thumbBudget, "resume_after", lastKey)
+		return aged, nil
+	}
+	// Reached the end of the prefix: the next tick starts a fresh cycle.
+	delete(w.thumbCursor, tenantID)
+
+	return aged, nil
+}
+
+// deleteThumbnail removes the REBUILT key — never the raw string the bucket
+// listing handed us. Exists-guarded and not-found-tolerant, so two `run workers`
+// replicas racing the same orphan produce one delete and one no-op.
+func (w *OrphanFileGCWorker) deleteThumbnail(ctx context.Context, bucket *blob.Bucket, tenantID, fileID, size string) bool {
+	key := blobkeys.BuildThumbnailBlobKey(tenantID, fileID, size)
+
+	exists, err := bucket.Exists(ctx, key)
+	if err != nil {
+		orphanGCFailuresTotal.Inc()
+		slog.Error("Orphan file GC: failed to stat orphan thumbnail",
+			"event", "orphan_gc.thumbnail", "action", "failed",
+			"blob_key", key, "tenant_id", tenantID, "error", err.Error())
+		return false
+	}
+	if !exists {
+		return false
+	}
+	if err := bucket.Delete(ctx, key); err != nil {
+		orphanGCFailuresTotal.Inc()
+		slog.Error("Orphan file GC: failed to delete orphan thumbnail",
+			"event", "orphan_gc.thumbnail", "action", "failed",
+			"blob_key", key, "tenant_id", tenantID, "error", err.Error())
+		return false
+	}
+	return true
+}
+
+// parseThumbnailBlobKey parses a listed key as
+// `t/<tenant>/thumbnails/<fileID>_<size>.jpg` and applies the ROUND-TRIP GUARD:
+// the parsed components are fed back through blobkeys.BuildThumbnailBlobKey and
+// the result must byte-equal the listed key. Any key that does not round-trip
+// (a nested path, a bad size, a non-.jpg extension, a crafted traversal) is
+// rejected, and the caller KEEPS it.
+func parseThumbnailBlobKey(tenantID, key string) (fileID, size string, ok bool) {
+	prefix := blobkeys.TenantPrefix(tenantID) + blobkeys.ThumbnailsSegment + "/"
+	rest, found := strings.CutPrefix(key, prefix)
+	if !found || rest == "" {
+		return "", "", false
+	}
+	if strings.ContainsRune(rest, '/') {
+		return "", "", false // no nesting under thumbnails/
+	}
+	base, found := strings.CutSuffix(rest, ".jpg")
+	if !found {
+		return "", "", false // all thumbnails are JPEG
+	}
+	idx := strings.LastIndex(base, "_")
+	if idx <= 0 || idx == len(base)-1 {
+		return "", "", false
+	}
+	fileID, size = base[:idx], base[idx+1:]
+	if !orphanGCThumbnailSizes[size] {
+		return "", "", false
+	}
+	if blobkeys.BuildThumbnailBlobKey(tenantID, fileID, size) != key {
+		return "", "", false // round-trip guard
+	}
+	return fileID, size, true
+}
+
+func logOrphanThumbnail(level slog.Level, mode OrphanFileGCMode, action, tenantID, fileID, size string, cand orphanThumbKey) {
+	slog.Log(context.Background(), level, "Orphan file GC: orphan thumbnail blob",
+		"event", "orphan_gc.thumbnail",
+		"mode", string(mode),
+		"action", action,
+		"blob_key", cand.key,
+		"tenant_id", tenantID,
+		"file_id", fileID,
+		"size", size,
+		"mod_time", cand.modTime,
+		"age_hours", time.Since(cand.modTime).Hours(),
+	)
+}

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -522,6 +522,20 @@ func (w *OrphanFileGCWorker) Stop() {
 }
 
 func (w *OrphanFileGCWorker) runCleanup(ctx context.Context) {
+	// Sweep once at startup rather than waiting a full interval, matching
+	// LoginEventRetentionWorker and the reminder workers. With the 24h default
+	// the alternative is a day of silence after every deploy — and in the
+	// shipping REPORT mode that silence IS the feature not working: the whole
+	// point of report mode is to give the operator candidate counts to look at
+	// before they ever arm the delete.
+	//
+	// Safe on this worker specifically because a restart bypasses NOTHING: the
+	// soft-pause (#1308) is DB-backed and re-read inside RunOnce, so a paused
+	// worker still does nothing on boot; the in-flight gate is DB-backed too, so
+	// a tenant mid-restore stays blocked across the restart; and the age gate is
+	// wall-clock, so nothing becomes eligible merely because the process is new.
+	w.RunOnce(ctx)
+
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -852,6 +852,12 @@ func (w *OrphanFileGCWorker) sweepRowCandidate(
 	if err != nil {
 		// A non-ErrNotFound probe failure must never read as "gone".
 		orphanGCSkippedTotal.WithLabelValues(orphanGCSkipProbeError).Inc()
+		// NAME the row that aborted the tick. The cursor deliberately advances
+		// past it, so a permanently-failing row (a poison row, a flaky replica)
+		// stops a tick every time the scan comes back round to it — and without
+		// this record an operator would watch skipped{reason=probe_error} climb
+		// with nothing to grep for.
+		logOrphanRow(slog.LevelError, w.mode, "failed", orphanGCSkipProbeError, file, "error", err.Error())
 		return err
 	}
 	if !verdict.proceed {
@@ -1054,7 +1060,7 @@ func (w *OrphanFileGCWorker) deleteRow(ctx context.Context, file *models.FileEnt
 //	deleting  — about to be deleted; the pre-image, written while the row still exists
 //	deleted   — the delete RETURNED SUCCESS. Never emitted speculatively.
 //	failed    — the delete raised (deleteRow); the row is still there and is retried
-func logOrphanRow(level slog.Level, mode OrphanFileGCMode, action, reason string, file *models.FileEntity) {
+func logOrphanRow(level slog.Level, mode OrphanFileGCMode, action, reason string, file *models.FileEntity, extra ...any) {
 	attrs := []any{
 		"event", "orphan_gc.row",
 		"mode", string(mode),
@@ -1082,6 +1088,7 @@ func logOrphanRow(level slog.Level, mode OrphanFileGCMode, action, reason string
 			"size_bytes", file.SizeBytes,
 		)
 	}
+	attrs = append(attrs, extra...)
 	slog.Log(context.Background(), level, "Orphan file GC: orphan file row", attrs...)
 }
 
@@ -1255,6 +1262,14 @@ func (w *OrphanFileGCWorker) sweepTenantThumbnails(
 			// The one and only path to a delete.
 		default:
 			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipProbeError).Inc()
+			// NAME the key that aborted the tick, for the same reason the row
+			// path does: the cursor moves past it, so a permanently-failing
+			// probe stops a tick each time the cycle returns to it, and the
+			// metric alone gives an operator nothing to grep for.
+			slog.Error("Orphan file GC: thumbnail row probe failed; aborting tick",
+				"event", "orphan_gc.thumbnail", "action", "failed",
+				"reason", orphanGCSkipProbeError, "blob_key", cand.key,
+				"file_id", fileID, "tenant_id", tenantID, "error", err.Error())
 			// Persist the position BEFORE aborting, for the same reason as the
 			// row cursor: a recurring failure on one key would otherwise make
 			// every tick re-list and re-probe the identical head of this

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -238,7 +238,7 @@ func (p OrphanFileGCProbes) forLinkType(linkType string) EntityExistenceProbe {
 // the GC reads. Read-only: the worker adds no new write path anywhere.
 type OrphanFileGCFileRegistry interface {
 	ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error)
-	ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error)
+	ExistingIDs(ctx context.Context, ids []string) ([]string, error)
 	CountByOriginalPath(ctx context.Context, originalPath string) (int, error)
 	Get(ctx context.Context, id string) (*models.FileEntity, error)
 }
@@ -471,11 +471,38 @@ func NewOrphanFileGCWorker(deps OrphanFileGCDeps, opts ...OrphanFileGCOption) *O
 	}
 }
 
-// Start launches the background sweep goroutine. No-op when the file registry
-// or the deleter is missing.
+// missingDeps names every dependency RunOnce dereferences unconditionally.
+// Checking only Files/Deleter would let a half-wired worker report a successful
+// startup and then panic inside the sweep goroutine — on a DESTRUCTIVE worker,
+// a nil Exports/Restores registry is not a crash to debug later, it is the
+// concurrency gate silently missing.
+func (d OrphanFileGCDeps) missingDeps() []string {
+	var missing []string
+	add := func(name string, ok bool) {
+		if !ok {
+			missing = append(missing, name)
+		}
+	}
+	add("Files", d.Files != nil)
+	add("Deleter", d.Deleter != nil)
+	add("Exports", d.Exports != nil)
+	add("Restores", d.Restores != nil)
+	add("Tenants", d.Tenants != nil)
+	add("Groups", d.Groups != nil)
+	add("Users", d.Users != nil)
+	add("UploadLocation", d.UploadLocation != "")
+	// A link type with no probe is not fatal — verifyRowCandidate keeps every
+	// candidate of that type (fail closed) — so probes are deliberately NOT
+	// required here. A worker with no probes at all simply collects nothing.
+	return missing
+}
+
+// Start launches the background sweep goroutine. Incomplete wiring is refused
+// outright rather than deferred to a panic mid-sweep.
 func (w *OrphanFileGCWorker) Start(ctx context.Context) {
-	if w.deps.Files == nil || w.deps.Deleter == nil {
-		slog.Warn("OrphanFileGCWorker: incomplete dependencies, skipping startup")
+	if missing := w.deps.missingDeps(); len(missing) > 0 {
+		slog.Error("OrphanFileGCWorker: incomplete dependencies, skipping startup",
+			"missing", strings.Join(missing, ","))
 		return
 	}
 	w.wg.Go(func() {
@@ -939,7 +966,7 @@ func (w *OrphanFileGCWorker) verifyRowCandidate(ctx context.Context, file *model
 // tenant). Returns the skip reason, or "" when the candidate survives them all.
 //
 // R1 is re-asserted here even though the candidate query already applied it, so
-// a future registry bug cannot widen the blast radius: ” (standalone, #2235),
+// a future registry bug cannot widen the blast radius: "" (standalone, #2235),
 // 'export', and any unknown/future link type are KEPT.
 func screenRowCandidate(file *models.FileEntity, gate orphanGCGate, cutoff time.Time) string {
 	if !orphanGCLinkAllowlist[file.LinkedEntityType] {
@@ -1177,29 +1204,42 @@ func (w *OrphanFileGCWorker) sweepTenantThumbnails(
 		return stats, nil
 	}
 
-	// Step 3 — only NOW read the DB. A row created during the listing is in the
-	// set, which is the safe direction.
-	ids, err := w.deps.Files.ListIDsByTenant(ctx, tenantID)
-	if err != nil {
-		return stats, err
-	}
-	live := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		live[id] = true
-	}
-
+	// T1/T2 — parse every aged key BEFORE any DB read. Anything that does not
+	// parse-and-round-trip exactly is KEPT: this is the structural
+	// anti-traversal / anti-confusion guard — we only ever delete a key we
+	// REBUILT ourselves.
+	parsed := make([]orphanThumbCandidate, 0, len(aged))
 	for _, cand := range aged {
 		fileID, size, ok := parseThumbnailBlobKey(tenantID, cand.key)
 		if !ok {
-			// T1/T2 — anything that does not parse-and-round-trip exactly is
-			// KEPT. This is the structural anti-traversal / anti-confusion
-			// guard: we only ever delete a key we REBUILT ourselves.
 			orphanGCSkippedTotal.WithLabelValues(orphanGCSkipUnparseableKey).Inc()
 			slog.Warn("Orphan file GC: unparseable thumbnail key, keeping",
 				"event", "orphan_gc.thumbnail", "action", "skipped",
 				"reason", orphanGCSkipUnparseableKey, "blob_key", cand.key, "tenant_id", tenantID)
 			continue
 		}
+		parsed = append(parsed, orphanThumbCandidate{key: cand, fileID: fileID, size: size})
+	}
+	if len(parsed) == 0 {
+		return stats, nil
+	}
+
+	// Step 3 — only NOW read the DB, and ask ONLY about the ids the listed keys
+	// actually named. A tenant-wide id dump would cost, and hold in memory, one
+	// entry per file row in the tenant to answer a question about at most
+	// thumbBudget keys — the dominant cost of the sweep on a large install, for
+	// no added safety.
+	//
+	// A row created DURING the listing lands in this set (the query runs after),
+	// which is the safe direction: the sweep keeps its thumbnails.
+	live, err := w.liveFileIDs(ctx, parsed)
+	if err != nil {
+		return stats, err
+	}
+
+	for _, p := range parsed {
+		cand, fileID, size := p.key, p.fileID, p.size
+
 		// T3 — the double check. The membership set alone can never cause a
 		// delete: a fresh service-mode Get must independently return EXACTLY
 		// registry.ErrNotFound.
@@ -1328,6 +1368,41 @@ func (w *OrphanFileGCWorker) listAgedThumbnails(
 	delete(w.thumbCursor, tenantID)
 
 	return aged, nil
+}
+
+// orphanThumbCandidate is one listed thumbnail key that survived the age filter
+// AND the round-trip parse: the key itself plus the components it decomposed
+// into. Parsing up front is what lets the DB question be asked about exactly the
+// file ids the keys named, and nothing else.
+type orphanThumbCandidate struct {
+	key    orphanThumbKey
+	fileID string
+	size   string
+}
+
+// liveFileIDs asks, in ONE round-trip, which of the file ids named by the parsed
+// keys still have a row. Duplicate ids (a file has a small AND a medium
+// thumbnail) collapse before the query.
+func (w *OrphanFileGCWorker) liveFileIDs(ctx context.Context, parsed []orphanThumbCandidate) (map[string]bool, error) {
+	seen := make(map[string]bool, len(parsed))
+	ids := make([]string, 0, len(parsed))
+	for _, p := range parsed {
+		if seen[p.fileID] {
+			continue
+		}
+		seen[p.fileID] = true
+		ids = append(ids, p.fileID)
+	}
+
+	existing, err := w.deps.Files.ExistingIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	live := make(map[string]bool, len(existing))
+	for _, id := range existing {
+		live[id] = true
+	}
+	return live, nil
 }
 
 // deleteThumbnail removes the REBUILT key — never the raw string the bucket

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -844,6 +844,52 @@ func TestOrphanFileGC_LosingAThumbnailRaceIsNotAFailure(t *testing.T) {
 		qt.Commentf("losing the race to another replica was reported as a delete failure"))
 }
 
+// The worker sweeps ONCE AT STARTUP instead of waiting a full interval. With the
+// 24h default the alternative is a day of silence after every deploy — and in
+// the shipping report mode that silence is the feature not working, since the
+// candidate counts are the entire point.
+//
+// The second half of the test is the one that matters: a restart must bypass
+// NOTHING. The soft-pause is DB-backed and re-read inside RunOnce, so a paused
+// worker still does nothing on boot.
+func TestOrphanFileGC_SweepsOnceAtStartup(t *testing.T) {
+	t.Run("an unpaused worker sweeps immediately", func(t *testing.T) {
+		c := qt.New(t)
+		f := newGCFixture(c)
+
+		file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+		worker := services.NewOrphanFileGCWorker(f.deps(),
+			services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+			services.WithOrphanFileGCInterval(time.Hour), // the ticker must never fire
+		)
+		worker.Start(f.ctx)
+		worker.Stop() // waits for the startup sweep to finish
+
+		c.Assert(f.fileExists(file.ID), qt.IsFalse,
+			qt.Commentf("the worker waited for the first tick instead of sweeping at startup"))
+	})
+
+	t.Run("a paused worker still does nothing", func(t *testing.T) {
+		c := qt.New(t)
+		f := newGCFixture(c)
+
+		file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+		pause := &stubPause{paused: map[models.WorkerType]bool{models.WorkerTypeOrphanFileGC: true}}
+		worker := services.NewOrphanFileGCWorker(f.deps(),
+			services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+			services.WithOrphanFileGCInterval(time.Hour),
+			services.WithOrphanFileGCPauseController(pause),
+		)
+		worker.Start(f.ctx)
+		worker.Stop()
+
+		c.Assert(f.fileExists(file.ID), qt.IsTrue,
+			qt.Commentf("the startup sweep bypassed the soft-pause emergency stop"))
+	})
+}
+
 // A half-wired DESTRUCTIVE worker must refuse to start, not log a successful
 // startup and then panic inside the sweep goroutine. A nil Exports/Restores
 // registry is not a crash to debug later — it is the concurrency gate silently

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -844,6 +844,35 @@ func TestOrphanFileGC_LosingAThumbnailRaceIsNotAFailure(t *testing.T) {
 		qt.Commentf("losing the race to another replica was reported as a delete failure"))
 }
 
+// A nil probe for an ALLOWLISTED link type is a MISWIRING, not a policy
+// decision, and the two must not share a skip reason.
+//
+// Both outcomes keep the file, which is exactly why the labels have to differ:
+// a worker wired without its commodity probe reports zero candidates forever,
+// and under `disallowed_link_type` that reads as the intended handling of an
+// unknown link type rather than the bug it is. The operator watching report mode
+// during the rollout would conclude "no orphans in this install" from a worker
+// that is structurally incapable of finding any.
+func TestOrphanFileGC_MissingProbeIsNotDisallowedLink(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	deps := f.deps()
+	deps.Probes.Commodity = nil // the miswiring
+
+	worker := services.NewOrphanFileGCWorker(deps,
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete))
+
+	logs := captureLogs(c, func() { worker.RunOnce(f.ctx) })
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("an unprobeable file must be KEPT"))
+	c.Assert(logs, qt.Contains, `"reason":"missing_probe"`)
+	c.Assert(logs, qt.Not(qt.Contains), `"reason":"disallowed_link_type"`,
+		qt.Commentf("a miswired worker must not masquerade as a policy skip"))
+}
+
 // The worker sweeps ONCE AT STARTUP instead of waiting a full interval. With the
 // 24h default the alternative is a day of silence after every deploy — and in
 // the shipping report mode that silence is the feature not working, since the

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -359,9 +359,9 @@ func (r *countingFileRegistry) ListOrphanCandidates(ctx context.Context, olderTh
 	return r.FileRegistry.ListOrphanCandidates(ctx, olderThan, after, limit)
 }
 
-func (r *countingFileRegistry) ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error) {
+func (r *countingFileRegistry) ExistingIDs(ctx context.Context, ids []string) ([]string, error) {
 	r.calls++
-	return r.FileRegistry.ListIDsByTenant(ctx, tenantID)
+	return r.FileRegistry.ExistingIDs(ctx, ids)
 }
 
 // failingGetFileRegistry makes the thumbnail sweep's row probe fail
@@ -835,6 +835,55 @@ func TestOrphanFileGC_LosingAThumbnailRaceIsNotAFailure(t *testing.T) {
 	c.Assert(f.blobExists(key), qt.IsFalse)
 	c.Assert(logs, qt.Not(qt.Contains), `"action":"failed"`,
 		qt.Commentf("losing the race to another replica was reported as a delete failure"))
+}
+
+// A half-wired DESTRUCTIVE worker must refuse to start, not log a successful
+// startup and then panic inside the sweep goroutine. A nil Exports/Restores
+// registry is not a crash to debug later — it is the concurrency gate silently
+// missing, i.e. the guard that keeps the GC off a tenant mid-restore.
+func TestOrphanFileGC_IncompleteWiringRefusesToStart(t *testing.T) {
+	tests := []struct {
+		name    string
+		unwire  func(*services.OrphanFileGCDeps)
+		missing string
+	}{
+		{name: "no files registry", unwire: func(d *services.OrphanFileGCDeps) { d.Files = nil }, missing: "Files"},
+		{name: "no deleter", unwire: func(d *services.OrphanFileGCDeps) { d.Deleter = nil }, missing: "Deleter"},
+		{name: "no exports registry", unwire: func(d *services.OrphanFileGCDeps) { d.Exports = nil }, missing: "Exports"},
+		{name: "no restores registry", unwire: func(d *services.OrphanFileGCDeps) { d.Restores = nil }, missing: "Restores"},
+		{name: "no tenants registry", unwire: func(d *services.OrphanFileGCDeps) { d.Tenants = nil }, missing: "Tenants"},
+		{name: "no groups registry", unwire: func(d *services.OrphanFileGCDeps) { d.Groups = nil }, missing: "Groups"},
+		{name: "no users registry", unwire: func(d *services.OrphanFileGCDeps) { d.Users = nil }, missing: "Users"},
+		{name: "no upload location", unwire: func(d *services.OrphanFileGCDeps) { d.UploadLocation = "" }, missing: "UploadLocation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			// An orphan the worker WOULD collect if it ran.
+			file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+			deps := f.deps()
+			tt.unwire(&deps)
+
+			logs := captureLogs(c, func() {
+				worker := services.NewOrphanFileGCWorker(deps,
+					services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+					services.WithOrphanFileGCInterval(time.Millisecond),
+				)
+				worker.Start(f.ctx)
+				worker.Stop() // returns immediately: nothing was started
+			})
+
+			c.Assert(logs, qt.Contains, "incomplete dependencies")
+			c.Assert(logs, qt.Contains, tt.missing)
+			c.Assert(logs, qt.Not(qt.Contains), "Orphan file GC worker started")
+			c.Assert(f.fileExists(file.ID), qt.IsTrue,
+				qt.Commentf("a half-wired worker swept anyway"))
+		})
+	}
 }
 
 // Soft-pause (#1308) is the operator's emergency stop for the only destructive

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -784,6 +784,59 @@ func TestOrphanFileGC_ThumbnailLogNeverClaimsAnUnattemptedDelete(t *testing.T) {
 	c.Assert(logs, qt.Contains, `"action":"deleted"`)
 }
 
+// racingThumbnailRegistry deletes a blob from underneath the sweep, right when
+// the sweep probes the owning row — i.e. exactly the window a SECOND `run
+// workers` replica occupies: it listed the same orphan thumbnail and got to the
+// delete first.
+type racingThumbnailRegistry struct {
+	services.OrphanFileGCFileRegistry
+	c              *qt.C
+	ctx            context.Context
+	uploadLocation string
+	key            string
+}
+
+func (r *racingThumbnailRegistry) Get(ctx context.Context, id string) (*models.FileEntity, error) {
+	b, err := blob.OpenBucket(r.ctx, r.uploadLocation)
+	r.c.Assert(err, qt.IsNil)
+	defer b.Close()
+	_ = b.Delete(r.ctx, r.key) // the other replica wins the race
+	return r.OrphanFileGCFileRegistry.Get(ctx, id)
+}
+
+// Two replicas racing the same orphan thumbnail must produce one delete and one
+// NO-OP — not one delete and one reported FAILURE. Counting the loser's
+// already-gone key as a failure would light up orphanGCFailuresTotal and write
+// an error record on every tick of a perfectly healthy two-replica deployment,
+// which is exactly the noise that hides a real failure.
+func TestOrphanFileGC_LosingAThumbnailRaceIsNotAFailure(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildThumbnailBlobKey(f.tenantID, "a-file-id-with-no-row", "small")
+	f.writeBlob(key, []byte("s"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	deps := f.deps()
+	deps.Files = &racingThumbnailRegistry{
+		OrphanFileGCFileRegistry: deps.Files,
+		c:                        c,
+		ctx:                      f.ctx,
+		uploadLocation:           f.uploadLocation,
+		key:                      key,
+	}
+
+	logs := captureLogs(c, func() {
+		services.NewOrphanFileGCWorker(deps,
+			services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		).RunOnce(f.ctx)
+	})
+
+	c.Assert(f.blobExists(key), qt.IsFalse)
+	c.Assert(logs, qt.Not(qt.Contains), `"action":"failed"`,
+		qt.Commentf("losing the race to another replica was reported as a delete failure"))
+}
+
 // Soft-pause (#1308) is the operator's emergency stop for the only destructive
 // worker in the tree. A paused worker must do NOTHING — not even read.
 //

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -710,10 +710,17 @@ func TestOrphanFileGC_ProbeErrorAbortsTheTick(t *testing.T) {
 	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
 	f.probeErr = context.DeadlineExceeded // NOT registry.ErrNotFound
 
-	f.sweep()
+	logs := captureLogs(c, func() { f.sweep() })
 
 	c.Assert(f.fileExists(file.ID), qt.IsTrue,
 		qt.Commentf("a transient probe failure was treated as 'the entity is gone'"))
+
+	// The tick aborts AND the cursor moves past this row, so a permanently
+	// failing row stops a tick every cycle. The log must name it — a rising
+	// skipped{reason=probe_error} with nothing to grep for is not diagnosable.
+	c.Assert(logs, qt.Contains, `"reason":"probe_error"`)
+	c.Assert(logs, qt.Contains, file.ID,
+		qt.Commentf("the row that aborted the tick was not named in the logs"))
 }
 
 // The row scan must keep its place across an ABORTED tick. A probe failure that
@@ -1537,12 +1544,20 @@ func TestOrphanFileGC_ThumbnailProbeErrorNeverReadsAsGone(t *testing.T) {
 		err:          context.DeadlineExceeded, // NOT registry.ErrNotFound
 	}
 
-	services.NewOrphanFileGCWorker(deps,
-		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
-	).RunOnce(f.ctx)
+	logs := captureLogs(c, func() {
+		services.NewOrphanFileGCWorker(deps,
+			services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		).RunOnce(f.ctx)
+	})
 
 	c.Assert(f.blobExists(key), qt.IsTrue,
 		qt.Commentf("a transient probe failure was treated as 'the file row is gone'"))
+
+	// As on the row path: the tick aborts and the cursor moves past this key, so
+	// the key that keeps failing must be named or it cannot be found.
+	c.Assert(logs, qt.Contains, `"reason":"probe_error"`)
+	c.Assert(logs, qt.Contains, key,
+		qt.Commentf("the thumbnail key that aborted the tick was not named in the logs"))
 }
 
 // ---------------------------------------------------------------------------

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -716,6 +716,74 @@ func TestOrphanFileGC_ProbeErrorAbortsTheTick(t *testing.T) {
 		qt.Commentf("a transient probe failure was treated as 'the entity is gone'"))
 }
 
+// The row scan must keep its place across an ABORTED tick. A probe failure that
+// recurs on the same row (a poison row, a permanently unhealthy replica) would
+// otherwise replay the identical oldest-first page every tick, forever, and no
+// orphan behind it would ever be enumerated — the worker would look alive while
+// collecting nothing.
+func TestOrphanFileGC_AbortedTickDoesNotReplayTheSamePage(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	// Two orphans, oldest first. The probe blows up, so tick 1 aborts on the
+	// first one.
+	first := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone-1", linkMeta: "images"})
+	second := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone-2", linkMeta: "images"})
+
+	// EXACTLY one row per tick. Without that the assertion is vacuous: a tick
+	// that restarts from the top would simply page through both orphans and the
+	// regression would hide.
+	deps := f.deps()
+	worker := services.NewOrphanFileGCWorker(deps,
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		services.WithOrphanFileGCRowBudget(1, 1),
+	)
+
+	f.probeErr = context.DeadlineExceeded
+	worker.RunOnce(f.ctx) // aborts on the first candidate
+
+	// The failure clears. The next tick must resume AFTER the row it choked on,
+	// not re-serve it — so its one unit of budget reaches the SECOND orphan.
+	f.probeErr = nil
+	worker.RunOnce(f.ctx)
+
+	c.Assert(f.fileExists(second.ID), qt.IsFalse,
+		qt.Commentf("the scan replayed the failed page instead of making progress"))
+	c.Assert(f.fileExists(first.ID), qt.IsTrue,
+		qt.Commentf("the row the probe choked on must be KEPT, not deleted, and revisited when the scan wraps"))
+}
+
+// The forensic log is the ONLY artifact from which a destroyed thumbnail can be
+// reconstructed, so it must never claim a destruction that did not happen. The
+// row path splits "deleting" (pre-image) from "deleted" (post-success); the
+// thumbnail path must do the same, including when the tenant gate fires between
+// the two.
+func TestOrphanFileGC_ThumbnailLogNeverClaimsAnUnattemptedDelete(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildThumbnailBlobKey(f.tenantID, "a-file-id-with-no-row", "small")
+	f.writeBlob(key, []byte("s"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	// report mode: the candidate is found, and NOTHING is deleted.
+	logs := captureLogs(c, func() {
+		f.sweep(services.WithOrphanFileGCMode(services.OrphanFileGCModeReport))
+	})
+
+	c.Assert(f.blobExists(key), qt.IsTrue, qt.Commentf("report mode deleted a blob"))
+	c.Assert(logs, qt.Contains, `"action":"candidate"`)
+	c.Assert(logs, qt.Not(qt.Contains), `"action":"deleted"`,
+		qt.Commentf("the log claimed a thumbnail was deleted while in report mode"))
+
+	// delete mode: "deleting" precedes the attempt, "deleted" follows its success.
+	logs = captureLogs(c, func() { f.sweep() })
+
+	c.Assert(f.blobExists(key), qt.IsFalse)
+	c.Assert(logs, qt.Contains, `"action":"deleting"`)
+	c.Assert(logs, qt.Contains, `"action":"deleted"`)
+}
+
 // Soft-pause (#1308) is the operator's emergency stop for the only destructive
 // worker in the tree. A paused worker must do NOTHING — not even read.
 //

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -1,0 +1,1574 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register the file:// driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// The orphan-file GC (#2237) DELETES USER DATA. The bar is not "does it delete
+// orphans" — it is "can it ever delete something that is NOT an orphan". The
+// NEGATIVE tests below (everything that must SURVIVE a sweep) are therefore the
+// point of the feature and come first; the positive tests merely confirm the
+// worker is not inert.
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const (
+	gcTenantA = "tenant-a"
+	gcTenantB = "tenant-b"
+)
+
+// gcFixture is a memory-backed installation with one active tenant, one active
+// group and one user, plus a file:// bucket on a temp dir.
+type gcFixture struct {
+	c              *qt.C
+	fs             *registry.FactorySet
+	ctx            context.Context
+	tempDir        string
+	uploadLocation string
+
+	tenantID string
+	groupID  string
+	userID   string
+
+	// probeCalls counts existence probes per link type so a test can assert
+	// that, e.g., an export-linked file never triggers a probe at all.
+	probeCalls map[string]int
+
+	// probeErr, when set, is returned by every probe INSTEAD of the real
+	// answer — used to prove a transient failure never reads as "gone".
+	probeErr error
+}
+
+func newGCFixture(c *qt.C) *gcFixture {
+	c.Helper()
+
+	tempDir := c.TempDir()
+	uploadLocation := "file://" + tempDir + "?create_dir=1"
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	}
+
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	f := &gcFixture{
+		c:              c,
+		fs:             factorySet,
+		ctx:            ctx,
+		tempDir:        tempDir,
+		uploadLocation: uploadLocation,
+		probeCalls:     make(map[string]int),
+	}
+
+	f.tenantID = f.newTenant(gcTenantA, models.TenantStatusActive)
+	f.groupID = f.newGroup(f.tenantID, "group-a", models.LocationGroupStatusActive)
+	f.userID = f.newUser(f.tenantID, "owner@example.com")
+
+	return f
+}
+
+func (f *gcFixture) newTenant(slug string, status models.TenantStatus) string {
+	f.c.Helper()
+	t, err := f.fs.TenantRegistry.Create(f.ctx, models.Tenant{
+		Name:   "Tenant " + slug,
+		Slug:   slug,
+		Status: status,
+	})
+	f.c.Assert(err, qt.IsNil)
+	return t.ID
+}
+
+func (f *gcFixture) newGroup(tenantID, slug string, status models.LocationGroupStatus) string {
+	f.c.Helper()
+	g, err := f.fs.LocationGroupRegistry.Create(f.ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Slug:                slug + "-000000000000000000",
+		Name:                "Group " + slug,
+		Status:              status,
+		CreatedBy:           "seed",
+		GroupCurrency:       "USD",
+	})
+	f.c.Assert(err, qt.IsNil)
+	return g.ID
+}
+
+func (f *gcFixture) newUser(tenantID, email string) string {
+	f.c.Helper()
+	u, err := f.fs.UserRegistry.Create(f.ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               email,
+		Name:                "Owner",
+		IsActive:            true,
+	})
+	f.c.Assert(err, qt.IsNil)
+	return u.ID
+}
+
+// seedFileOpts describes one file row to plant.
+type seedFileOpts struct {
+	tenantID   string
+	groupID    string
+	userID     string
+	linkType   string
+	linkID     string
+	linkMeta   string
+	createdAgo time.Duration
+	updatedAgo time.Duration
+	blobKey    string // when set, a blob is written at this key and OriginalPath points at it
+	mimeType   string
+}
+
+// seedFile creates a file row through the SERVICE registry so the test controls
+// tenant/group/creator/timestamps exactly (the memory service registry does not
+// override them the way a user registry would).
+func (f *gcFixture) seedFile(o seedFileOpts) *models.FileEntity {
+	f.c.Helper()
+
+	if o.tenantID == "" {
+		o.tenantID = f.tenantID
+	}
+	if o.groupID == "" {
+		o.groupID = f.groupID
+	}
+	if o.userID == "" {
+		o.userID = f.userID
+	}
+	if o.createdAgo == 0 {
+		o.createdAgo = 30 * 24 * time.Hour
+	}
+	if o.updatedAgo == 0 {
+		o.updatedAgo = o.createdAgo
+	}
+	if o.mimeType == "" {
+		o.mimeType = "image/jpeg"
+	}
+
+	now := time.Now()
+	file := models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        o.tenantID,
+			GroupID:         o.groupID,
+			CreatedByUserID: o.userID,
+		},
+		Title:            "seeded",
+		Type:             models.FileTypeImage,
+		LinkedEntityType: o.linkType,
+		LinkedEntityID:   o.linkID,
+		LinkedEntityMeta: o.linkMeta,
+		CreatedAt:        now.Add(-o.createdAgo),
+		UpdatedAt:        now.Add(-o.updatedAgo),
+		File: &models.File{
+			Path:         "seeded",
+			OriginalPath: o.blobKey,
+			Ext:          ".jpg",
+			MIMEType:     o.mimeType,
+		},
+	}
+
+	created, err := f.fs.FileRegistryFactory.CreateServiceRegistry().Create(f.ctx, file)
+	f.c.Assert(err, qt.IsNil)
+
+	if o.blobKey != "" {
+		f.writeBlob(o.blobKey, []byte("payload"))
+	}
+	return created
+}
+
+// userCtx builds the (user, group) request context the entity registries need.
+// Note the WORKER never gets this context — it is handed a bare background
+// context and has to resolve the owner itself from the candidate row.
+func (f *gcFixture) userCtx(userID, groupID string) context.Context {
+	f.c.Helper()
+	u, err := f.fs.UserRegistry.Get(f.ctx, userID)
+	f.c.Assert(err, qt.IsNil)
+	g, err := f.fs.LocationGroupRegistry.Get(f.ctx, groupID)
+	f.c.Assert(err, qt.IsNil)
+	return appctx.WithGroup(appctx.WithUser(f.ctx, u), g)
+}
+
+// seedLiveCommodity creates a real location → area → commodity chain in the
+// given group and returns the three ids.
+func (f *gcFixture) seedLiveCommodity(groupID, userID string) (locationID, areaID, commodityID string) {
+	f.c.Helper()
+	ctx := f.userCtx(userID, groupID)
+
+	loc, err := f.fs.LocationRegistryFactory.MustCreateUserRegistry(ctx).Create(ctx, models.Location{
+		Name: "Live Location",
+	})
+	f.c.Assert(err, qt.IsNil)
+
+	area, err := f.fs.AreaRegistryFactory.MustCreateUserRegistry(ctx).Create(ctx, models.Area{
+		Name:       "Live Area",
+		LocationID: loc.ID,
+	})
+	f.c.Assert(err, qt.IsNil)
+
+	com, err := f.fs.CommodityRegistryFactory.MustCreateUserRegistry(ctx).Create(ctx, models.Commodity{
+		Name:   "Live Commodity",
+		AreaID: new(area.ID),
+	})
+	f.c.Assert(err, qt.IsNil)
+
+	return loc.ID, area.ID, com.ID
+}
+
+func (f *gcFixture) writeBlob(key string, data []byte) {
+	f.c.Helper()
+	b, err := blob.OpenBucket(f.ctx, f.uploadLocation)
+	f.c.Assert(err, qt.IsNil)
+	defer b.Close()
+	f.c.Assert(b.WriteAll(f.ctx, key, data, nil), qt.IsNil)
+}
+
+func (f *gcFixture) blobExists(key string) bool {
+	f.c.Helper()
+	b, err := blob.OpenBucket(f.ctx, f.uploadLocation)
+	f.c.Assert(err, qt.IsNil)
+	defer b.Close()
+	exists, err := b.Exists(f.ctx, key)
+	f.c.Assert(err, qt.IsNil)
+	return exists
+}
+
+// backdateBlobs rewinds the mtime of every file currently in the bucket's
+// backing directory. The blob age gate reads the bucket's ModTime (which no
+// application code can set), so this is the only way to simulate an aged blob.
+//
+// Walks through an os.Root so the traversal is confined to the temp dir and
+// cannot follow a symlink out of it.
+func (f *gcFixture) backdateBlobs(age time.Duration) {
+	f.c.Helper()
+	when := time.Now().Add(-age)
+
+	root, err := os.OpenRoot(f.tempDir)
+	f.c.Assert(err, qt.IsNil)
+	defer root.Close()
+
+	err = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		return root.Chtimes(path, when, when)
+	})
+	f.c.Assert(err, qt.IsNil)
+}
+
+func (f *gcFixture) fileExists(id string) bool {
+	f.c.Helper()
+	_, err := f.fs.FileRegistryFactory.CreateServiceRegistry().Get(f.ctx, id)
+	return err == nil
+}
+
+// countingProbe wraps a real existence probe with a call counter and an
+// optional forced error.
+func (f *gcFixture) countingProbe(linkType string, inner services.EntityExistenceProbe) services.EntityExistenceProbe {
+	return func(ctx context.Context, id string) error {
+		f.probeCalls[linkType]++
+		if f.probeErr != nil {
+			return f.probeErr
+		}
+		return inner(ctx, id)
+	}
+}
+
+func (f *gcFixture) deps() services.OrphanFileGCDeps {
+	comReg := f.fs.CommodityRegistryFactory.CreateServiceRegistry()
+	areaReg := f.fs.AreaRegistryFactory.CreateServiceRegistry()
+	locReg := f.fs.LocationRegistryFactory.CreateServiceRegistry()
+
+	return services.OrphanFileGCDeps{
+		Files: f.fs.FileRegistryFactory.CreateServiceRegistry(),
+		Probes: services.OrphanFileGCProbes{
+			Commodity: f.countingProbe("commodity", func(ctx context.Context, id string) error {
+				_, err := comReg.Get(ctx, id)
+				return err
+			}),
+			Area: f.countingProbe("area", func(ctx context.Context, id string) error {
+				_, err := areaReg.Get(ctx, id)
+				return err
+			}),
+			Location: f.countingProbe("location", func(ctx context.Context, id string) error {
+				_, err := locReg.Get(ctx, id)
+				return err
+			}),
+		},
+		Exports:        f.fs.ExportRegistryFactory.CreateServiceRegistry(),
+		Restores:       f.fs.RestoreOperationRegistryFactory.CreateServiceRegistry(),
+		Tenants:        f.fs.TenantRegistry,
+		Groups:         f.fs.LocationGroupRegistry,
+		Users:          f.fs.UserRegistry,
+		Deleter:        services.NewFileService(f.fs, f.uploadLocation),
+		UploadLocation: f.uploadLocation,
+	}
+}
+
+// sweep runs one tick in DELETE mode (the dangerous mode — every negative test
+// must survive it).
+func (f *gcFixture) sweep(opts ...services.OrphanFileGCOption) {
+	f.c.Helper()
+	opts = append([]services.OrphanFileGCOption{
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+	}, opts...)
+	services.NewOrphanFileGCWorker(f.deps(), opts...).RunOnce(f.ctx)
+}
+
+// stubPause is a PauseChecker that reports a fixed pause state.
+type stubPause struct {
+	paused map[models.WorkerType]bool
+	calls  int
+}
+
+func (s *stubPause) IsPaused(wt models.WorkerType) bool {
+	s.calls++
+	return s.paused[wt]
+}
+
+// countingFileRegistry records every read so a test can prove the paused worker
+// touched nothing at all.
+type countingFileRegistry struct {
+	registry.FileRegistry
+	calls int
+}
+
+func (r *countingFileRegistry) ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error) {
+	r.calls++
+	return r.FileRegistry.ListOrphanCandidates(ctx, olderThan, after, limit)
+}
+
+func (r *countingFileRegistry) ListIDsByTenant(ctx context.Context, tenantID string) ([]string, error) {
+	r.calls++
+	return r.FileRegistry.ListIDsByTenant(ctx, tenantID)
+}
+
+// failingGetFileRegistry makes the thumbnail sweep's row probe fail
+// TRANSIENTLY — a DB timeout, a connection reset. It must never read as "the
+// row is gone".
+type failingGetFileRegistry struct {
+	registry.FileRegistry
+	err error
+}
+
+func (r *failingGetFileRegistry) Get(ctx context.Context, id string) (*models.FileEntity, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.FileRegistry.Get(ctx, id)
+}
+
+// failingDeleter stands in for FileService when the delete itself raises (on
+// postgres: an FK the teardown could not break). Used to prove the forensic log
+// never claims a destruction that did not happen.
+type failingDeleter struct{ err error }
+
+func (d *failingDeleter) DeleteFileWithPhysical(context.Context, string) error { return d.err }
+
+// captureLogs swaps in a JSON slog handler for the duration of fn and returns
+// everything the worker logged. The forensic record is the ONLY artifact from
+// which a destroyed file can be reconstructed, so its content is a contract.
+func captureLogs(c *qt.C, fn func()) string {
+	c.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+// seedThumbnailJob plants a thumbnail-generation job for fileID OWNED BY
+// userID. The owner matters: RequestThumbnailGeneration deliberately stamps the
+// job with the REQUESTING user (so one member cannot spend another's rate
+// limit), and merely viewing a not-yet-generated thumbnail enqueues one — so in
+// any shared group the job's owner is routinely NOT the file's creator.
+func (f *gcFixture) seedThumbnailJob(fileID, userID, tenantID string) {
+	f.c.Helper()
+	_, err := f.fs.ThumbnailGenerationJobRegistryFactory.CreateServiceRegistry().Create(f.ctx, models.ThumbnailGenerationJob{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{TenantID: tenantID, UserID: userID},
+		FileID:                  fileID,
+		Status:                  models.ThumbnailStatusPending,
+		MaxAttempts:             3,
+	})
+	f.c.Assert(err, qt.IsNil)
+}
+
+// thumbnailJobCount counts the jobs still referencing fileID, RLS-free.
+func (f *gcFixture) thumbnailJobCount(fileID string) int {
+	f.c.Helper()
+	jobs, err := f.fs.ThumbnailGenerationJobRegistryFactory.CreateServiceRegistry().ListByFileID(f.ctx, fileID)
+	f.c.Assert(err, qt.IsNil)
+	return len(jobs)
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE — things that MUST survive a delete-mode sweep
+// ---------------------------------------------------------------------------
+
+// A STANDALONE file (linked_entity_type = "") is LEGITIMATE, not an orphan.
+// Since #2235 standalone files are first-class and are exported in backups.
+// "No link" must NEVER mean "orphan": an orphan is a file whose link points at
+// a NONEXISTENT entity. A predicate shaped `linked_entity_id IS NULL OR NOT
+// EXISTS(...)` would silently eat every standalone file in the installation —
+// this test is the guard against exactly that.
+func TestOrphanFileGC_StandaloneFileIsNeverSwept(t *testing.T) {
+	tests := []struct {
+		name     string
+		linkType string
+		linkID   string
+	}{
+		{"standalone: no link at all", "", ""},
+		{"standalone: empty type with a stray id (malformed, still not an orphan)", "", "some-dangling-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			file := f.seedFile(seedFileOpts{linkType: tt.linkType, linkID: tt.linkID})
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("#2235 standalone file was destroyed by the GC"))
+		})
+	}
+}
+
+// linked_entity_type='export' belongs to the backup subsystem's own lifecycle.
+// The GC must not sweep it AND must never probe the exports table for
+// existence: ExportRegistry.Get filters `deleted_at IS NULL`, so a Get-based
+// probe would read a soft-deleted (recoverable) export as nonexistent and
+// destroy the user's backup. Because 'export' is not in the allowlist, that
+// trap is structurally unreachable — asserted here by the zero probe count.
+func TestOrphanFileGC_ExportLinkedFileIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{
+		linkType: "export",
+		linkID:   "an-export-id-that-does-not-exist",
+		linkMeta: "inb-2.0",
+	})
+
+	f.sweep()
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("export-linked file was destroyed by the GC"))
+	c.Assert(f.probeCalls["commodity"]+f.probeCalls["area"]+f.probeCalls["location"], qt.Equals, 0,
+		qt.Commentf("an export-linked file must not trigger ANY existence probe"))
+}
+
+// The registries do NOT enforce models.FileEntity.ValidateWithContext, so the
+// DB is a superset of the validator's enumeration and a link type this release
+// has never heard of can appear. It must be KEPT — the allowlist fails closed.
+func TestOrphanFileGC_UnknownLinkTypeIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{linkType: "widget", linkID: "no-such-widget"})
+
+	f.sweep()
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("unknown link type must fail closed, not be swept"))
+}
+
+// THE catastrophic-bug guard. PUT /files/{id} copies linked_entity_type /
+// linked_entity_id straight from client input with NO existence, tenant, or
+// group check, so a file in group A legitimately linked to a commodity in
+// group B is reachable in production. If the existence probe were ever swapped
+// for a group-scoped (user) registry it would 404 on that LIVE commodity and
+// delete a LIVE file. This test fails loudly if anyone does that.
+func TestOrphanFileGC_CrossGroupLinkIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	otherGroupID := f.newGroup(f.tenantID, "group-b", models.LocationGroupStatusActive)
+	_, _, commodityID := f.seedLiveCommodity(otherGroupID, f.userID)
+
+	// The file lives in group A; its link points at a LIVE commodity in group B.
+	file := f.seedFile(seedFileOpts{
+		groupID:  f.groupID,
+		linkType: "commodity",
+		linkID:   commodityID,
+		linkMeta: "images",
+	})
+
+	f.sweep()
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue,
+		qt.Commentf("a file linked ACROSS GROUPS to a live commodity was destroyed — the probe is not service-mode/by-id"))
+}
+
+// Same shape across tenants: the service-mode probe matches by ID only, finds
+// the live entity, and the file is kept.
+func TestOrphanFileGC_CrossTenantLinkIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	otherTenantID := f.newTenant(gcTenantB, models.TenantStatusActive)
+	otherGroupID := f.newGroup(otherTenantID, "group-t2", models.LocationGroupStatusActive)
+	otherUserID := f.newUser(otherTenantID, "other@example.com")
+	_, _, commodityID := f.seedLiveCommodity(otherGroupID, otherUserID)
+
+	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: commodityID, linkMeta: "images"})
+
+	f.sweep()
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue,
+		qt.Commentf("a file linked ACROSS TENANTS to a live commodity was destroyed"))
+}
+
+// The happy path: a file whose linked entity is alive is never a candidate, for
+// all three allowlisted link types.
+func TestOrphanFileGC_LiveEntityFileIsNeverSwept(t *testing.T) {
+	tests := []string{"commodity", "area", "location"}
+
+	for _, linkType := range tests {
+		t.Run(linkType, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			locationID, areaID, commodityID := f.seedLiveCommodity(f.groupID, f.userID)
+			targets := map[string]string{
+				"commodity": commodityID,
+				"area":      areaID,
+				"location":  locationID,
+			}
+
+			file := f.seedFile(seedFileOpts{
+				linkType: linkType,
+				linkID:   targets[linkType],
+				linkMeta: "images",
+			})
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsTrue,
+				qt.Commentf("a file linked to a LIVE %s was destroyed", linkType))
+		})
+	}
+}
+
+// The age gate needs BOTH timestamps. updated_at is the load-bearing one: the
+// concurrent-attach case is a PUT /files/{id} that lands while the entity
+// delete is in flight, and that PUT stamps UpdatedAt = time.Now(). A gate that
+// only looked at created_at would sweep the freshly-attached file.
+func TestOrphanFileGC_TooYoungFileIsNeverSwept(t *testing.T) {
+	tests := []struct {
+		name       string
+		createdAgo time.Duration
+		updatedAgo time.Duration
+	}{
+		{"concurrent attach: old row, fresh updated_at", 30 * 24 * time.Hour, time.Hour},
+		{"fresh row, backdated updated_at", time.Hour, 30 * 24 * time.Hour},
+		{"both fresh", time.Hour, time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			file := f.seedFile(seedFileOpts{
+				linkType:   "commodity",
+				linkID:     "gone-commodity",
+				linkMeta:   "images",
+				createdAgo: tt.createdAgo,
+				updatedAgo: tt.updatedAgo,
+			})
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("a file inside the age window was destroyed"))
+		})
+	}
+}
+
+// A restore is a machine that deletes every entity and then recreates the files
+// over an UNBOUNDED duration — mid-restore every surviving file row legitimately
+// points at a just-deleted entity. The age gate cannot cover that window (a
+// restore writes the ARCHIVE's timestamps verbatim, so a row written seconds ago
+// can look years old); the DB-backed, per-tenant concurrency gate is what does.
+//
+// The gate must be PER-TENANT: an unrelated tenant keeps sweeping normally, so
+// one stuck operation cannot disable the GC for the whole installation.
+func TestOrphanFileGC_InFlightOperationBlocksItsTenantOnly(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(f *gcFixture, tenantID, groupID string)
+	}{
+		{
+			name: "restore pending",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedRestore(tenantID, groupID, models.RestoreStatusPending, nil)
+			},
+		},
+		{
+			name: "restore running",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedRestore(tenantID, groupID, models.RestoreStatusRunning, nil)
+			},
+		},
+		{
+			name: "export pending",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedExport(tenantID, groupID, models.ExportStatusPending, false, nil)
+			},
+		},
+		{
+			name: "export in_progress",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedExport(tenantID, groupID, models.ExportStatusInProgress, false, nil)
+			},
+		},
+		{
+			// A pending IMPORT is an export row with Imported=true, Status=pending
+			// (backup/import/worker.go claims on exactly that), so the same gate
+			// covers import ingestion.
+			name: "import pending",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedExport(tenantID, groupID, models.ExportStatusPending, true, nil)
+			},
+		},
+		{
+			// COOLDOWN: a restore that finished 1h ago still blocks, because the
+			// rows it wrote carry the ARCHIVE's timestamps and would clear the row
+			// age gate instantly.
+			name: "restore completed within min-age (cooldown)",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedRestore(tenantID, groupID, models.RestoreStatusCompleted, models.NewPTimestamp(time.Now().Add(-time.Hour)))
+			},
+		},
+		{
+			name: "export failed within min-age (cooldown)",
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedExport(tenantID, groupID, models.ExportStatusFailed, false, models.NewPTimestamp(time.Now().Add(-time.Hour)))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			// Tenant A: the blocked one.
+			blockedFile := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone-1", linkMeta: "images"})
+			tt.setup(f, f.tenantID, f.groupID)
+
+			// Tenant B: no in-flight operation — must sweep normally.
+			otherTenantID := f.newTenant(gcTenantB, models.TenantStatusActive)
+			otherGroupID := f.newGroup(otherTenantID, "group-t2", models.LocationGroupStatusActive)
+			otherUserID := f.newUser(otherTenantID, "other@example.com")
+			sweepableFile := f.seedFile(seedFileOpts{
+				tenantID: otherTenantID,
+				groupID:  otherGroupID,
+				userID:   otherUserID,
+				linkType: "commodity",
+				linkID:   "gone-2",
+				linkMeta: "images",
+			})
+
+			f.sweep()
+
+			c.Assert(f.fileExists(blockedFile.ID), qt.IsTrue,
+				qt.Commentf("a file in a tenant with an in-flight/just-finished operation was destroyed"))
+			c.Assert(f.fileExists(sweepableFile.ID), qt.IsFalse,
+				qt.Commentf("the gate blocked an UNRELATED tenant — it must be per-tenant, not global"))
+		})
+	}
+}
+
+// A DB timeout, a connection reset, or any driver error from the existence
+// probe must NEVER be read as "the entity does not exist". It aborts the tick.
+func TestOrphanFileGC_ProbeErrorAbortsTheTick(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+	f.probeErr = context.DeadlineExceeded // NOT registry.ErrNotFound
+
+	f.sweep()
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue,
+		qt.Commentf("a transient probe failure was treated as 'the entity is gone'"))
+}
+
+// Soft-pause (#1308) is the operator's emergency stop for the only destructive
+// worker in the tree. A paused worker must do NOTHING — not even read.
+//
+// workerpause.Controller fails OPEN for worker types it does not know about, so
+// this test is worthless without models/worker_control_test.go's assertion that
+// WorkerTypeOrphanFileGC is actually in AllWorkerTypes(). The two go together.
+func TestOrphanFileGC_PausedWorkerTouchesNothing(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	counting := &countingFileRegistry{FileRegistry: f.fs.FileRegistryFactory.CreateServiceRegistry()}
+	deps := f.deps()
+	deps.Files = counting
+
+	pause := &stubPause{paused: map[models.WorkerType]bool{models.WorkerTypeOrphanFileGC: true}}
+
+	services.NewOrphanFileGCWorker(deps,
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		services.WithOrphanFileGCPauseController(pause),
+	).RunOnce(f.ctx)
+
+	c.Assert(pause.calls, qt.Equals, 1)
+	c.Assert(counting.calls, qt.Equals, 0, qt.Commentf("a paused GC still read the file registry"))
+	c.Assert(f.probeCalls["commodity"], qt.Equals, 0, qt.Commentf("a paused GC still probed for entity existence"))
+	c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("a PAUSED GC deleted a file"))
+}
+
+// The shipping default. Report mode evaluates the identical predicate and
+// reports the identical candidates — and deletes nothing, in either class.
+func TestOrphanFileGC_ReportModeDeletesNothing(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	rowFile := f.seedFile(seedFileOpts{
+		linkType: "commodity",
+		linkID:   "gone",
+		linkMeta: "images",
+		blobKey:  blobkeys.BuildFileUploadKey(f.tenantID, "orphan.jpg"),
+	})
+	thumbKey := blobkeys.BuildThumbnailBlobKey(f.tenantID, "no-such-file-id", "small")
+	f.writeBlob(thumbKey, []byte("thumb"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	// Explicitly NOT delete mode.
+	services.NewOrphanFileGCWorker(f.deps(),
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeReport),
+	).RunOnce(f.ctx)
+
+	c.Assert(f.fileExists(rowFile.ID), qt.IsTrue, qt.Commentf("report mode deleted a file row"))
+	c.Assert(f.blobExists(thumbKey), qt.IsTrue, qt.Commentf("report mode deleted a thumbnail blob"))
+}
+
+// Off mode does not even scan.
+func TestOrphanFileGC_OffModeDoesNotScan(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	file := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	counting := &countingFileRegistry{FileRegistry: f.fs.FileRegistryFactory.CreateServiceRegistry()}
+	deps := f.deps()
+	deps.Files = counting
+
+	services.NewOrphanFileGCWorker(deps, services.WithOrphanFileGCMode(services.OrphanFileGCModeOff)).RunOnce(f.ctx)
+
+	c.Assert(counting.calls, qt.Equals, 0)
+	c.Assert(f.fileExists(file.ID), qt.IsTrue)
+}
+
+// The blob sweep enumerates EXACTLY ONE prefix — t/<tenant>/thumbnails/ — and
+// every other blob class is NEVER-SWEEP, structurally (never listed, never
+// read, never deleted). Each of these keys is aged well past the gate and owned
+// by NO file row, i.e. each is exactly what a naive "blobs with no owning file
+// row" sweep would destroy:
+//
+//   - restores/  — #2121. POST /uploads/restores writes the blob and creates NO
+//     ROW OF ANY KIND. Rowless until POST /exports/import, rowless forever if
+//     the user never submits, rowless forever if the import FAILS. Deleting it
+//     destroys a user's uploaded backup. THE most dangerous case.
+//   - files/     — upload is blob-first/row-second, so every in-flight upload is
+//     legitimately a rowless blob; a restore and the blobbackfill CLI are
+//     blob-first too.
+//   - exports/   — a FAILED export leaves its .inb referenced by no file row AND
+//     no export row.
+//   - seed-*     — sits directly under the tenant root.
+//   - legacy flat keys — still live wherever `inventario backfill blobs` never ran.
+func TestOrphanFileGC_NeverSweepsAnythingButThumbnails(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	keys := map[string]string{
+		"#2121 pending-import source blob": blobkeys.BuildRestoreUploadKey(f.tenantID, "backup.inb"),
+		"fresh upload (blob-before-row)":   blobkeys.BuildFileUploadKey(f.tenantID, "invoice-123.pdf"),
+		"failed-export artifact":           blobkeys.BuildBackupBlobKey(f.tenantID, "full", "20260101"),
+		"seed fixture":                     blobkeys.BuildSeedKey(f.tenantID, "seed-abc.jpg"),
+		"legacy flat key (pre-#1793)":      "thumbnails/legacy-file-id_small.jpg",
+		"legacy flat upload key":           "some-old-upload-1234.jpg",
+	}
+	for _, key := range keys {
+		f.writeBlob(key, []byte("precious"))
+	}
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	f.sweep()
+
+	for name, key := range keys {
+		c.Assert(f.blobExists(key), qt.IsTrue, qt.Commentf("NEVER-SWEEP blob was destroyed: %s (%s)", name, key))
+	}
+}
+
+// A live file's thumbnail must survive: RequestThumbnailGeneration returns the
+// EXISTING job and enqueues nothing unless its status is 'failed', so a deleted
+// thumbnail on a live file does NOT self-heal — it would be a visible,
+// user-facing regression.
+func TestOrphanFileGC_LiveFileThumbnailIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	_, _, commodityID := f.seedLiveCommodity(f.groupID, f.userID)
+	live := f.seedFile(seedFileOpts{linkType: "commodity", linkID: commodityID, linkMeta: "images"})
+
+	small := blobkeys.BuildThumbnailBlobKey(f.tenantID, live.ID, "small")
+	medium := blobkeys.BuildThumbnailBlobKey(f.tenantID, live.ID, "medium")
+	f.writeBlob(small, []byte("s"))
+	f.writeBlob(medium, []byte("m"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	f.sweep()
+
+	c.Assert(f.blobExists(small), qt.IsTrue, qt.Commentf("a LIVE file's thumbnail was destroyed"))
+	c.Assert(f.blobExists(medium), qt.IsTrue)
+}
+
+// Guards the thumbnail worker's detached Get→write window (bounded at 2 minutes
+// by the detached-job timeout): a thumbnail written moments ago is inside the
+// age gate and must be kept even if its owning row is already gone.
+func TestOrphanFileGC_FreshThumbnailIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildThumbnailBlobKey(f.tenantID, "no-such-file-id", "small")
+	f.writeBlob(key, []byte("thumb")) // ModTime = now
+
+	f.sweep()
+
+	c.Assert(f.blobExists(key), qt.IsTrue, qt.Commentf("a freshly-written thumbnail was destroyed"))
+}
+
+// The ROUND-TRIP GUARD: a key is only deletable if it parses AND
+// blobkeys.BuildThumbnailBlobKey rebuilds it byte-for-byte. Anything else is
+// kept — the worker never hands a raw, externally-derived string to Delete.
+func TestOrphanFileGC_UnparseableThumbnailKeyIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	prefix := blobkeys.TenantPrefix(f.tenantID) + blobkeys.ThumbnailsSegment + "/"
+	keys := []string{
+		prefix + "garbage",                    // no size, no extension
+		prefix + "nested/dir/file_small.jpg",  // nesting is not a legal thumbnail key
+		prefix + "some-file-id_large.jpg",     // 'large' is not a thumbnail size we write
+		prefix + "some-file-id_small.png",     // thumbnails are always JPEG
+		prefix + "_small.jpg",                 // empty file id
+		prefix + "some-file-id_.jpg",          // empty size
+		prefix + "some-file-id_small.jpg.bak", // suffix confusion
+	}
+	for _, key := range keys {
+		f.writeBlob(key, []byte("x"))
+	}
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	f.sweep()
+
+	for _, key := range keys {
+		c.Assert(f.blobExists(key), qt.IsTrue, qt.Commentf("a non-round-tripping key was deleted: %s", key))
+	}
+}
+
+// A pending_deletion group belongs to GroupPurgeWorker; a non-active tenant may
+// be mid-administrative-operation (#2115 hard delete). Both are under-collection,
+// which is free.
+func TestOrphanFileGC_InactiveGroupOrTenantIsNeverSwept(t *testing.T) {
+	tests := []struct {
+		name         string
+		tenantStatus models.TenantStatus
+		groupStatus  models.LocationGroupStatus
+	}{
+		{"group pending_deletion", models.TenantStatusActive, models.LocationGroupStatusPendingDeletion},
+		{"tenant suspended", models.TenantStatusSuspended, models.LocationGroupStatusActive},
+		{"tenant inactive", models.TenantStatusInactive, models.LocationGroupStatusActive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			tenantID := f.newTenant("tenant-x", tt.tenantStatus)
+			groupID := f.newGroup(tenantID, "group-x", tt.groupStatus)
+			userID := f.newUser(tenantID, "x@example.com")
+
+			file := f.seedFile(seedFileOpts{
+				tenantID: tenantID, groupID: groupID, userID: userID,
+				linkType: "commodity", linkID: "gone", linkMeta: "images",
+			})
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsTrue,
+				qt.Commentf("a file in an inactive group/tenant was destroyed"))
+		})
+	}
+}
+
+// Without a resolvable owner the delete cannot run under the file's own RLS
+// scope. The worker KEEPS the file — it must never fall back to a raw
+// service-mode row delete (which would also FK-fail on the thumbnail job chain).
+func TestOrphanFileGC_UnresolvableOwnerIsNeverSwept(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(o *seedFileOpts)
+		comment string
+	}{
+		{
+			name:    "creator no longer exists",
+			mutate:  func(o *seedFileOpts) { o.userID = "user-that-was-deleted" },
+			comment: "a file whose creator is gone was deleted anyway",
+		},
+		{
+			name:    "group no longer exists",
+			mutate:  func(o *seedFileOpts) { o.groupID = "group-that-was-purged" },
+			comment: "a file whose group is gone was deleted anyway",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			opts := seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"}
+			tt.mutate(&opts)
+			file := f.seedFile(opts)
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsTrue, qt.Commentf("%s", tt.comment))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POSITIVE — the residues the worker exists to reclaim
+// ---------------------------------------------------------------------------
+
+// The crash window: a process dies between an entity-row delete and its
+// DeleteLinkedFiles, leaving file rows pointing at an id that will never exist
+// again (entity ids are server-minted and never reused, so "entity X does not
+// exist" is monotone and irreversible). Nothing else in the tree sweeps these
+// for a live group.
+//
+// The commodity case matters most: DeleteCommodityRecursive has NO already-gone
+// self-heal (unlike area/location), so a crashed commodity delete's files are
+// permanent orphans today.
+func TestOrphanFileGC_SweepsCrashWindowOrphanRows(t *testing.T) {
+	tests := []string{"commodity", "area", "location"}
+
+	for _, linkType := range tests {
+		t.Run(linkType, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			blobKey := blobkeys.BuildFileUploadKey(f.tenantID, "orphan-"+linkType+".jpg")
+			file := f.seedFile(seedFileOpts{
+				linkType: linkType,
+				linkID:   "id-of-an-entity-that-no-longer-exists",
+				linkMeta: "images",
+				blobKey:  blobKey,
+			})
+			// Its thumbnails go with it — DeleteFileWithPhysical removes them.
+			small := blobkeys.BuildThumbnailBlobKey(f.tenantID, file.ID, "small")
+			f.writeBlob(small, []byte("s"))
+
+			f.sweep()
+
+			c.Assert(f.fileExists(file.ID), qt.IsFalse, qt.Commentf("the orphan %s file row survived", linkType))
+			c.Assert(f.blobExists(blobKey), qt.IsFalse, qt.Commentf("the orphan file's blob survived"))
+			c.Assert(f.blobExists(small), qt.IsFalse, qt.Commentf("the orphan file's thumbnail survived"))
+		})
+	}
+}
+
+// The thumbnail mid-generation race: a file deleted while the RLS-bypassing
+// thumbnail worker sits between its Get and its blob writes leaves thumbnails
+// nothing will ever collect.
+func TestOrphanFileGC_SweepsOrphanThumbnails(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	small := blobkeys.BuildThumbnailBlobKey(f.tenantID, "a-file-id-with-no-row", "small")
+	medium := blobkeys.BuildThumbnailBlobKey(f.tenantID, "a-file-id-with-no-row", "medium")
+	f.writeBlob(small, []byte("s"))
+	f.writeBlob(medium, []byte("m"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	f.sweep()
+
+	c.Assert(f.blobExists(small), qt.IsFalse, qt.Commentf("the orphan thumbnail survived"))
+	c.Assert(f.blobExists(medium), qt.IsFalse)
+}
+
+// Two `run workers` replicas sweep concurrently (no cleanup worker in the tree
+// takes a claim or a lock). Safety does not depend on a lock — every delete is
+// re-verified against a monotone predicate and both the row delete and the blob
+// delete are not-found-tolerant. A second identical tick must be a clean no-op.
+func TestOrphanFileGC_IsIdempotent(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	blobKey := blobkeys.BuildFileUploadKey(f.tenantID, "orphan.jpg")
+	file := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images", blobKey: blobKey,
+	})
+	thumb := blobkeys.BuildThumbnailBlobKey(f.tenantID, "no-row", "small")
+	f.writeBlob(thumb, []byte("t"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	f.sweep()
+	f.sweep() // the "other replica"
+
+	c.Assert(f.fileExists(file.ID), qt.IsFalse)
+	c.Assert(f.blobExists(blobKey), qt.IsFalse)
+	c.Assert(f.blobExists(thumb), qt.IsFalse)
+}
+
+// ---------------------------------------------------------------------------
+// Configuration surface
+// ---------------------------------------------------------------------------
+
+func TestParseOrphanFileGCMode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want services.OrphanFileGCMode
+		ok   bool
+	}{
+		{"off", services.OrphanFileGCModeOff, true},
+		{"report", services.OrphanFileGCModeReport, true},
+		{"delete", services.OrphanFileGCModeDelete, true},
+		{"", "", false},
+		{"DELETE", "", false},
+		{"purge", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			c := qt.New(t)
+			got, ok := services.ParseOrphanFileGCMode(tt.in)
+			c.Assert(ok, qt.Equals, tt.ok)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+// The min-age floor is a safety property, not a preference: a programmatic
+// caller cannot shrink it below MinOrphanFileGCMinAge (bootstrap fails fast on
+// the same value, this is the defence-in-depth).
+func TestOrphanFileGC_MinAgeFloorIsEnforced(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	// A genuine orphan, but only 2h old — well inside the 24h floor.
+	file := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images",
+		createdAgo: 2 * time.Hour, updatedAgo: 2 * time.Hour,
+	})
+
+	// Try to shrink the window to an hour. The option must refuse.
+	f.sweep(services.WithOrphanFileGCMinAge(time.Hour))
+
+	c.Assert(f.fileExists(file.ID), qt.IsTrue,
+		qt.Commentf("the min-age floor was bypassed by WithOrphanFileGCMinAge"))
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers that need models the tests above reference
+// ---------------------------------------------------------------------------
+
+func (f *gcFixture) seedExport(tenantID, groupID string, status models.ExportStatus, imported bool, completed models.PTimestamp) {
+	f.c.Helper()
+	_, err := f.fs.ExportRegistryFactory.CreateServiceRegistry().Create(f.ctx, models.Export{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: tenantID, GroupID: groupID, CreatedByUserID: f.userID,
+		},
+		Type:          models.ExportTypeFullDatabase,
+		Status:        status,
+		Imported:      imported,
+		Description:   "seeded",
+		CreatedDate:   models.NewPTimestamp(time.Now().Add(-2 * time.Hour)),
+		CompletedDate: completed,
+	})
+	f.c.Assert(err, qt.IsNil)
+}
+
+func (f *gcFixture) seedRestore(tenantID, groupID string, status models.RestoreStatus, completed models.PTimestamp) {
+	f.c.Helper()
+	// A restore_operation needs an export to point at.
+	exp, err := f.fs.ExportRegistryFactory.CreateServiceRegistry().Create(f.ctx, models.Export{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: tenantID, GroupID: groupID, CreatedByUserID: f.userID,
+		},
+		Type:        models.ExportTypeFullDatabase,
+		Status:      models.ExportStatusCompleted,
+		Description: "source",
+		// Old enough that the export cooldown does not itself block the tenant —
+		// the restore under test is what must do the blocking.
+		CreatedDate:   models.NewPTimestamp(time.Now().Add(-30 * 24 * time.Hour)),
+		CompletedDate: models.NewPTimestamp(time.Now().Add(-30 * 24 * time.Hour)),
+	})
+	f.c.Assert(err, qt.IsNil)
+
+	_, err = f.fs.RestoreOperationRegistryFactory.CreateServiceRegistry().Create(f.ctx, models.RestoreOperation{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: tenantID, GroupID: groupID, CreatedByUserID: f.userID,
+		},
+		ExportID:      exp.ID,
+		Description:   "seeded",
+		Status:        status,
+		Options:       models.RestoreOptions{Strategy: "merge_add"},
+		CreatedDate:   models.NewPTimestamp(time.Now().Add(-2 * time.Hour)),
+		CompletedDate: completed,
+	})
+	f.c.Assert(err, qt.IsNil)
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE — a blob key is NOT row-unique
+// ---------------------------------------------------------------------------
+
+// THE catastrophic case. The row delete is RLS-narrow, but the blob delete that
+// follows it is KEY-scoped — and `files.original_path` has no unique index. An
+// upload key is `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`
+// (filekit.UploadFileName): no group segment, no row segment, no randomness. Two
+// uploads of the same filename inside one tenant in the same second — two
+// members of different groups, or one user multi-selecting two same-named files
+// — produce two DISTINCT rows that share one blob key.
+//
+// So an orphan row can share its key with a LIVE row (here: a #2235 standalone
+// file, which no other gate in this worker even looks at). Deleting the orphan's
+// blob would destroy the live file's BYTES, irreversibly — `files` has no
+// soft-delete and there is no trash. Anything ambiguous is KEPT: the orphan is
+// not collected at all.
+func TestOrphanFileGC_SharedBlobKeyIsNeverSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	// The exact collision production mints: same tenant, same basename, same second.
+	shared := blobkeys.BuildFileUploadKey(f.tenantID, "receipt-1783824560.jpg")
+
+	otherGroupID := f.newGroup(f.tenantID, "group-b", models.LocationGroupStatusActive)
+	live := f.seedFile(seedFileOpts{
+		groupID: otherGroupID, // a standalone file in ANOTHER group — 100% legitimate
+		blobKey: shared,
+	})
+	orphan := f.seedFile(seedFileOpts{
+		linkType: "commodity",
+		linkID:   "id-of-an-entity-that-no-longer-exists",
+		linkMeta: "images",
+		blobKey:  shared, // same key, different row
+	})
+
+	f.sweep()
+
+	c.Assert(f.blobExists(shared), qt.IsTrue,
+		qt.Commentf("the GC destroyed the bytes of a LIVE file that shares the orphan's blob key"))
+	c.Assert(f.fileExists(live.ID), qt.IsTrue)
+	c.Assert(f.fileExists(orphan.ID), qt.IsTrue,
+		qt.Commentf("an orphan whose blob key is shared must be KEPT WHOLE, not half-deleted"))
+}
+
+// The guard must not turn into a blanket refusal: an orphan that solely owns its
+// key is still collected, blob and all.
+func TestOrphanFileGC_SoleOwnedBlobKeyIsStillSwept(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildFileUploadKey(f.tenantID, "sole-1783824560.jpg")
+	orphan := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images", blobKey: key,
+	})
+
+	f.sweep()
+
+	c.Assert(f.fileExists(orphan.ID), qt.IsFalse)
+	c.Assert(f.blobExists(key), qt.IsFalse)
+}
+
+// ---------------------------------------------------------------------------
+// The thumbnail-generation job chain
+// ---------------------------------------------------------------------------
+
+// A thumbnail job is owned by the user who REQUESTED generation, not by the
+// file's creator (RequestThumbnailGeneration stamps the requesting user so one
+// member cannot spend another's rate limit), and any group member who merely
+// VIEWS a not-yet-generated thumbnail enqueues one. The GC deletes through the
+// file's CREATOR, so a user-scoped teardown of the job chain cannot see — let
+// alone delete — a co-member's job. On postgres the surviving job row then trips
+// fk_thumbnail_job_file (NO ACTION; the FK check bypasses RLS) and the orphan can
+// NEVER be collected: it fails on every tick, forever.
+//
+// The chain teardown therefore runs service-mode. Asserted here by the job row
+// actually being gone (the memory backend has no FKs, so the row is the tell).
+func TestOrphanFileGC_TearsDownAThumbnailJobOwnedByAnotherGroupMember(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	viewerID := f.newUser(f.tenantID, "viewer@example.com")
+
+	orphan := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+	f.seedThumbnailJob(orphan.ID, viewerID, f.tenantID) // requested by a co-member, not the creator
+
+	f.sweep()
+
+	c.Assert(f.thumbnailJobCount(orphan.ID), qt.Equals, 0,
+		qt.Commentf("a co-member's thumbnail job survived the teardown — on postgres this FK-fails the delete forever"))
+	c.Assert(f.fileExists(orphan.ID), qt.IsFalse)
+}
+
+// ---------------------------------------------------------------------------
+// The forensic log is the recovery artifact — it must not lie
+// ---------------------------------------------------------------------------
+
+// `files` has no soft-delete, so the log line is the ONLY record of what was
+// destroyed. A record that says action=deleted for a file that still exists is
+// worse than no record: it sends an operator reconciling a data-loss report
+// looking for a file that was never touched. "deleted" is emitted only after the
+// delete RETURNS SUCCESS.
+func TestOrphanFileGC_NeverLogsDeletedWhenTheDeleteFailed(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	orphan := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	deps := f.deps()
+	deps.Deleter = &failingDeleter{err: errors.New("fk_thumbnail_job_file violation")}
+
+	logs := captureLogs(c, func() {
+		services.NewOrphanFileGCWorker(deps,
+			services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		).RunOnce(f.ctx)
+	})
+
+	c.Assert(logs, qt.Contains, `"action":"deleting"`,
+		qt.Commentf("the pre-image must be written BEFORE the attempt — it is the recovery artifact"))
+	c.Assert(logs, qt.Not(qt.Contains), `"action":"deleted"`,
+		qt.Commentf("the log claimed a file was deleted, but the delete failed and the row is still there"))
+	c.Assert(logs, qt.Contains, `"action":"failed"`)
+	c.Assert(f.fileExists(orphan.ID), qt.IsTrue)
+}
+
+// The confirmation is emitted on the success path, so an operator can tell the
+// two apart in the same grep.
+func TestOrphanFileGC_LogsDeletedOnlyAfterTheDeleteSucceeded(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	orphan := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	logs := captureLogs(c, func() { f.sweep() })
+
+	c.Assert(logs, qt.Contains, `"action":"deleted"`)
+	c.Assert(f.fileExists(orphan.ID), qt.IsFalse)
+}
+
+// ---------------------------------------------------------------------------
+// Thumbnail-sweep survival guards
+// ---------------------------------------------------------------------------
+
+// The blob-side gates need their own reds: the row-side tests seed no blob, so
+// they cannot tell whether the THUMBNAIL sweep honours the in-flight gate and the
+// tenant-status guard. A deleted thumbnail does not self-heal
+// (RequestThumbnailGeneration returns the existing job unless it is 'failed'), so
+// this is a user-visible regression, not a free re-render.
+func TestOrphanFileGC_ThumbnailSweepHonoursTenantGuards(t *testing.T) {
+	tests := []struct {
+		name         string
+		tenantStatus models.TenantStatus
+		setup        func(f *gcFixture, tenantID, groupID string)
+	}{
+		{
+			name:         "restore in flight pins the tenant",
+			tenantStatus: models.TenantStatusActive,
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedRestore(tenantID, groupID, models.RestoreStatusRunning, nil)
+			},
+		},
+		{
+			name:         "export in flight pins the tenant",
+			tenantStatus: models.TenantStatusActive,
+			setup: func(f *gcFixture, tenantID, groupID string) {
+				f.seedExport(tenantID, groupID, models.ExportStatusInProgress, false, nil)
+			},
+		},
+		{
+			name:         "suspended tenant is never swept",
+			tenantStatus: models.TenantStatusSuspended,
+			setup:        func(*gcFixture, string, string) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			f := newGCFixture(c)
+
+			tenantID := f.newTenant("tenant-guard", tt.tenantStatus)
+			groupID := f.newGroup(tenantID, "group-guard", models.LocationGroupStatusActive)
+			f.newUser(tenantID, "guard@example.com")
+			tt.setup(f, tenantID, groupID)
+
+			// An aged thumbnail with no owning row — a genuine orphan by every
+			// other rule. Only the tenant guard stands between it and deletion.
+			key := blobkeys.BuildThumbnailBlobKey(tenantID, "a-file-id-with-no-row", "small")
+			f.writeBlob(key, []byte("t"))
+			f.backdateBlobs(30 * 24 * time.Hour)
+
+			f.sweep()
+
+			c.Assert(f.blobExists(key), qt.IsTrue,
+				qt.Commentf("the thumbnail sweep ignored the tenant guard"))
+		})
+	}
+}
+
+// A transient failure of the thumbnail sweep's row probe (a DB timeout, a
+// connection reset) must NEVER be read as "the row is gone". Only
+// registry.ErrNotFound is evidence of absence; anything else aborts the tick.
+func TestOrphanFileGC_ThumbnailProbeErrorNeverReadsAsGone(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildThumbnailBlobKey(f.tenantID, "a-file-id-the-probe-cannot-resolve", "small")
+	f.writeBlob(key, []byte("t"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	deps := f.deps()
+	deps.Files = &failingGetFileRegistry{
+		FileRegistry: f.fs.FileRegistryFactory.CreateServiceRegistry(),
+		err:          context.DeadlineExceeded, // NOT registry.ErrNotFound
+	}
+
+	services.NewOrphanFileGCWorker(deps,
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+	).RunOnce(f.ctx)
+
+	c.Assert(f.blobExists(key), qt.IsTrue,
+		qt.Commentf("a transient probe failure was treated as 'the file row is gone'"))
+}
+
+// ---------------------------------------------------------------------------
+// Liveness — a bounded tick must still make progress
+// ---------------------------------------------------------------------------
+
+// Head-of-line blocking. Re-verification KEEPS far more rows than it deletes, and
+// several keep-reasons NEVER clear (a tenant pinned by a crashed restore, a
+// suspended tenant, a purged owner). Those rows are also among the OLDEST
+// orphans, so they sort to the front of an oldest-first window and — because
+// nothing ever removes them — a non-resumable bounded scan would re-serve the
+// same page every tick and never reach anything behind it.
+//
+// Here: a full page of permanently-skipped rows sits in front of a collectable
+// orphan. The tick must page PAST them, within the tick.
+func TestOrphanFileGC_SkippedRowsDoNotStarveTheScanWithinATick(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	// A suspended tenant: its rows are candidates forever and deleted never.
+	deadTenant := f.newTenant("tenant-suspended", models.TenantStatusSuspended)
+	deadGroup := f.newGroup(deadTenant, "group-suspended", models.LocationGroupStatusActive)
+	deadUser := f.newUser(deadTenant, "dead@example.com")
+	for range 4 {
+		f.seedFile(seedFileOpts{
+			tenantID: deadTenant, groupID: deadGroup, userID: deadUser,
+			linkType: "commodity", linkID: "gone", linkMeta: "images",
+			createdAgo: 40 * 24 * time.Hour, // OLDER than the collectable one below
+		})
+	}
+
+	// The collectable orphan sorts behind all of them.
+	orphan := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images",
+		createdAgo: 10 * 24 * time.Hour,
+	})
+
+	// Two rows per candidate query — the skipped rows fill the first page whole.
+	f.sweep(services.WithOrphanFileGCRowBudget(2, 100))
+
+	c.Assert(f.fileExists(orphan.ID), qt.IsFalse,
+		qt.Commentf("permanently-skipped rows squatted on the candidate window and starved a collectable orphan"))
+}
+
+// The same starvation across TICKS: when a tick runs out of its row budget the
+// next one must RESUME from the keyset cursor, not restart at the oldest row.
+// Otherwise the same head rows are re-examined forever and nothing behind them
+// is ever reached — and in the shipping REPORT mode, where nothing is ever
+// deleted, every row is a head row.
+func TestOrphanFileGC_RowScanResumesOnTheNextTick(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	deadTenant := f.newTenant("tenant-suspended", models.TenantStatusSuspended)
+	deadGroup := f.newGroup(deadTenant, "group-suspended", models.LocationGroupStatusActive)
+	deadUser := f.newUser(deadTenant, "dead@example.com")
+	for range 2 {
+		f.seedFile(seedFileOpts{
+			tenantID: deadTenant, groupID: deadGroup, userID: deadUser,
+			linkType: "commodity", linkID: "gone", linkMeta: "images",
+			createdAgo: 40 * 24 * time.Hour,
+		})
+	}
+
+	orphan := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images",
+		createdAgo: 10 * 24 * time.Hour,
+	})
+
+	// One row per tick: tick 1 can only reach the first skipped row.
+	worker := services.NewOrphanFileGCWorker(f.deps(),
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		services.WithOrphanFileGCRowBudget(1, 1),
+	)
+
+	worker.RunOnce(f.ctx)
+	c.Assert(f.fileExists(orphan.ID), qt.IsTrue, qt.Commentf("the budget was not honoured"))
+
+	// Ticks 2 and 3 must advance past the two skipped rows and reach the orphan.
+	worker.RunOnce(f.ctx)
+	worker.RunOnce(f.ctx)
+
+	c.Assert(f.fileExists(orphan.ID), qt.IsFalse,
+		qt.Commentf("the scan restarted from the top every tick — it can never reach past the skipped rows"))
+}
+
+// The thumbnail listing budget must be PER TENANT. A single shared budget is
+// spent by whichever tenant is enumerated first — by its LIVE thumbnails, which
+// outnumber orphans by orders of magnitude — and every tenant after it is then
+// skipped on this tick and (the listing being lexicographic from the top, and
+// nothing ever removing those keys) on every future tick too. The blob half of
+// the GC would be a permanent no-op for most of the installation, invisibly.
+func TestOrphanFileGC_OneTenantsThumbnailsDoNotStarveAnother(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	// Tenant A: live thumbnails that will exhaust a small budget.
+	_, _, commodityID := f.seedLiveCommodity(f.groupID, f.userID)
+	live := f.seedFile(seedFileOpts{linkType: "commodity", linkID: commodityID, linkMeta: "images"})
+	f.writeBlob(blobkeys.BuildThumbnailBlobKey(f.tenantID, live.ID, "small"), []byte("s"))
+	f.writeBlob(blobkeys.BuildThumbnailBlobKey(f.tenantID, live.ID, "medium"), []byte("m"))
+
+	// Tenant B: one orphan thumbnail, behind tenant A in the iteration order.
+	otherTenantID := f.newTenant(gcTenantB, models.TenantStatusActive)
+	orphanKey := blobkeys.BuildThumbnailBlobKey(otherTenantID, "a-file-id-with-no-row", "small")
+	f.writeBlob(orphanKey, []byte("o"))
+
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	// A budget of 2 keys is exactly tenant A's live thumbnails.
+	f.sweep(services.WithOrphanFileGCThumbnailBudget(2))
+
+	c.Assert(f.blobExists(orphanKey), qt.IsFalse,
+		qt.Commentf("tenant A's live thumbnails consumed a SHARED budget and tenant B was never swept"))
+}
+
+// Within one tenant, a listing that runs out of budget must RESUME on the next
+// tick. Live thumbnails are never deleted, so a truncated window would never
+// advance on its own: every orphan sorting after the cutoff key would be
+// unreachable forever.
+func TestOrphanFileGC_ThumbnailListingResumesOnTheNextTick(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	prefix := blobkeys.TenantPrefix(f.tenantID) + blobkeys.ThumbnailsSegment + "/"
+
+	// Two keys that are always KEPT (they do not round-trip), sorting FIRST, and
+	// an orphan thumbnail sorting last. blob.List walks keys lexicographically.
+	kept := []string{prefix + "aaa-1_large.jpg", prefix + "aaa-2_large.jpg"}
+	for _, k := range kept {
+		f.writeBlob(k, []byte("x"))
+	}
+	orphanKey := blobkeys.BuildThumbnailBlobKey(f.tenantID, "zzz-file-id-with-no-row", "small")
+	f.writeBlob(orphanKey, []byte("o"))
+	f.backdateBlobs(30 * 24 * time.Hour)
+
+	worker := services.NewOrphanFileGCWorker(f.deps(),
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		services.WithOrphanFileGCThumbnailBudget(2),
+	)
+
+	worker.RunOnce(f.ctx) // burns the whole budget on the two kept keys
+	c.Assert(f.blobExists(orphanKey), qt.IsTrue, qt.Commentf("the per-tenant budget was not honoured"))
+
+	worker.RunOnce(f.ctx) // must resume AFTER them
+
+	c.Assert(f.blobExists(orphanKey), qt.IsFalse,
+		qt.Commentf("the listing restarted from the top of the prefix — keys past the budget are unreachable forever"))
+	for _, k := range kept {
+		c.Assert(f.blobExists(k), qt.IsTrue)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+// The ticker path is the one production actually runs; every other test drives
+// RunOnce directly. Mirrors the EmailVerificationCleanupWorker /
+// OperationSlotCleanupWorker lifecycle tests.
+func TestOrphanFileGC_StartRunsTicksAndStopIsClean(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	orphan := f.seedFile(seedFileOpts{linkType: "commodity", linkID: "gone", linkMeta: "images"})
+
+	worker := services.NewOrphanFileGCWorker(f.deps(),
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete),
+		services.WithOrphanFileGCInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	worker.Start(ctx)
+	c.Assert(eventually(c, 2*time.Second, func() bool { return !f.fileExists(orphan.ID) }), qt.IsTrue,
+		qt.Commentf("the ticker never drove a sweep"))
+
+	worker.Stop() // returns cleanly: no hang, no panic
+	worker.Stop() // idempotent
+}
+
+// Start is a no-op without the two dependencies that make a delete possible.
+func TestOrphanFileGC_StartWithIncompleteDepsIsANoOp(t *testing.T) {
+	worker := services.NewOrphanFileGCWorker(services.OrphanFileGCDeps{},
+		services.WithOrphanFileGCInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	worker.Start(ctx)
+	worker.Stop()
+}
+
+// Compile-time guard: registry.FileRegistry must satisfy the narrow, read-only
+// slice the GC consumes, so a signature drift is caught here rather than at
+// wiring time.
+var _ services.OrphanFileGCFileRegistry = (registry.FileRegistry)(nil)

--- a/go/services/storage_usage_service_test.go
+++ b/go/services/storage_usage_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -68,6 +69,18 @@ func (s *stubFileRegistry) CountByCategory(context.Context, string, *models.File
 }
 
 func (s *stubFileRegistry) ListPendingSizeBackfill(context.Context, int) ([]*models.FileEntity, error) {
+	panic("not implemented")
+}
+
+func (s *stubFileRegistry) ListOrphanCandidates(context.Context, time.Time, registry.OrphanCandidateCursor, int) ([]*models.FileEntity, error) {
+	panic("not implemented")
+}
+
+func (s *stubFileRegistry) ListIDsByTenant(context.Context, string) ([]string, error) {
+	panic("not implemented")
+}
+
+func (s *stubFileRegistry) CountByOriginalPath(context.Context, string) (int, error) {
 	panic("not implemented")
 }
 

--- a/go/services/storage_usage_service_test.go
+++ b/go/services/storage_usage_service_test.go
@@ -76,7 +76,7 @@ func (s *stubFileRegistry) ListOrphanCandidates(context.Context, time.Time, regi
 	panic("not implemented")
 }
 
-func (s *stubFileRegistry) ListIDsByTenant(context.Context, string) ([]string, error) {
+func (s *stubFileRegistry) ExistingIDs(context.Context, []string) ([]string, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
Closes #2237.

A backstop for the residues the delete paths structurally cannot close: the crash window between an entity row delete and its `DeleteLinkedFiles` (#2119), a file attached to an entity *while* its delete is in flight, and thumbnails orphaned by the thumbnail worker's `Get`→write window. Nothing swept these for a live group — only group purge / tenant hard-delete did, i.e. **never**.

## The design premise

This worker **deletes user data**, with **RLS bypass**. So the bar is not "does it collect orphans" — it is **"can it ever collect a non-orphan"**. Everything ambiguous is KEPT; under-collecting forever is free, one wrong delete is not.

The safety argument rests on a fact worth stating: **entity ids are server-minted and never reused** (`store/rlsgroup.go` re-mints on every `Create`, including service mode; restore builds a fresh id mapping rather than preserving archive ids). So *"the linked entity is gone"* is **monotone** — once true, it cannot be un-made under us, which is what makes a probe→delete sequence safe at all.

## Row sweep — a file row is deleted only if ALL of

- `linked_entity_type ∈ {commodity, area, location}` — a **positive allowlist, never a negation**. `""` is a **STANDALONE file** (#2235): first-class, exported in backups — *"no link" is not "orphan"*. `"export"` belongs to the backup lifecycle. An unknown/future type **fails closed** (the registries don't run `ValidateWithContext`, so the DB is a superset of the validator's enum).
- the linked id **does not exist**, probed through an **RLS-bypassing service registry, by id only**. This one is load-bearing: `PUT /files/{id}` does **not** validate the link target, so a **cross-group link is reachable in production** — a group-scoped probe would read a *live* entity as missing and delete a **live file**.
- *"does not exist"* means **exactly `registry.ErrNotFound`**. Any other error aborts the tick; a DB timeout must never be read as absence.
- **both** `created_at` and `updated_at` are older than min-age (default **72h**, hard floor 24h). `updated_at` is the one that matters: `PUT /files/{id}` stamps it, so a file attached concurrently with a delete is immune for the whole window.
- the tenant has **no export/restore in flight** — DB-backed and re-checked before *every* delete (the archive workers run in a *different process*, so an in-memory flag would be wrong by construction).
- group and tenant are **ACTIVE** (a `pending_deletion` group belongs to GroupPurgeWorker; a suspended tenant may be mid-#2115).
- the row is the **sole referent of its blob key** — see below.

## Blob sweep — thumbnails ONLY

Exactly **one** prefix is ever passed to `bucket.List`: `t/<tenant>/thumbnails/`.

| prefix | verdict | why |
|---|---|---|
| `thumbnails/` | **SWEEP** | key embeds the owning row id → orphan-ness is an exact single-row question; derived + regenerable, so even a false positive is not data loss |
| `restores/` | **NEVER** | a #2121 pending import has **no owning row by design** — sweeping it would **destroy a user's uploaded backup** |
| `files/` | **NEVER** | upload is blob-first/row-second; restore and `blobbackfill` also write before repointing. Reclaiming these needs a provably-complete global keep-set, which I cannot prove under concurrency → deferred to an operator CLI, not guessed at by an autonomous worker |
| `exports/` | **NEVER** | a failed export leaves an artifact referenced by no row |
| seed / legacy flat keys | **NEVER** | not under the enumerated prefix at all |

These are **structural** exclusions (a prefix never passed to `List`), not filters a bug could invert. And a key is deleted **only if it round-trips through `BuildThumbnailBlobKey`** — i.e. only a key the worker rebuilt itself, which is also the anti-traversal guard.

## Ships in REPORT mode

It evaluates the full predicate, logs every candidate with a forensic record, increments `inventario_orphan_gc_candidates_total` — and **deletes nothing**. Enforcement is an explicit opt-in (`--orphan-file-gc-mode=delete`), so an operator can watch the predicate against real production data for a release cycle before arming it. Pausable via #1308. **No migration** — `worker_control.worker_type` is a plain `TEXT` column.

## Two real bugs this surfaced

1. **Fixed here (drive-by, and required for the GC to work at all):** `deleteThumbnailGenerationChain` resolved jobs through a **user-scoped** registry, but a thumbnail job is owned by whoever **requested** generation — and *merely viewing* a file enqueues one (`servePlaceholderThumbnail`). In any multi-member group the job row was **invisible** to the deleting user, survived, and **FK-blocked the file delete outright** (`fk_thumbnail_job_file` is NO ACTION; Postgres' RI check bypasses row security, so an invisible child still blocks the parent). The teardown now runs service-scoped, *after* the caller's ownership was already proven by the user-scoped `Get` — authorization is unchanged.

2. **Filed as #2241 (pre-existing, affects every delete path):** upload blob keys are `<name>-<unix SECONDS><ext>` — **no randomness**, no unique index on `original_path`. Two same-second uploads of one filename in a tenant share a key, so `DeleteFileWithPhysical` deleting one file **destroys the other's bytes**. The GC would be the first automated caller to hit this at scale, so it carries a `CountByOriginalPath` guard: **unless the row is the only referent of its key, the file is kept whole**. The same guard belongs in the shared delete primitive — that's #2241.

## Tests — negatives first (36)

The negatives *are* the feature. Each of these **survives** a sweep: a standalone file (#2235), an export-linked file (and **zero** probes fire, so the exports soft-delete trap is unreachable), an unknown link type, a **cross-group** link, a cross-tenant link, a live entity's file, a too-young file (both timestamps), a blocked tenant, an inactive group/tenant, a **shared blob key**, a #2121 `restores/` blob, `files/`/`exports/`/seed keys, a fresh thumbnail, an unparseable key, an unresolvable owner. Plus: report and off modes delete nothing, a paused worker touches nothing, a probe error aborts the tick, `Start`/`Stop` are idempotent. Then the positives: a genuine crash-window orphan and an orphaned thumbnail *are* collected.

## Gates

`go build` (both tags) ✅ · `golangci-lint run` ✅ **0 issues** · `nolintguard` ✅ · `qtlint` ✅ · `go test ./...` ✅ **83 pkgs, 0 FAIL** (postgres registry tests self-skip without a DSN; they type-check and run in the `go-test-postgres` lane). No migration, no frontend/e2e/seeddata touched. Runbook updated (`devdocs/admin-runbook.md` §8: the NEVER-SWEEP table, the report→delete rollout, and what to do about a tenant pinned by a crashed restore).

## Known, deliberately not solved here

- **Original-blob reclamation** (`files/`) — needs the provably-complete keep-set above; an operator CLI with a mandatory dry-run is the honest shape.
- An orphan row is still **listed and downloadable** in the Files tab, so `delete` mode destroys *user-visible* data with no undo. That is precisely why the default is `report` — and why `PUT /files/{id}` should validate its link target in the first place (worth its own issue).
- A stuck export/restore pins its tenant's sweep indefinitely (by design — fail-safe); the runbook says how to spot it via `inventario_orphan_gc_blocked_tenants`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added orphan-file garbage collection for stale file records and thumbnail blobs, running as a new background housekeeping worker (including `run all`).
  * Added new persistent controls: `--orphan-file-gc-interval`, `--orphan-file-gc-min-age`, and `--orphan-file-gc-mode` (`off`, `report`, `delete`), with safe defaults and resumable scanning.
  * Introduced pauseable worker support and stronger safety validation for `min-age` and `mode`.
* **Documentation**
  * Expanded the administrator runbook with a complete orphan-file GC section, sweep rules, rollout workflow, and pause/monitoring guidance.
* **Tests**
  * Added extensive unit and integration coverage for discovery, paging, safety gates, and delete/report/off behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->