### PR TITLE
fix(files): mint blob keys from a UUID and never delete a blob another row still owns (#2241)

### DIFF
--- a/frontend/src/components/files/FilePreviewDialog.tsx
+++ b/frontend/src/components/files/FilePreviewDialog.tsx
@@ -44,6 +44,14 @@ export interface FilePreviewDialogProps {
   onDelete?: (fileId: string) => void
 }
 
+// appendExt gives `name` the extension `ext`, unless it already ends with it.
+// Case-insensitive, because a user who typed "Receipt.PDF" gets one extension,
+// not two.
+function appendExt(name: string, ext: string | undefined | null): string {
+  if (!ext) return name
+  return name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`
+}
+
 export function FilePreviewDialog({ file, onClose, onDelete }: FilePreviewDialogProps) {
   const { t } = useTranslation()
   if (!file) return null
@@ -54,7 +62,11 @@ export function FilePreviewDialog({ file, onClose, onDelete }: FilePreviewDialog
   // (`t/<tenant>/files/<uuid>.jpg`), never a filename the user would recognise
   // — offering it as the download name saved their receipt as a UUID under a
   // path-shaped name. Build the name from what the user actually sees.
-  const downloadName = `${file.file.path?.trim() || title}${file.file.ext ?? ""}`
+  //
+  // `path` is nominally the name WITHOUT its extension, but the API accepts one
+  // that already carries it ("receipt.pdf"), so appending unconditionally would
+  // hand the browser `receipt.pdf.pdf`.
+  const downloadName = appendExt(file.file.path?.trim() || title, file.file.ext)
   const downloadUrl = file.signedUrl?.url
 
   function handleDelete() {

--- a/frontend/src/components/files/FilePreviewDialog.tsx
+++ b/frontend/src/components/files/FilePreviewDialog.tsx
@@ -50,7 +50,11 @@ export function FilePreviewDialog({ file, onClose, onDelete }: FilePreviewDialog
 
   const mime = file.file.mime_type
   const title = file.file.title?.trim() || file.file.path?.trim() || file.file.id
-  const downloadName = file.file.original_path || file.file.path || title
+  // NOT original_path: that field is the storage blob KEY
+  // (`t/<tenant>/files/<uuid>.jpg`), never a filename the user would recognise
+  // — offering it as the download name saved their receipt as a UUID under a
+  // path-shaped name. Build the name from what the user actually sees.
+  const downloadName = `${file.file.path?.trim() || title}${file.file.ext ?? ""}`
   const downloadUrl = file.signedUrl?.url
 
   function handleDelete() {

--- a/frontend/src/components/files/__tests__/FilePreviewDialog.test.tsx
+++ b/frontend/src/components/files/__tests__/FilePreviewDialog.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { FilePreviewDialog } from "@/components/files/FilePreviewDialog"
+import type { ListedFile } from "@/features/files/api"
+
+// `original_path` is the storage blob KEY, not a filename (#2241): today
+// `t/<tenant>/files/<uuid>.pdf`, and before that a path-shaped
+// `t/<tenant>/files/receipt-1783824560.pdf`. It was being handed to the browser
+// as the download name, so saving a file wrote a UUID under a path-shaped name
+// instead of the name the user gave it.
+//
+// The name the user sees in the UI is the name they must get on disk.
+function makeFile(overrides: Partial<ListedFile["file"]> = {}): ListedFile {
+  return {
+    file: {
+      id: "f1",
+      title: "Kitchen receipt",
+      path: "kitchen-receipt",
+      ext: ".pdf",
+      original_path: "t/tenant-1/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf",
+      mime_type: "application/octet-stream",
+      tags: [],
+      ...overrides,
+    },
+    signedUrl: { url: "https://example.test/signed" },
+  } as unknown as ListedFile
+}
+
+describe("FilePreviewDialog download name", () => {
+  it("saves under the human filename, never the blob key", () => {
+    render(<FilePreviewDialog file={makeFile()} onClose={() => {}} />)
+
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("download", "kitchen-receipt.pdf")
+    expect(link.getAttribute("download")).not.toContain("t/tenant-1")
+    expect(link.getAttribute("download")).not.toContain("f47ac10b")
+  })
+
+  it("falls back to the title when the row carries no path", () => {
+    render(<FilePreviewDialog file={makeFile({ path: "" })} onClose={() => {}} />)
+
+    expect(screen.getByRole("link")).toHaveAttribute("download", "Kitchen receipt.pdf")
+  })
+})

--- a/frontend/src/components/files/__tests__/FilePreviewDialog.test.tsx
+++ b/frontend/src/components/files/__tests__/FilePreviewDialog.test.tsx
@@ -42,4 +42,20 @@ describe("FilePreviewDialog download name", () => {
 
     expect(screen.getByRole("link")).toHaveAttribute("download", "Kitchen receipt.pdf")
   })
+
+  // `path` is nominally the name WITHOUT its extension, but the API accepts one
+  // that already carries it (see go/jsonapi/files_update_validation_test.go,
+  // which round-trips "receipt.pdf"), so appending unconditionally would save
+  // the file as `receipt.pdf.pdf`.
+  it("does not double the extension when path already carries it", () => {
+    render(<FilePreviewDialog file={makeFile({ path: "receipt.pdf" })} onClose={() => {}} />)
+
+    expect(screen.getByRole("link")).toHaveAttribute("download", "receipt.pdf")
+  })
+
+  it("matches the extension case-insensitively", () => {
+    render(<FilePreviewDialog file={makeFile({ path: "Receipt.PDF" })} onClose={() => {}} />)
+
+    expect(screen.getByRole("link")).toHaveAttribute("download", "Receipt.PDF")
+  })
 })

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -12156,8 +12156,14 @@ export type components = {
              */
             mime_type?: string;
             /**
-             * @description OriginalPath is the original filename as uploaded by the user.
-             *     Example: "invoice.pdf"
+             * @description OriginalPath is the storage blob key, NOT a filename despite the name.
+             *     The human filename lives on Path/Title.
+             *     Example: "t/<tenant>/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf"
+             *
+             *     Minted from a server-side UUID (blobkeys.BuildFileBlobKey). It is the key
+             *     every reader opens and every delete path removes by, so it must be unique
+             *     per row — see #2241, and the shared-key guard in FileService, for what
+             *     happens when it is not.
              */
             original_path?: string;
             /**

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/render"
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
 	"gocloud.dev/blob"
 
 	"github.com/denisvmedia/inventario/apiserver/middleware"
@@ -364,12 +365,24 @@ func (api *uploadsAPI) readUploadedFiles(r *http.Request, tenantID string, kind 
 // error (wrapped in uploadHTTPError for the unprocessable-entity-bound
 // MIME mismatch).
 func (api *uploadsAPI) saveOnePart(ctx context.Context, part io.Reader, basename, tenantID string, kind uploadKind, allowedContentTypes []string) (uploadedFile, error) {
+	// The blob key is minted from a fresh server-side UUID, NOT from the
+	// filename (#2241). The key is the delete key and nothing enforces one row
+	// per key, so a key derived from `<name>-<unix SECONDS>` — which two
+	// same-named uploads in one second collide on — is a key whose deletion
+	// destroys another live file's bytes, irreversibly. The human name survives
+	// as the file's Title/Path; it has no business in the key.
+	//
+	// The row does not exist yet (this runs in the streaming multipart
+	// middleware), which is exactly why the key cannot be the row id — and does
+	// not need to be. Uniqueness and unguessability are all it owes.
+	blobID := uuid.New().String()
+
 	var blobKey string
 	switch kind {
 	case uploadKindRestore:
-		blobKey = blobkeys.BuildRestoreUploadKey(tenantID, basename)
+		blobKey = blobkeys.BuildRestoreUploadKey(tenantID, blobID, basename)
 	default:
-		blobKey = blobkeys.BuildFileUploadKey(tenantID, basename)
+		blobKey = blobkeys.BuildFileBlobKey(tenantID, blobID, filekit.Extension(basename))
 	}
 	mimeType, size, err := api.saveFile(ctx, blobKey, part, allowedContentTypes)
 	switch {

--- a/go/apiserver/uploads_test.go
+++ b/go/apiserver/uploads_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-extras/go-kit/must"
@@ -22,6 +23,7 @@ import (
 	"github.com/denisvmedia/inventario/apiserver"
 	"github.com/denisvmedia/inventario/internal/backupsign"
 	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/internal/filekit"
 	"github.com/denisvmedia/inventario/internal/inb"
 )
 
@@ -149,10 +151,16 @@ func TestUploads_restores(t *testing.T) {
 	c.Assert(response.Type, qt.Equals, "uploads")
 	c.Assert(response.Attributes.Type, qt.Equals, "restores")
 	c.Assert(response.Attributes.FileNames, qt.HasLen, 1)
-	// Restore uploads land under the per-tenant `restores/` namespace
-	// (#1793). The trailing segment is the filekit-sanitized basename of the
-	// uploaded `.inb` archive (#534).
-	c.Assert(response.Attributes.FileNames[0], qt.Matches, `t/[^/]+/restores/backup-\d+\.inb`)
+	// Restore uploads land under the per-tenant `restores/` namespace (#1793),
+	// keyed by a server-minted UUID with the filekit-sanitized basename of the
+	// uploaded `.inb` archive (#534) kept after it for operator legibility.
+	//
+	// The UUID is the load-bearing part (#2241): a restore blob has NO owning
+	// row of any kind (#2121), so a name-keyed upload of `backup.inb` would
+	// silently OVERWRITE an earlier one uploaded in the same second, and the
+	// pending import would then restore bytes its user never uploaded.
+	c.Assert(response.Attributes.FileNames[0], qt.Matches,
+		`t/[^/]+/restores/[0-9a-f-]{36}-backup-\d+\.inb`)
 }
 
 func TestUploads_restores_invalid(t *testing.T) {
@@ -349,6 +357,91 @@ func TestUploads_file_tenantPrefixedKey(t *testing.T) {
 	c.Assert(strings.HasPrefix(resp.Attributes.OriginalPath, "t/"+testUser.TenantID+"/files/"), qt.IsTrue,
 		qt.Commentf("OriginalPath %q must live under the authenticated tenant's namespace", resp.Attributes.OriginalPath))
 	c.Assert(resp.Attributes.Path, qt.Not(qt.Contains), "t/")
+}
+
+// TestUploads_file_sameNameSameSecond_distinctBlobKeys is the #2241 regression
+// test, and it is a DATA-LOSS test, not a naming one.
+//
+// The old key was `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`: no
+// group segment, no row segment, no randomness. Two uploads of `receipt.jpg`
+// inside one second — two members of different groups, or one user
+// multi-selecting two same-named files — produced two DISTINCT file rows
+// pointing at ONE blob key. Every blob delete goes by key and `files` has no
+// soft-delete, so deleting either row destroyed the other, still-live file's
+// bytes, irreversibly.
+//
+// The clock is frozen to make the collision certain rather than a race the test
+// might miss. Both uploads must still land their own bytes, and the human name
+// must survive on Path/Title where it belongs.
+func TestUploads_file_sameNameSameSecond_distinctBlobKeys(t *testing.T) {
+	c := qt.New(t)
+
+	frozen := time.Unix(1783824560, 0)
+	prev := filekit.NowFunc
+	filekit.NowFunc = func() time.Time { return frozen }
+	defer func() { filekit.NowFunc = prev }()
+
+	params, testUser, testGroup := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false})
+
+	upload := func() (originalPath, humanPath string) {
+		c.Helper()
+
+		img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+		var imgBuf bytes.Buffer
+		c.Assert(jpeg.Encode(&imgBuf, img, &jpeg.Options{Quality: 80}), qt.IsNil)
+
+		bodyBuf := &bytes.Buffer{}
+		bodyWriter := multipart.NewWriter(bodyBuf)
+		fileWriter, err := bodyWriter.CreatePart(CreateFormFileMIME("file", "receipt.jpg", "image/jpeg"))
+		c.Assert(err, qt.IsNil)
+		_, err = fileWriter.Write(imgBuf.Bytes())
+		c.Assert(err, qt.IsNil)
+		contentType := bodyWriter.FormDataContentType()
+		bodyWriter.Close()
+
+		req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/file", bodyBuf)
+		c.Assert(err, qt.IsNil)
+		req.Header.Set("Content-Type", contentType)
+		addTestUserAuthHeader(req, testUser.ID)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		c.Assert(rr.Code, qt.Equals, http.StatusCreated, qt.Commentf("body=%s", rr.Body.String()))
+
+		var resp struct {
+			Attributes struct {
+				OriginalPath string `json:"original_path"`
+				Path         string `json:"path"`
+			} `json:"attributes"`
+		}
+		c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+		return resp.Attributes.OriginalPath, resp.Attributes.Path
+	}
+
+	firstKey, firstName := upload()
+	secondKey, secondName := upload()
+
+	c.Assert(firstKey, qt.Not(qt.Equals), secondKey,
+		qt.Commentf("two same-named uploads in one second share a blob key: deleting either destroys the other's bytes"))
+
+	// Both blobs are really there — the second upload did not OVERWRITE the
+	// first, which is the same collision seen from the write side.
+	bucket, err := blob.OpenBucket(context.Background(), params.UploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer bucket.Close()
+	for _, key := range []string{firstKey, secondKey} {
+		exists, err := bucket.Exists(context.Background(), key)
+		c.Assert(err, qt.IsNil)
+		c.Assert(exists, qt.IsTrue, qt.Commentf("blob %q is missing — one upload clobbered the other", key))
+	}
+
+	// The human name is unchanged and still human: the entropy belongs in the
+	// key, not in what the user reads.
+	c.Assert(firstName, qt.Equals, secondName)
+	c.Assert(firstName, qt.Contains, "receipt")
+	c.Assert(firstKey, qt.Not(qt.Contains), "receipt",
+		qt.Commentf("a key derived from the filename is exactly what collided"))
 }
 
 // TestUploads_file_tooLarge is the #2101 regression test: a POST

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -13437,7 +13437,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "original_path": {
-                    "description": "OriginalPath is the original filename as uploaded by the user.\nExample: \"invoice.pdf\"",
+                    "description": "OriginalPath is the storage blob key, NOT a filename despite the name.\nThe human filename lives on Path/Title.\nExample: \"t/\u003ctenant\u003e/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf\"\n\nMinted from a server-side UUID (blobkeys.BuildFileBlobKey). It is the key\nevery reader opens and every delete path removes by, so it must be unique\nper row — see #2241, and the shared-key guard in FileService, for what\nhappens when it is not.",
                     "type": "string"
                 },
                 "path": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -13430,7 +13430,7 @@
                     "type": "string"
                 },
                 "original_path": {
-                    "description": "OriginalPath is the original filename as uploaded by the user.\nExample: \"invoice.pdf\"",
+                    "description": "OriginalPath is the storage blob key, NOT a filename despite the name.\nThe human filename lives on Path/Title.\nExample: \"t/\u003ctenant\u003e/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf\"\n\nMinted from a server-side UUID (blobkeys.BuildFileBlobKey). It is the key\nevery reader opens and every delete path removes by, so it must be unique\nper row — see #2241, and the shared-key guard in FileService, for what\nhappens when it is not.",
                     "type": "string"
                 },
                 "path": {

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -3797,8 +3797,14 @@ definitions:
         type: string
       original_path:
         description: |-
-          OriginalPath is the original filename as uploaded by the user.
-          Example: "invoice.pdf"
+          OriginalPath is the storage blob key, NOT a filename despite the name.
+          The human filename lives on Path/Title.
+          Example: "t/<tenant>/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf"
+
+          Minted from a server-side UUID (blobkeys.BuildFileBlobKey). It is the key
+          every reader opens and every delete path removes by, so it must be unique
+          per row — see #2241, and the shared-key guard in FileService, for what
+          happens when it is not.
         type: string
       path:
         description: |-

--- a/go/internal/blobkeys/blobkeys.go
+++ b/go/internal/blobkeys/blobkeys.go
@@ -10,11 +10,18 @@
 //
 // Layout:
 //
-//	t/<tenant>/files/<file-id><ext>             — original uploaded file
+//	t/<tenant>/files/<blob-id><ext>             — original uploaded file
 //	t/<tenant>/thumbnails/<file-id>_<size>.jpg  — derived thumbnail (JPEG)
 //	t/<tenant>/exports/export_<type>_<ts>.xml   — exported XML bundle
-//	t/<tenant>/restores/<filename>              — uploaded XML for restore
+//	t/<tenant>/restores/<blob-id>-<filename>    — uploaded archive for restore
 //	t/<tenant>/seed-<uuid><ext>                 — demo / seed fixtures
+//
+// Every <blob-id> is a server-minted UUID. That is a correctness
+// requirement, not a style choice: the key is the DELETE key, nothing
+// enforces one row per key, and `files` has no soft-delete — so a key
+// that two rows can share is a key whose deletion destroys a live file's
+// bytes. See #2241, where an upload key of `<name>-<unix SECONDS><ext>`
+// did exactly that.
 //
 // The tenant is always supplied by server-side context (the authenticated
 // user's TenantID, or — for cross-tenant background workers — the tenant
@@ -84,35 +91,31 @@ func sanitizeSegment(s string) string {
 }
 
 // BuildFileBlobKey produces the canonical blob key for an original file
-// upload: `t/<tenant>/files/<file-id><ext>`. The extension argument is
+// upload: `t/<tenant>/files/<blob-id><ext>`. The extension argument is
 // expected to start with a dot (".pdf", ".jpg"); an empty string is
 // allowed for files whose MIME type carries no canonical extension.
 //
-// fileID is the FileEntity row ID, not the user-supplied filename, so
-// the key is stable across renames and cannot be guessed from a Path
-// the operator might choose.
-func BuildFileBlobKey(tenantID, fileID, ext string) string {
+// blobID MUST be a server-minted UUID and MUST NOT be derived from the
+// user-supplied filename. Two properties depend on it, and #2241 is what
+// happens when either is lost:
+//
+//   - UNIQUENESS. The key is the delete key. Nothing enforces one row per
+//     key (there is no unique index on files.original_path), so a key two
+//     rows can share is a key whose deletion destroys a live file's bytes.
+//     The old upload key was `<sanitized-name>-<unix SECONDS><ext>`, which
+//     two same-named uploads in one second collide on exactly.
+//   - UNGUESSABILITY. The key must not be derivable from a Path the user
+//     chooses, or from a filename they control.
+//
+// Callers that already have the FileEntity row ID (the restore importer)
+// pass that; the upload handler mints a fresh UUID because the row does
+// not exist yet. Both are unique and unguessable, which is all this key
+// needs — it is not required to equal the row id, and does not.
+func BuildFileBlobKey(tenantID, blobID, ext string) string {
 	return fmt.Sprintf("%s%s/%s/%s%s",
 		Prefix, tenantID, FilesSegment,
-		sanitizeSegment(fileID), sanitizeSegment(ext),
+		sanitizeSegment(blobID), sanitizeSegment(ext),
 	)
-}
-
-// BuildFileUploadKey is the upload-time variant of BuildFileBlobKey for
-// flows that mint the per-blob basename *before* the FileEntity row
-// exists (the multipart upload handler is the canonical example: it
-// writes the bucket from a streaming middleware that doesn't have a
-// row ID yet, only the filekit.UploadFileName-sanitized basename).
-//
-// `basename` already carries its own extension and uniqueness suffix —
-// callers MUST NOT pass a user-supplied filename here; sanitize first
-// via filekit.UploadFileName so the on-disk key is collision-resistant.
-//
-// The key shape is identical to BuildFileBlobKey
-// (`t/<tenant>/files/<basename>`) so readers don't care which writer
-// minted the row.
-func BuildFileUploadKey(tenantID, basename string) string {
-	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, FilesSegment, sanitizeSegment(basename))
 }
 
 // BuildThumbnailBlobKey produces the canonical blob key for a derived
@@ -201,13 +204,24 @@ func SanitizeArchivePath(p string) string {
 	return strings.Join(segments, "/")
 }
 
-// BuildRestoreUploadKey produces the canonical blob key for an XML
-// backup file uploaded as part of a restore operation:
-// `t/<tenant>/restores/<filename>`. `filename` is expected to already
-// be sanitized (the upload pipeline runs every name through
-// filekit.UploadFileName before reaching us).
-func BuildRestoreUploadKey(tenantID, filename string) string {
-	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, RestoresSegment, sanitizeSegment(filename))
+// BuildRestoreUploadKey produces the canonical blob key for a backup
+// archive uploaded as part of a restore operation:
+// `t/<tenant>/restores/<blob-id>-<filename>`. `filename` is expected to
+// already be sanitized (the upload pipeline runs every name through
+// filekit.UploadFileName before reaching us) and is kept only so an
+// operator staring at the bucket can tell what a key is.
+//
+// blobID is a server-minted UUID and carries the uniqueness (#2241). A
+// restore blob has NO owning row of any kind (#2121) — it stays rowless
+// until the user submits the import, and forever if they never do — so a
+// name-only key means two uploads of `backup.inb` in the same second
+// silently OVERWRITE each other, and a pending import then restores bytes
+// its user never uploaded.
+func BuildRestoreUploadKey(tenantID, blobID, filename string) string {
+	return fmt.Sprintf("%s%s/%s/%s-%s",
+		Prefix, tenantID, RestoresSegment,
+		sanitizeSegment(blobID), sanitizeSegment(filename),
+	)
 }
 
 // BuildSeedKey produces the canonical blob key for a demo / seed

--- a/go/internal/blobkeys/blobkeys_test.go
+++ b/go/internal/blobkeys/blobkeys_test.go
@@ -40,10 +40,20 @@ func TestBuildFileBlobKey(t *testing.T) {
 	}
 }
 
-func TestBuildFileUploadKey(t *testing.T) {
+// There is exactly ONE way to key a file blob, and it takes a server-minted
+// blob id. The upload-time variant that keyed by filename is GONE (#2241): it
+// produced `<name>-<unix SECONDS><ext>`, which two same-named uploads inside one
+// second collide on, and the collision made deleting one file destroy the other
+// file's bytes. Re-adding a filename-keyed builder would re-open that.
+func TestBuildFileBlobKey_IsTheOnlyFileKeyBuilder(t *testing.T) {
 	c := qt.New(t)
-	got := blobkeys.BuildFileUploadKey("tenant-a", "my-photo-1748000000.jpg")
-	c.Assert(got, qt.Equals, "t/tenant-a/files/my-photo-1748000000.jpg")
+
+	a := blobkeys.BuildFileBlobKey("tenant-a", "f47ac10b-58cc-4372-a567-0e02b2c3d479", ".jpg")
+	b := blobkeys.BuildFileBlobKey("tenant-a", "9d3f1c2e-7b4a-4d18-9f6e-2c5a8b1e0d77", ".jpg")
+
+	c.Assert(a, qt.Equals, "t/tenant-a/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg")
+	c.Assert(a, qt.Not(qt.Equals), b,
+		qt.Commentf("distinct blob ids must never share a key — the key is the DELETE key"))
 }
 
 func TestBuildThumbnailBlobKey(t *testing.T) {
@@ -82,10 +92,18 @@ func TestBuildExportBlobKey_LowercasesType(t *testing.T) {
 	c.Assert(got, qt.Equals, "t/tenant-a/exports/export_commodities_20260523_120000.xml")
 }
 
+// A restore blob has NO owning row of any kind (#2121), so nothing would ever
+// notice an overwrite: two uploads of `backup.inb` in the same second must not
+// land on one key, or a pending import restores bytes its user never uploaded.
 func TestBuildRestoreUploadKey(t *testing.T) {
 	c := qt.New(t)
-	got := blobkeys.BuildRestoreUploadKey("tenant-a", "backup-1748000000.xml")
-	c.Assert(got, qt.Equals, "t/tenant-a/restores/backup-1748000000.xml")
+
+	got := blobkeys.BuildRestoreUploadKey("tenant-a", "f47ac10b-58cc-4372-a567-0e02b2c3d479", "backup-1748000000.inb")
+	c.Assert(got, qt.Equals, "t/tenant-a/restores/f47ac10b-58cc-4372-a567-0e02b2c3d479-backup-1748000000.inb")
+
+	other := blobkeys.BuildRestoreUploadKey("tenant-a", "9d3f1c2e-7b4a-4d18-9f6e-2c5a8b1e0d77", "backup-1748000000.inb")
+	c.Assert(got, qt.Not(qt.Equals), other,
+		qt.Commentf("same filename, same second — the blob id is the only thing keeping these apart"))
 }
 
 func TestBuildSeedKey(t *testing.T) {
@@ -201,12 +219,13 @@ func TestKeysAlwaysCarryTenantNamespace(t *testing.T) {
 
 	hostileInputs := []string{
 		blobkeys.BuildFileBlobKey(tenant, "../../escape", ".pdf"),
-		blobkeys.BuildFileUploadKey(tenant, "../../escape.pdf"),
+		blobkeys.BuildFileBlobKey(tenant, "file-1", "../../escape.pdf"),
 		blobkeys.BuildThumbnailBlobKey(tenant, "../../escape", "small"),
 		blobkeys.BuildExportBlobKey(tenant, "any", "ts"),
-		blobkeys.BuildRestoreUploadKey(tenant, "../escape.xml"),
+		blobkeys.BuildRestoreUploadKey(tenant, "blob-id", "../escape.xml"),
+		blobkeys.BuildRestoreUploadKey(tenant, "../../escape", "backup.inb"),
 		blobkeys.BuildSeedKey(tenant, "../etc/passwd"),
-		blobkeys.BuildFileUploadKey(tenant, `..\windows\system32\config\sam`),
+		blobkeys.BuildFileBlobKey(tenant, `..\windows\system32\config\sam`, ""),
 	}
 	for i, got := range hostileInputs {
 		c.Assert(strings.HasPrefix(got, prefix), qt.IsTrue,

--- a/go/internal/filekit/filekit.go
+++ b/go/internal/filekit/filekit.go
@@ -11,13 +11,22 @@ import (
 
 var NowFunc = time.Now
 
-// UploadFileName generates a sanitized and unique file name with a timestamp for the given file name input.
-// The generated file name is in the format: [sanitized_file_name]-[timestamp].[file_extension]
-// The timestamp is obtained from the NowFunc function, which can be mocked for testing purposes.
-// The file name is sanitized by converting it to lowercase and replacing spaces with dashes.
-// If the file name is empty, it defaults to "h" (hidden).
-// The function properly handles multi-part extensions (like .tar.gz) using getMultiPartExtension.
-// The function returns the generated file name.
+// UploadFileName generates a sanitized, HUMAN-READABLE file name with a
+// timestamp for the given file name input, in the format
+// [sanitized_file_name]-[timestamp].[file_extension].
+//
+// It is NOT unique and MUST NOT be used to derive a blob key. The timestamp has
+// SECOND granularity and there is no randomness, so two uploads of the same
+// filename within one second produce the identical string — which is precisely
+// how #2241 turned a file delete into the destruction of another live file's
+// bytes. Blob keys are minted from a server-side UUID via
+// blobkeys.BuildFileBlobKey; this name exists so the user sees "invoice-…"
+// rather than a UUID as the title of their upload.
+//
+// The timestamp is obtained from the NowFunc function, which can be mocked for
+// testing purposes. The file name is sanitized by converting it to lowercase and
+// replacing spaces with dashes. If the file name is empty, it defaults to "h"
+// (hidden). Multi-part extensions (like .tar.gz) are handled via Extension.
 func UploadFileName(fileName string) string {
 	fileExt := getMultiPartExtension(fileName)
 	originalFileName := strings.TrimSuffix(
@@ -37,6 +46,18 @@ func UploadFileName(fileName string) string {
 	buf.WriteString(fileExt)
 
 	return buf.String()
+}
+
+// Extension returns the file extension of filePath INCLUDING the leading dot,
+// handling multi-part extensions (".tar.gz") the same way UploadFileName does.
+// Returns "" for a name with no extension.
+//
+// Exported so the upload handler can give a UUID-minted blob key the same
+// extension the human-readable name carries — the key's extension is cosmetic
+// (readers open the key verbatim and take the MIME type from the row), but a
+// bucket full of extensionless UUIDs is miserable to operate.
+func Extension(filePath string) string {
+	return getMultiPartExtension(filePath)
 }
 
 func getMultiPartExtension(filePath string) string {

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -380,6 +380,19 @@ type FileIndexes struct {
 	// Trigram similarity index for file path search
 	//migrator:schema:index name="files_path_trgm_idx" fields="path" type="GIN" ops="gin_trgm_ops" table="files"
 	_ int
+
+	// original_path is looked up by EXACT value on the delete hot path: every
+	// blob delete asks "does another row still reference this key?" (#2241)
+	// before it removes any bytes. Without this index that question is a
+	// sequential scan of `files` on every single-file delete, every cascade,
+	// every purge, and every orphan-GC candidate.
+	//
+	// NOT unique, deliberately: rows written before #2241 can legitimately share
+	// a key (that IS the bug), so a unique index would fail to build on exactly
+	// the installations that need it most. Uniqueness is now enforced by
+	// construction at the key-minting site instead.
+	//migrator:schema:index name="files_original_path_idx" fields="original_path" table="files"
+	_ int
 }
 
 func (*FileEntity) Validate() error {

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -60,8 +60,14 @@ type File struct {
 	//migrator:schema:field name="path" type="TEXT" not_null="true"
 	Path string `json:"path" db:"path"`
 
-	// OriginalPath is the original filename as uploaded by the user.
-	// Example: "invoice.pdf"
+	// OriginalPath is the storage blob key, NOT a filename despite the name.
+	// The human filename lives on Path/Title.
+	// Example: "t/<tenant>/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.pdf"
+	//
+	// Minted from a server-side UUID (blobkeys.BuildFileBlobKey). It is the key
+	// every reader opens and every delete path removes by, so it must be unique
+	// per row — see #2241, and the shared-key guard in FileService, for what
+	// happens when it is not.
 	//migrator:schema:field name="original_path" type="TEXT" not_null="true"
 	OriginalPath string `json:"original_path" db:"original_path"`
 

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -431,15 +431,16 @@ func afterOrphanCursor(file *models.FileEntity, after registry.OrphanCandidateCu
 	return file.CreatedAt.After(after.CreatedAt)
 }
 
-// CountByOriginalPath mirrors the postgres method — how many file rows, across
-// EVERY tenant and group, reference the given blob key (#2237). Service-mode
-// only: it reads the shared item map directly rather than through the
-// visibility filter, because the whole point is to see rows the caller cannot.
-func (r *FileRegistry) CountByOriginalPath(_ context.Context, originalPath string) (int, error) {
+// ListIDsByOriginalPath mirrors the postgres method — the ids of every file
+// row, across EVERY tenant and group, that references the given blob key
+// (#2241). Service-mode only: it reads the shared item map directly rather than
+// through the visibility filter, because the whole point is to see the rows the
+// caller cannot.
+func (r *FileRegistry) ListIDsByOriginalPath(_ context.Context, originalPath string) ([]string, error) {
 	if originalPath == "" {
-		return 0, nil
+		return nil, nil
 	}
-	count := 0
+	var ids []string
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
@@ -448,10 +449,10 @@ func (r *FileRegistry) CountByOriginalPath(_ context.Context, originalPath strin
 			continue
 		}
 		if file.OriginalPath == originalPath {
-			count++
+			ids = append(ids, file.ID)
 		}
 	}
-	return count, nil
+	return ids, nil
 }
 
 // ExistingIDs mirrors the postgres method — the subset of ids that still have a

--- a/go/registry/memory/files_orphan_candidates_test.go
+++ b/go/registry/memory/files_orphan_candidates_test.go
@@ -186,11 +186,11 @@ func TestMemoryFileRegistry_ListOrphanCandidates_KeysetCursor(t *testing.T) {
 }
 
 // A blob key is NOT row-unique — there is no unique index on original_path, and
-// an upload key carries only a sanitized filename plus a unix SECOND. Two rows
-// in one tenant can legitimately share one key, and deleting one row's blob by
-// key destroys the other row's bytes. CountByOriginalPath is what lets the GC
-// see that, so it must count rows the caller cannot otherwise see: every tenant,
-// every group.
+// a pre-#2241 upload key carried only a sanitized filename plus a unix SECOND.
+// Two rows in one tenant can legitimately share one key, and deleting one row's
+// blob by key destroys the other row's bytes. ListIDsByOriginalPath is what lets
+// the delete paths (and the GC) see that: it returns the IDS of every row on the
+// key, across every tenant and group — rows the caller cannot otherwise see.
 func TestMemoryFileRegistry_ListIDsByOriginalPath(t *testing.T) {
 	c := qt.New(t)
 	fs := memory.NewFactorySet()

--- a/go/registry/memory/files_orphan_candidates_test.go
+++ b/go/registry/memory/files_orphan_candidates_test.go
@@ -191,34 +191,43 @@ func TestMemoryFileRegistry_ListOrphanCandidates_KeysetCursor(t *testing.T) {
 // key destroys the other row's bytes. CountByOriginalPath is what lets the GC
 // see that, so it must count rows the caller cannot otherwise see: every tenant,
 // every group.
-func TestMemoryFileRegistry_CountByOriginalPath(t *testing.T) {
+func TestMemoryFileRegistry_ListIDsByOriginalPath(t *testing.T) {
 	c := qt.New(t)
 	fs := memory.NewFactorySet()
 
+	// A pre-#2241 key: `<name>-<unix SECONDS><ext>`, which two same-named
+	// uploads in one second collide on. Rows like these are already sitting in
+	// deployed databases and can never be un-collided by a code change, so the
+	// delete paths must keep asking who else points at the blob.
 	const shared = "t/tenant-1/files/receipt-1783824560.jpg"
-	seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour, shared)
-	seedOrphanFileWithPath(c, fs, "tenant-1", "group-2", "", "", 30*24*time.Hour, shared)
-	seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "", "", 30*24*time.Hour, "t/tenant-1/files/sole-1783824560.jpg")
+	a := seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "commodity", "gone", 30*24*time.Hour, shared)
+	b := seedOrphanFileWithPath(c, fs, "tenant-1", "group-2", "", "", 30*24*time.Hour, shared)
+	sole := seedOrphanFileWithPath(c, fs, "tenant-1", "group-1", "", "", 30*24*time.Hour, "t/tenant-1/files/sole-1783824560.jpg")
 
 	reg := fs.FileRegistryFactory.CreateServiceRegistry()
 	ctx := context.Background()
 
-	n, err := reg.CountByOriginalPath(ctx, shared)
+	// Service mode: the row in the OTHER group must be visible, or the delete
+	// that consults this would happily destroy its bytes.
+	ids, err := reg.ListIDsByOriginalPath(ctx, shared)
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 2, qt.Commentf("a key shared by two rows must not look sole-owned"))
+	c.Assert(ids, qt.HasLen, 2)
+	c.Assert(ids, qt.Contains, a)
+	c.Assert(ids, qt.Contains, b, qt.Commentf("a sharer in another group was invisible"))
 
-	n, err = reg.CountByOriginalPath(ctx, "t/tenant-1/files/sole-1783824560.jpg")
+	ids, err = reg.ListIDsByOriginalPath(ctx, "t/tenant-1/files/sole-1783824560.jpg")
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 1)
+	c.Assert(ids, qt.DeepEquals, []string{sole})
 
-	n, err = reg.CountByOriginalPath(ctx, "t/tenant-1/files/never-uploaded.jpg")
+	ids, err = reg.ListIDsByOriginalPath(ctx, "t/tenant-1/files/never-uploaded.jpg")
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 0)
+	c.Assert(ids, qt.HasLen, 0)
 
-	// An empty path must never be read as "nobody references this".
-	n, err = reg.CountByOriginalPath(ctx, "")
+	// "" is the sentinel for a row with no blob, not a key. It must never come
+	// back as "these rows reference it".
+	ids, err = reg.ListIDsByOriginalPath(ctx, "")
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 0)
+	c.Assert(ids, qt.HasLen, 0)
 }
 
 func TestMemoryFileRegistry_ExistingIDs(t *testing.T) {

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -675,31 +675,43 @@ func (r *FileRegistry) ExistingIDs(ctx context.Context, ids []string) ([]string,
 	return existing, nil
 }
 
-// CountByOriginalPath counts the file rows that reference the given blob key,
-// across EVERY tenant and group (#2237). Service-mode only.
+// ListIDsByOriginalPath returns the IDs of the file rows that reference the
+// given blob key, across EVERY tenant and group (#2241). Service-mode only.
 //
-// The count is deliberately NOT tenant-scoped. Post-#1793 keys carry a
-// `t/<tenant>/` prefix, but legacy flat keys (rows whose blob predates the
-// backfill) do not, so two rows in DIFFERENT tenants can reference one legacy
-// key. The orphan-file GC treats any key referenced by more than one row as
-// shared and keeps the row rather than destroy another row's bytes.
+// Deliberately NOT tenant-scoped. Post-#1793 keys carry a `t/<tenant>/` prefix,
+// but legacy flat keys (rows whose blob predates the backfill) do not, so two
+// rows in DIFFERENT tenants can reference one legacy key. A blob delete that
+// scoped this lookup to the caller's own tenant would happily destroy the other
+// tenant's bytes.
 //
-// An empty path counts as zero rather than matching every row whose blob is
+// An empty path returns no ids rather than matching every row whose blob is
 // unset — a caller must never conclude "nobody else references this" from it.
-func (r *FileRegistry) CountByOriginalPath(ctx context.Context, originalPath string) (int, error) {
+func (r *FileRegistry) ListIDsByOriginalPath(ctx context.Context, originalPath string) ([]string, error) {
 	if originalPath == "" {
-		return 0, nil
+		return nil, nil
 	}
-	var count int
+	var ids []string
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE original_path = $1`, r.tableNames.Files())
-		return tx.QueryRowxContext(ctx, query, originalPath).Scan(&count)
+		query := fmt.Sprintf(`SELECT id FROM %s WHERE original_path = $1`, r.tableNames.Files())
+		rows, err := tx.QueryxContext(ctx, query, originalPath)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, id)
+		}
+		return rows.Err()
 	})
 	if err != nil {
-		return 0, errxtrace.Wrap("failed to count files by original path", err)
+		return nil, errxtrace.Wrap("failed to list file ids by original path", err)
 	}
-	return count, nil
+	return ids, nil
 }
 
 // SumSizeBreakdownByGroup mirrors SumSizeBreakdown but for an explicit

--- a/go/registry/postgres/files_orphan_candidates_test.go
+++ b/go/registry/postgres/files_orphan_candidates_test.go
@@ -175,16 +175,17 @@ func TestFileRegistry_Postgres_ListOrphanCandidates(t *testing.T) {
 	})
 }
 
-// TestFileRegistry_Postgres_CountByOriginalPath pins the guard that stops the
-// orphan-file GC from destroying a LIVE file's bytes.
+// TestFileRegistry_Postgres_ListIDsByOriginalPath pins the lookup that stops
+// every delete path — and the orphan-file GC — from destroying a LIVE file's
+// bytes.
 //
-// files.original_path has NO unique index, and an upload key is
+// files.original_path has NO unique index, and a pre-#2241 upload key was
 // `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>` — no group segment, no
 // row segment, no randomness. Two rows in one tenant can therefore legitimately
 // share one blob key, while the blob delete inside DeleteFileWithPhysical is
-// key-scoped: deleting the orphan would take the live row's bytes with it,
+// key-scoped: deleting one row would take the other's bytes with it,
 // irreversibly (`files` has no soft-delete).
-func TestFileRegistry_Postgres_CountByOriginalPath(t *testing.T) {
+func TestFileRegistry_Postgres_ListIDsByOriginalPath(t *testing.T) {
 	c := qt.New(t)
 
 	_, cleanup := setupTestRegistrySet(t)

--- a/go/registry/postgres/files_orphan_candidates_test.go
+++ b/go/registry/postgres/files_orphan_candidates_test.go
@@ -225,19 +225,19 @@ func TestFileRegistry_Postgres_CountByOriginalPath(t *testing.T) {
 	mk(group2, shared)
 	mk(group1, sole)
 
-	n, err := svc.CountByOriginalPath(ctx, shared)
+	ids, err := svc.ListIDsByOriginalPath(ctx, shared)
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 2, qt.Commentf("a key shared by two rows must not look sole-owned to the GC"))
+	c.Assert(ids, qt.HasLen, 2, qt.Commentf("a key shared by two rows must not look sole-owned"))
 
-	n, err = svc.CountByOriginalPath(ctx, sole)
+	ids, err = svc.ListIDsByOriginalPath(ctx, sole)
 	c.Assert(err, qt.IsNil)
-	c.Assert(n, qt.Equals, 1)
+	c.Assert(ids, qt.HasLen, 1)
 
 	t.Run("an empty path never reads as unreferenced", func(t *testing.T) {
 		c := qt.New(t)
-		n, err := svc.CountByOriginalPath(ctx, "")
+		ids, err := svc.ListIDsByOriginalPath(ctx, "")
 		c.Assert(err, qt.IsNil)
-		c.Assert(n, qt.Equals, 0)
+		c.Assert(ids, qt.HasLen, 0)
 	})
 }
 

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -482,22 +482,27 @@ type FileRegistry interface {
 	// empty input returns (nil, nil) without a query.
 	ExistingIDs(ctx context.Context, ids []string) ([]string, error)
 
-	// CountByOriginalPath returns how many file rows — across EVERY
-	// tenant and group — carry the given files.original_path (#2237).
-	// Service-mode only.
+	// ListIDsByOriginalPath returns the IDs of every file row — across
+	// EVERY tenant and group — that carries the given files.original_path
+	// (#2241). Service-mode only. An empty path returns (nil, nil) without
+	// a query: "" is the sentinel for a row with no blob, not a key.
 	//
-	// It exists because a blob key is NOT row-unique and there is no
-	// unique index on original_path. An upload's key is
-	// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`, which has
-	// no group segment, no row segment and no randomness: two uploads of
-	// the same filename inside one tenant in the same second (two members
-	// of different groups; one user multi-selecting two same-named files)
-	// legitimately produce two DISTINCT rows that share one key. Deleting
-	// a file row's blob by key therefore destroys the bytes of every other
-	// row pointing at it, and `files` has no soft-delete. The orphan-file
-	// GC calls this before any destructive step and KEEPS anything whose
-	// key is shared.
-	CountByOriginalPath(ctx context.Context, originalPath string) (int, error)
+	// It exists because a blob key is NOT row-unique. Uploads minted before
+	// #2241 are keyed `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`
+	// — no group segment, no row segment, no randomness — so two uploads of
+	// the same filename inside one tenant in the same second (two members of
+	// different groups; one user multi-selecting two same-named files) produce
+	// two DISTINCT rows sharing one key. Every blob delete goes by key, and
+	// `files` has no soft-delete, so deleting one of those rows would destroy
+	// the other's bytes irreversibly. New uploads carry a UUID and cannot
+	// collide, but the rows already in deployed databases can, forever.
+	//
+	// IDs rather than a count on purpose: the callers that need this are
+	// deleting a BATCH (a group purge, a tenant hard-delete) and must ask
+	// "does any row OUTSIDE my batch still reference this blob?". A count
+	// cannot answer that without arithmetic over the batch, and getting that
+	// arithmetic subtly wrong destroys user data.
+	ListIDsByOriginalPath(ctx context.Context, originalPath string) ([]string, error)
 }
 
 // OrphanCandidateCursor is the keyset position a paged

--- a/go/schema/migrations/_sqldata/1783869344_add_files_original_path_index.down.sql
+++ b/go/schema/migrations/_sqldata/1783869344_add_files_original_path_index.down.sql
@@ -1,0 +1,5 @@
+-- Migration rollback
+-- Generated on: 2026-07-12T15:15:44Z
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS files_original_path_idx;

--- a/go/schema/migrations/_sqldata/1783869344_add_files_original_path_index.up.sql
+++ b/go/schema/migrations/_sqldata/1783869344_add_files_original_path_index.up.sql
@@ -1,0 +1,5 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-07-12T15:15:44Z
+-- Direction: UP
+
+CREATE INDEX IF NOT EXISTS files_original_path_idx ON files (original_path);

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -170,7 +170,10 @@ func (s *FileService) DeleteFileWithPhysical(ctx context.Context, fileID string)
 	// a failure to remove the physical blob or its thumbnails must never undo
 	// the row delete or surface as an error to the caller.
 	if file.File != nil && file.File.OriginalPath != "" {
-		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, fileID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+		// The row is already gone (#2120 is row-first), so the batch is empty:
+		// any row still referencing this key is somebody else's, and its bytes
+		// must survive.
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, fileID, file.File.OriginalPath, file.File.MIMEType, nil); err != nil {
 			slog.WarnContext(ctx, "failed to delete physical blob after file row delete (best-effort)",
 				"file_id", fileID, "tenant_id", file.TenantID, "error", err.Error())
 		}
@@ -259,6 +262,13 @@ func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID,
 		return errxtrace.Wrap("failed to list files by group", err)
 	}
 
+	// The rows are still in the table while this sweep runs (the GroupPurger
+	// removes them afterwards), so the shared-key guard has to be told which
+	// rows are ours — otherwise every blob would look shared with itself and
+	// nothing would ever be cleaned up. A row in ANOTHER group that shares a
+	// pre-#2241 key is NOT in this set, and its bytes survive.
+	batch := blobDeleteBatch(files)
+
 	for _, file := range files {
 		if file == nil {
 			continue
@@ -266,11 +276,23 @@ func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID,
 		if file.File == nil || file.File.OriginalPath == "" {
 			continue
 		}
-		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType, batch); err != nil {
 			return errxtrace.Wrap(fmt.Sprintf("failed to delete physical blobs for file %s", file.ID), err)
 		}
 	}
 	return nil
+}
+
+// blobDeleteBatch is the set of row IDs a blob sweep is removing, for the
+// #2241 shared-key guard.
+func blobDeleteBatch(files []*models.FileEntity) map[string]bool {
+	batch := make(map[string]bool, len(files))
+	for _, file := range files {
+		if file != nil {
+			batch[file.ID] = true
+		}
+	}
+	return batch
 }
 
 // DeletePhysicalFilesForTenant deletes every physical blob (and its
@@ -299,14 +321,25 @@ func (s *FileService) DeletePhysicalFilesForTenant(ctx context.Context, tenantID
 		return errxtrace.Wrap("failed to list files for tenant", err)
 	}
 
+	// Narrow to the rows this hard-delete actually removes BEFORE building the
+	// guard's batch: the listing is installation-wide, and a batch built from it
+	// would tell the guard that another tenant's row is "ours" and hand it that
+	// tenant's bytes to delete. Cross-tenant sharing is not hypothetical — legacy
+	// flat keys predate the #1793 tenant prefix.
+	owned := make([]*models.FileEntity, 0, len(files))
 	for _, file := range files {
 		if file == nil || file.TenantID != tenantID {
 			continue
 		}
+		owned = append(owned, file)
+	}
+	batch := blobDeleteBatch(owned)
+
+	for _, file := range owned {
 		if file.File == nil || file.File.OriginalPath == "" {
 			continue
 		}
-		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType, batch); err != nil {
 			return errxtrace.Wrap(fmt.Sprintf("failed to delete physical blobs for file %s", file.ID), err)
 		}
 	}
@@ -321,9 +354,36 @@ func (s *FileService) DeletePhysicalFilesForTenant(ctx context.Context, tenantID
 // row still cleans up cleanly. The thumbnail-key derivation only knows
 // the new layout; an unbackfilled row's legacy thumbnails are deleted
 // best-effort by the backfill itself.
-func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, tenantID, fileID, filePath, mimeType string) error {
-	// Delete the original file
-	if err := s.deletePhysicalFile(ctx, filePath); err != nil {
+//
+// `batch` is the set of file-row IDs this caller is removing. It exists for the
+// SHARED-KEY guard below and nothing else; nil is correct for a caller whose
+// row is already gone from the table.
+func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, tenantID, fileID, filePath, mimeType string, batch map[string]bool) error {
+	// SHARED-KEY GUARD (#2241). A blob key is NOT row-unique: uploads minted
+	// before #2241 are keyed `<sanitized-name>-<unix SECONDS><ext>` with no
+	// group segment, no row segment and no randomness, so two rows — two
+	// members of different groups, one user multi-selecting two same-named
+	// files — can legitimately share one key. Deleting the blob by key would
+	// destroy the bytes of every OTHER row pointing at it, and `files` has no
+	// soft-delete and no trash: that loss is irreversible.
+	//
+	// New uploads carry a UUID and cannot collide, but the rows already sitting
+	// in deployed databases can, forever. So the delete asks the question
+	// directly, every time: does a row OUTSIDE this caller's batch still
+	// reference this blob? If so the bytes stay, and the blob is simply left
+	// behind — an orphan the GC (#2237) will reclaim once the last owner is
+	// gone. Leaking a blob is recoverable; destroying a live file's bytes is
+	// not, so the guard fails in that direction on purpose.
+	shared, err := s.blobSharedOutsideBatch(ctx, filePath, batch)
+	if err != nil {
+		// FAIL CLOSED: if we cannot prove the key unshared, we do not delete
+		// the bytes. The row is already (or about to be) gone either way.
+		return errxtrace.Wrap("failed to check whether the blob is shared by other file rows", err)
+	}
+	if shared {
+		slog.WarnContext(ctx, "keeping a blob shared by another file row (#2241)",
+			"file_id", fileID, "tenant_id", tenantID, "blob_key", filePath)
+	} else if err := s.deletePhysicalFile(ctx, filePath); err != nil {
 		return errxtrace.Wrap("failed to delete original file", err)
 	}
 
@@ -345,6 +405,39 @@ func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, tenan
 	}
 
 	return nil
+}
+
+// blobSharedOutsideBatch reports whether any file row OTHER than the ones in
+// `batch` still references blobKey (#2241).
+//
+// IDs, not a count: the callers are deleting a BATCH (a group purge, a tenant
+// hard-delete) and the rows in that batch are still in the table when the blobs
+// are swept, so "how many rows reference this key" cannot answer the question
+// without arithmetic over the batch — and arithmetic that is subtly wrong here
+// destroys user data. Asking for the ids and subtracting the batch cannot be
+// wrong by an off-by-one.
+//
+// A caller whose row is already deleted passes a nil batch: then ANY id that
+// comes back is somebody else's.
+//
+// The lookup is service-mode (RLS-bypassing) and deliberately NOT tenant-scoped
+// — legacy flat keys predate the #1793 tenant prefix, so the row sharing a key
+// can live in another tenant entirely, and a tenant-scoped check would not see
+// the very row whose bytes are at stake.
+func (s *FileService) blobSharedOutsideBatch(ctx context.Context, blobKey string, batch map[string]bool) (bool, error) {
+	if blobKey == "" {
+		return false, nil
+	}
+	ids, err := s.factorySet.FileRegistryFactory.CreateServiceRegistry().ListIDsByOriginalPath(ctx, blobKey)
+	if err != nil {
+		return false, err
+	}
+	for _, id := range ids {
+		if !batch[id] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // deletePhysicalFile is the unified implementation for deleting physical files

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -243,6 +243,72 @@ func TestFileService_DeletePhysicalFilesForGroup_SharedBlobKey(t *testing.T) {
 		qt.Commentf("purging group-1 destroyed group-2's live file bytes"))
 }
 
+// The tenant hard-delete is the one sweep where a CROSS-TENANT collision is
+// reachable, and it is not hypothetical: legacy flat keys predate the #1793
+// tenant prefix (`receipt-1783824560.jpg`, no `t/<tenant>/` at all), so two rows
+// in two DIFFERENT tenants can reference one blob. An unbackfilled installation
+// is full of them.
+//
+// It is also the sweep most likely to get the guard wrong: it lists files
+// INSTALLATION-WIDE and filters by tenant in application code, so a batch built
+// from the raw listing would tell the guard that the other tenant's row is
+// "ours" and hand it that tenant's bytes to delete.
+func TestFileService_DeletePhysicalFilesForTenant_SharedLegacyKeyAcrossTenants(t *testing.T) {
+	c := qt.New(t)
+	ctx := newTestContext()
+
+	tempDir := c.TempDir()
+	uploadLocation := "file://" + tempDir + "?create_dir=1"
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	}
+
+	factorySet := memory.NewFactorySet()
+	service := NewFileService(factorySet, uploadLocation)
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+
+	// A legacy, un-prefixed key — the only shape that can cross a tenant boundary.
+	const shared = "receipt-1783824560.jpg"
+	const doomed = "doomed-1783824560.jpg"
+	c.Assert(b.WriteAll(ctx, shared, []byte("tenant-2's only copy"), nil), qt.IsNil)
+	c.Assert(b.WriteAll(ctx, doomed, []byte("purge me"), nil), qt.IsNil)
+
+	mk := func(tenantID, key string) {
+		c.Helper()
+		_, err := fileReg.Create(ctx, models.FileEntity{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				TenantID: tenantID, GroupID: "group-1", CreatedByUserID: "user-1",
+			},
+			Title: "f", Type: models.FileTypeImage,
+			File: &models.File{Path: "f", OriginalPath: key, Ext: ".jpg", MIMEType: "image/jpeg"},
+		})
+		c.Assert(err, qt.IsNil)
+	}
+	mk("tenant-1", doomed)
+	mk("tenant-1", shared)
+	mk("tenant-2", shared) // the row whose bytes must survive tenant-1's hard-delete
+
+	c.Assert(service.DeletePhysicalFilesForTenant(ctx, "tenant-1"), qt.IsNil)
+
+	exists, err := b.Exists(ctx, doomed)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse,
+		qt.Commentf("the hard-deleted tenant's own blob was leaked"))
+
+	exists, err = b.Exists(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsTrue,
+		qt.Commentf("hard-deleting tenant-1 destroyed tenant-2's live file bytes"))
+
+	got, err := b.ReadAll(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(got), qt.Equals, "tenant-2's only copy")
+}
+
 func TestFileService_DeleteFileWithPhysical_FileNotFound(t *testing.T) {
 	c := qt.New(t)
 	ctx := newTestContext()

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -104,6 +104,145 @@ func TestFileService_DeleteFileWithPhysical(t *testing.T) {
 	c.Assert(exists, qt.IsFalse)
 }
 
+// TestFileService_SharedBlobKey_DeleteKeepsTheOtherRowsBytes is the #2241
+// regression test, and it is about the rows ALREADY IN DEPLOYED DATABASES.
+//
+// New uploads carry a UUID and cannot collide. The rows written before that
+// fix can, forever: their key is `<sanitized-name>-<unix SECONDS><ext>`, so two
+// members of two different groups who uploaded `receipt.jpg` in the same second
+// have two DISTINCT file rows pointing at ONE blob. No code change can
+// un-collide them.
+//
+// Every blob delete goes by key, and `files` has no soft-delete and no trash, so
+// before the guard, deleting either row destroyed the other, still-live file's
+// bytes — irreversibly, with the surviving row left pointing at nothing.
+//
+// The blob may only die with its LAST owner.
+func TestFileService_SharedBlobKey_DeleteKeepsTheOtherRowsBytes(t *testing.T) {
+	c := qt.New(t)
+	ctx := newTestContext()
+
+	tempDir := c.TempDir()
+	uploadLocation := "file://" + tempDir + "?create_dir=1"
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	}
+
+	factorySet := memory.NewFactorySet()
+	registrySet, err := factorySet.CreateUserRegistrySet(ctx)
+	c.Assert(err, qt.IsNil)
+	service := NewFileService(factorySet, uploadLocation)
+
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+
+	// The one blob both rows point at — a legacy, second-granularity key.
+	const shared = "t/test-tenant-id/files/receipt-1783824560.jpg"
+	c.Assert(b.WriteAll(ctx, shared, []byte("the only copy of the user's receipt"), nil), qt.IsNil)
+
+	mk := func(title string) *models.FileEntity {
+		c.Helper()
+		f, err := registrySet.FileRegistry.Create(ctx, models.FileEntity{
+			Title: title,
+			Type:  models.FileTypeImage,
+			File: &models.File{
+				Path: title, OriginalPath: shared, Ext: ".jpg", MIMEType: "image/jpeg",
+			},
+		})
+		c.Assert(err, qt.IsNil)
+		return f
+	}
+	first := mk("receipt-a")
+	second := mk("receipt-b")
+
+	// Deleting the FIRST row must not touch the bytes: the second row is still
+	// live and still points at them.
+	c.Assert(service.DeleteFileWithPhysical(ctx, first.ID), qt.IsNil)
+
+	_, err = registrySet.FileRegistry.Get(ctx, first.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	exists, err := b.Exists(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsTrue,
+		qt.Commentf("deleting one row destroyed the other live file's only copy — this is #2241"))
+
+	// And the survivor is not merely a row: its bytes are readable.
+	got, err := b.ReadAll(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(got), qt.Equals, "the only copy of the user's receipt")
+
+	// The LAST owner takes the blob with it — the guard must not leak the blob
+	// forever, it must only defer.
+	c.Assert(service.DeleteFileWithPhysical(ctx, second.ID), qt.IsNil)
+
+	exists, err = b.Exists(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse,
+		qt.Commentf("the last owner is gone, so nothing references the blob and it must not be leaked"))
+}
+
+// A group purge sweeps blobs while the rows it is purging are STILL IN THE
+// TABLE (the GroupPurger removes them afterwards). So the shared-key guard has
+// to distinguish "this key is referenced by a row I am deleting" from "this key
+// is referenced by somebody else's row" — and get it right in BOTH directions:
+//
+//   - a purged group's own blobs must actually be cleaned up (a naive
+//     "is anyone pointing at this?" check sees the row itself and leaks
+//     every blob in the installation, forever);
+//   - a blob shared with a row in ANOTHER group must survive the purge.
+func TestFileService_DeletePhysicalFilesForGroup_SharedBlobKey(t *testing.T) {
+	c := qt.New(t)
+	ctx := newTestContext()
+
+	tempDir := c.TempDir()
+	uploadLocation := "file://" + tempDir + "?create_dir=1"
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	}
+
+	factorySet := memory.NewFactorySet()
+	service := NewFileService(factorySet, uploadLocation)
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+
+	const doomed = "t/tenant-1/files/doomed-1783824560.jpg"
+	const shared = "t/tenant-1/files/receipt-1783824560.jpg"
+	c.Assert(b.WriteAll(ctx, doomed, []byte("purge me"), nil), qt.IsNil)
+	c.Assert(b.WriteAll(ctx, shared, []byte("keep me"), nil), qt.IsNil)
+
+	mk := func(groupID, key string) {
+		c.Helper()
+		_, err := fileReg.Create(ctx, models.FileEntity{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				TenantID: "tenant-1", GroupID: groupID, CreatedByUserID: "user-1",
+			},
+			Title: "f", Type: models.FileTypeImage,
+			File: &models.File{Path: "f", OriginalPath: key, Ext: ".jpg", MIMEType: "image/jpeg"},
+		})
+		c.Assert(err, qt.IsNil)
+	}
+	mk("group-1", doomed) // only group-1 points at this
+	mk("group-1", shared) // ...and group-1 shares this one with group-2
+	mk("group-2", shared)
+
+	c.Assert(service.DeletePhysicalFilesForGroup(ctx, "tenant-1", "group-1"), qt.IsNil)
+
+	exists, err := b.Exists(ctx, doomed)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse,
+		qt.Commentf("the purged group's own blob was leaked — the guard mistook the row for somebody else's"))
+
+	exists, err = b.Exists(ctx, shared)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsTrue,
+		qt.Commentf("purging group-1 destroyed group-2's live file bytes"))
+}
+
 func TestFileService_DeleteFileWithPhysical_FileNotFound(t *testing.T) {
 	c := qt.New(t)
 	ctx := newTestContext()

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -240,7 +240,7 @@ func (p OrphanFileGCProbes) forLinkType(linkType string) EntityExistenceProbe {
 type OrphanFileGCFileRegistry interface {
 	ListOrphanCandidates(ctx context.Context, olderThan time.Time, after registry.OrphanCandidateCursor, limit int) ([]*models.FileEntity, error)
 	ExistingIDs(ctx context.Context, ids []string) ([]string, error)
-	CountByOriginalPath(ctx context.Context, originalPath string) (int, error)
+	ListIDsByOriginalPath(ctx context.Context, originalPath string) ([]string, error)
 	Get(ctx context.Context, id string) (*models.FileEntity, error)
 }
 
@@ -957,32 +957,39 @@ func (w *OrphanFileGCWorker) verifyRowCandidate(ctx context.Context, file *model
 	}
 
 	// R8 — SOLE OWNERSHIP OF THE BLOB. The row delete is RLS-narrow, but the
-	// blob delete that follows it inside DeleteFileWithPhysical is KEY-scoped —
-	// and a blob key is NOT row-unique. An upload key is
-	// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>`: no group segment,
-	// no row segment, no randomness (internal/filekit.UploadFileName), and there
-	// is no unique index on files.original_path. Two uploads of the same
-	// filename inside one tenant in the same second — two members of different
-	// groups; one user multi-selecting two same-named files — produce two
-	// DISTINCT rows sharing one key. Deleting the orphan's blob would then
-	// destroy the bytes of a LIVE row (a standalone file, #2235, is not even
-	// reachable by any other gate here), irreversibly: `files` has no
-	// soft-delete and there is no trash.
+	// blob delete that follows it inside DeleteFileWithPhysical is KEY-scoped,
+	// and a blob key is NOT row-unique: there is no unique index on
+	// files.original_path.
+	//
+	// Uploads minted since #2241 carry a server-side UUID and cannot collide.
+	// The rows already sitting in deployed databases can, forever: their key is
+	// `t/<tenant>/files/<sanitized-name>-<unix SECONDS><ext>` — no group segment,
+	// no row segment, no randomness — so two members of different groups who
+	// uploaded the same filename in one second have two DISTINCT rows on ONE
+	// key. Deleting this orphan's blob would then destroy the bytes of a LIVE
+	// row (a standalone file, #2235, is not even reachable by any other gate
+	// here), irreversibly: `files` has no soft-delete and there is no trash.
 	//
 	// So: unless this row is the ONLY one referencing its key, the file is KEPT
-	// whole. Under-collecting a rare same-second filename collision is free;
-	// destroying a live file's bytes is not. There is no TOCTOU here — the key
-	// embeds the SECOND it was minted in, and a candidate must be at least
-	// MinOrphanFileGCMinAge old, so a fresh upload can never mint a colliding
-	// key while the tick runs; a restore, the only other writer that can
-	// re-introduce one, blocks the whole tenant via the concurrency gate.
+	// whole. Under-collecting a rare legacy collision is free; destroying a live
+	// file's bytes is not. DeleteFileWithPhysical re-asserts the same guard
+	// (#2241) — this one is here so the GC never even reports such a row as a
+	// candidate, and so a delete-mode tick cannot spend its budget on rows the
+	// primitive would refuse anyway.
+	//
+	// No TOCTOU: a candidate must be at least MinOrphanFileGCMinAge old, and no
+	// live writer can mint a key colliding with a legacy one (new keys are
+	// UUIDs); a restore, the only writer that can re-introduce an archived key,
+	// blocks the whole tenant via the concurrency gate.
 	if file.File != nil && file.OriginalPath != "" {
-		refs, cerr := w.deps.Files.CountByOriginalPath(ctx, file.OriginalPath)
+		refs, cerr := w.deps.Files.ListIDsByOriginalPath(ctx, file.OriginalPath)
 		if cerr != nil {
 			return orphanRowVerdict{}, cerr // transient: abort the tick, never guess
 		}
-		if refs != 1 {
-			return orphanRowVerdict{reason: orphanGCSkipSharedBlobKey}, nil
+		for _, id := range refs {
+			if id != file.ID {
+				return orphanRowVerdict{reason: orphanGCSkipSharedBlobKey}, nil
+			}
 		}
 	}
 

--- a/go/services/orphan_file_gc_worker.go
+++ b/go/services/orphan_file_gc_worker.go
@@ -986,10 +986,15 @@ func (w *OrphanFileGCWorker) verifyRowCandidate(ctx context.Context, file *model
 		if cerr != nil {
 			return orphanRowVerdict{}, cerr // transient: abort the tick, never guess
 		}
-		for _, id := range refs {
-			if id != file.ID {
-				return orphanRowVerdict{reason: orphanGCSkipSharedBlobKey}, nil
-			}
+		// The ONLY shape that proceeds is exactly [this row]. Not "no id that
+		// isn't mine" — that quietly passes an EMPTY result, and an empty result
+		// means the lookup could not even see the row we are holding. Whatever
+		// produced that (a replica that has not caught up, a concurrent delete, a
+		// registry bug), it is a claim about the world we just contradicted, and
+		// "I cannot see my own row" is not evidence that a blob is safe to
+		// destroy. Fail closed, exactly as the old refs != 1 check did.
+		if len(refs) != 1 || refs[0] != file.ID {
+			return orphanRowVerdict{reason: orphanGCSkipSharedBlobKey}, nil
 		}
 	}
 

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -1007,7 +1007,7 @@ func TestOrphanFileGC_ReportModeDeletesNothing(t *testing.T) {
 		linkType: "commodity",
 		linkID:   "gone",
 		linkMeta: "images",
-		blobKey:  blobkeys.BuildFileUploadKey(f.tenantID, "orphan.jpg"),
+		blobKey:  blobkeys.BuildFileBlobKey(f.tenantID, "orphan", ".jpg"),
 	})
 	thumbKey := blobkeys.BuildThumbnailBlobKey(f.tenantID, "no-such-file-id", "small")
 	f.writeBlob(thumbKey, []byte("thumb"))
@@ -1061,8 +1061,8 @@ func TestOrphanFileGC_NeverSweepsAnythingButThumbnails(t *testing.T) {
 	f := newGCFixture(c)
 
 	keys := map[string]string{
-		"#2121 pending-import source blob": blobkeys.BuildRestoreUploadKey(f.tenantID, "backup.inb"),
-		"fresh upload (blob-before-row)":   blobkeys.BuildFileUploadKey(f.tenantID, "invoice-123.pdf"),
+		"#2121 pending-import source blob": blobkeys.BuildRestoreUploadKey(f.tenantID, "blob-id", "backup.inb"),
+		"fresh upload (blob-before-row)":   blobkeys.BuildFileBlobKey(f.tenantID, "invoice-123", ".pdf"),
 		"failed-export artifact":           blobkeys.BuildBackupBlobKey(f.tenantID, "full", "20260101"),
 		"seed fixture":                     blobkeys.BuildSeedKey(f.tenantID, "seed-abc.jpg"),
 		"legacy flat key (pre-#1793)":      "thumbnails/legacy-file-id_small.jpg",
@@ -1241,7 +1241,7 @@ func TestOrphanFileGC_SweepsCrashWindowOrphanRows(t *testing.T) {
 			c := qt.New(t)
 			f := newGCFixture(c)
 
-			blobKey := blobkeys.BuildFileUploadKey(f.tenantID, "orphan-"+linkType+".jpg")
+			blobKey := blobkeys.BuildFileBlobKey(f.tenantID, "orphan-"+linkType, ".jpg")
 			file := f.seedFile(seedFileOpts{
 				linkType: linkType,
 				linkID:   "id-of-an-entity-that-no-longer-exists",
@@ -1288,7 +1288,7 @@ func TestOrphanFileGC_IsIdempotent(t *testing.T) {
 	c := qt.New(t)
 	f := newGCFixture(c)
 
-	blobKey := blobkeys.BuildFileUploadKey(f.tenantID, "orphan.jpg")
+	blobKey := blobkeys.BuildFileBlobKey(f.tenantID, "orphan", ".jpg")
 	file := f.seedFile(seedFileOpts{
 		linkType: "commodity", linkID: "gone", linkMeta: "images", blobKey: blobKey,
 	})
@@ -1425,7 +1425,7 @@ func TestOrphanFileGC_SharedBlobKeyIsNeverSwept(t *testing.T) {
 	f := newGCFixture(c)
 
 	// The exact collision production mints: same tenant, same basename, same second.
-	shared := blobkeys.BuildFileUploadKey(f.tenantID, "receipt-1783824560.jpg")
+	shared := blobkeys.BuildFileBlobKey(f.tenantID, "receipt-1783824560", ".jpg")
 
 	otherGroupID := f.newGroup(f.tenantID, "group-b", models.LocationGroupStatusActive)
 	live := f.seedFile(seedFileOpts{
@@ -1454,7 +1454,7 @@ func TestOrphanFileGC_SoleOwnedBlobKeyIsStillSwept(t *testing.T) {
 	c := qt.New(t)
 	f := newGCFixture(c)
 
-	key := blobkeys.BuildFileUploadKey(f.tenantID, "sole-1783824560.jpg")
+	key := blobkeys.BuildFileBlobKey(f.tenantID, "sole-1783824560", ".jpg")
 	orphan := f.seedFile(seedFileOpts{
 		linkType: "commodity", linkID: "gone", linkMeta: "images", blobKey: key,
 	})

--- a/go/services/orphan_file_gc_worker_test.go
+++ b/go/services/orphan_file_gc_worker_test.go
@@ -1448,6 +1448,48 @@ func TestOrphanFileGC_SharedBlobKeyIsNeverSwept(t *testing.T) {
 		qt.Commentf("an orphan whose blob key is shared must be KEPT WHOLE, not half-deleted"))
 }
 
+// blindRefsRegistry answers "nobody references that key" for a row we are
+// holding in our hand — the shape a lagging read replica, a concurrent delete,
+// or a registry bug would produce.
+type blindRefsRegistry struct {
+	services.OrphanFileGCFileRegistry
+}
+
+func (blindRefsRegistry) ListIDsByOriginalPath(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+// FAIL CLOSED on an empty answer. The sole-ownership gate proceeds on EXACTLY
+// one shape — [this row] — and on nothing else.
+//
+// An empty result is not "the blob is unreferenced, help yourself": it is the
+// lookup failing to see the very row the worker is holding. Whatever produced
+// it, the worker has just been handed a claim about the world that it can
+// directly contradict, and "I cannot see my own row" is not evidence that a
+// blob is safe to destroy. A `for _, id := range refs { if id != file.ID }`
+// loop reads as if it checks this and silently passes the empty case.
+func TestOrphanFileGC_EmptyRefsFailsClosed(t *testing.T) {
+	c := qt.New(t)
+	f := newGCFixture(c)
+
+	key := blobkeys.BuildFileBlobKey(f.tenantID, "sole-1783824560", ".jpg")
+	orphan := f.seedFile(seedFileOpts{
+		linkType: "commodity", linkID: "gone", linkMeta: "images", blobKey: key,
+	})
+
+	deps := f.deps()
+	deps.Files = blindRefsRegistry{deps.Files}
+
+	worker := services.NewOrphanFileGCWorker(deps,
+		services.WithOrphanFileGCMode(services.OrphanFileGCModeDelete))
+	worker.RunOnce(f.ctx)
+
+	c.Assert(f.fileExists(orphan.ID), qt.IsTrue,
+		qt.Commentf("the GC deleted a row whose blob ownership it could not establish"))
+	c.Assert(f.blobExists(key), qt.IsTrue,
+		qt.Commentf("an empty ownership answer was read as a licence to destroy the bytes"))
+}
+
 // The guard must not turn into a blanket refusal: an orphan that solely owns its
 // key is still collected, blob and all.
 func TestOrphanFileGC_SoleOwnedBlobKeyIsStillSwept(t *testing.T) {

--- a/go/services/storage_usage_service_test.go
+++ b/go/services/storage_usage_service_test.go
@@ -80,7 +80,7 @@ func (s *stubFileRegistry) ExistingIDs(context.Context, []string) ([]string, err
 	panic("not implemented")
 }
 
-func (s *stubFileRegistry) CountByOriginalPath(context.Context, string) (int, error) {
+func (s *stubFileRegistry) ListIDsByOriginalPath(context.Context, string) ([]string, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
Closes #2241.

## The bug

A blob key was minted from the filename plus a **second**-granularity timestamp:

```
t/<tenant>/files/<sanitized-name>-<unix seconds><ext>
```

No group segment, no row segment, no randomness — and no unique index on `files.original_path`. Two uploads of the same filename inside one tenant in the same second (two members of **different groups**; one user multi-selecting two same-named files) produced two **distinct file rows pointing at one blob**.

Every blob delete goes **by key**. `files` has no soft-delete and there is no trash. So deleting one of those rows **destroyed the other, still-live file's bytes** — irreversibly, leaving a row pointing at nothing. Reachable from every delete path: a direct file delete, a commodity/area/location cascade, a `full_replace` restore sweep, a group purge, a tenant hard-delete. The same collision on the write side let a second upload silently **overwrite** the first.

## Two fixes, because either alone is insufficient

**1. Keys are unique by construction.** Uploads now mint a server-side UUID and key the blob `t/<tenant>/files/<uuid><ext>` — the shape the restore importer already used, so readers already handle it. The human filename stays where it belongs, on `Path`/`Title`. `BuildFileUploadKey` (the filename-keyed builder) is **removed**, not deprecated: leaving it in the package is leaving the footgun loaded. Restore uploads get the same treatment — a restore blob has **no owning row of any kind** (#2121), so nothing would ever have noticed an overwrite, and a pending import would have restored bytes its user never uploaded.

**2. The delete asks first.** New keys cannot collide, but **the rows already in deployed databases can, forever** — no code change un-collides them. So the shared-key guard lives in the one primitive every delete path funnels through: unless *no row outside the caller's batch* references the key, the bytes stay. The blob dies with its **last** owner, so nothing is leaked either — and if it somehow is, the orphan GC (#2237) reclaims it. Leaking a blob is recoverable; destroying a live file's bytes is not.

The batch is a **set of row IDs, not a count**. Group and tenant purges sweep blobs while their own rows are *still in the table*, so "how many rows point at this key" cannot answer the question without arithmetic over the batch — and arithmetic that is subtly wrong there either leaks every blob in the installation or destroys another group's files. `FileRegistry.CountByOriginalPath` → `ListIDsByOriginalPath`, so the question is answerable exactly. (The #2237 GC's own sole-ownership check moves to the same method.)

## Drive-by

Found while tracing where `original_path` actually flows: the frontend handed it to the browser as the **download name**, so saving a file wrote the blob key — a path-shaped string, and now a UUID — instead of the name the user gave it. `FilePreviewDialog` now builds the name from `path`/`title` + `ext`.

## What is deliberately NOT here

- **No unique index on `original_path`**, and no dedupe backfill. Adding one requires rewriting already-colliding rows, and the guard makes those rows *safe* without touching them. Filing a follow-up is the honest move; a migration that rewrites user blobs to satisfy an index is not something to bundle into a data-loss fix.
- **No rewrite of existing keys.** Legacy and pre-#2241 keys stay readable exactly where they are; the guard is what makes them safe.

## Tests

Every guard mutation-verified — revert it and the named test reds:

| Test | Mutation that must red it |
|---|---|
| `TestUploads_file_sameNameSameSecond_distinctBlobKeys` (clock frozen, so the collision is certain rather than a race) | mint the key from the filename again |
| `TestFileService_SharedBlobKey_DeleteKeepsTheOtherRowsBytes` | drop the shared-key guard |
| `TestFileService_DeletePhysicalFilesForGroup_SharedBlobKey` | let the purge forget its own batch (leaks every blob) |
| `FilePreviewDialog` download-name tests | hand `original_path` back to the browser |

Also pinned: the blob dies with the **last** owner (the guard defers, it does not leak); a purge cleans its own blobs *and* spares one shared with another group; `ListIDsByOriginalPath` sees the sharer in another group and another tenant (legacy flat keys predate the #1793 tenant prefix, so a tenant-scoped check would miss the very row whose bytes are at stake).

Gates: `go build` both tags ✅ · `golangci-lint` ✅ 0 issues · `nolintguard` / `qtlint` ✅ · `go test ./...` ✅ 83 packages · `tsc` ✅ · `eslint` ✅ · `prettier` ✅ · `vitest` ✅ 1396 tests · swagger + FE codegen regenerated (the model comment was drifting the OpenAPI description).

https://claude.ai/code/session_013wnhe7acR8KrzcLDw3UW8y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Downloaded files now use the visible filename (plus extension) instead of an internal storage identifier.
  - Same-name uploads in the same second no longer overwrite each other.
  - File cleanup and orphan GC now preserve shared content until the last reference is removed.
  - Restore uploads now use unique storage identifiers while keeping recognizable filenames.
- **Documentation**
  - Clarified that the stored “original path” is an internal storage key, not the uploaded filename.
- **Tests**
  - Added/updated coverage to prevent filename/key regressions and shared-blob deletion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->