### PR TITLE
fix(files,backup): close every blob-delete path that bypasses the shared-key guard (#2250)

### DIFF
--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -31,6 +31,7 @@ import { useDeleteFile, useFile } from "@/features/files/hooks"
 import { isImageMime, isPdfMime } from "@/features/files/constants"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
+import { appendExt } from "@/lib/filename"
 import { formatDateTime } from "@/lib/intl"
 
 // Entry point for the file detail surface. EVERY file — image, PDF, and
@@ -102,7 +103,7 @@ export function FileDetailSheet({
   // Backend may return path="" for files attached via the unified upload+linkage
   // flow (#1448), so gate on path being truthy — an empty path means we have no
   // displayable filename even if `ext` is set (otherwise we'd render a stray ".pdf").
-  const filename = file?.path ? `${file.path}${file.ext ?? ""}` : ""
+  const filename = file?.path ? appendExt(file.path, file.ext) : ""
 
   async function onDelete() {
     if (!file) return

--- a/frontend/src/components/files/FilePreviewDialog.tsx
+++ b/frontend/src/components/files/FilePreviewDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog"
 import type { ListedFile } from "@/features/files/api"
 import { isImageMime, isPdfMime } from "@/features/files/constants"
+import { appendExt } from "@/lib/filename"
 import { formatBytes } from "@/lib/intl"
 
 // FilePreviewDialog mirrors `design-mocks/src/components/FilePreviewDialog.tsx`
@@ -42,14 +43,6 @@ export interface FilePreviewDialogProps {
   // responsible for the confirm + mutation; the dialog closes itself
   // straight after `onDelete` is invoked.
   onDelete?: (fileId: string) => void
-}
-
-// appendExt gives `name` the extension `ext`, unless it already ends with it.
-// Case-insensitive, because a user who typed "Receipt.PDF" gets one extension,
-// not two.
-function appendExt(name: string, ext: string | undefined | null): string {
-  if (!ext) return name
-  return name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`
 }
 
 export function FilePreviewDialog({ file, onClose, onDelete }: FilePreviewDialogProps) {

--- a/frontend/src/lib/__tests__/filename.test.ts
+++ b/frontend/src/lib/__tests__/filename.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { appendExt } from "@/lib/filename"
+
+// `files.path` is nominally the name WITHOUT its extension, but the API accepts
+// one that carries it, so concatenating blindly rendered — and downloaded —
+// `receipt.pdf.pdf` (#2250).
+describe("appendExt", () => {
+  it("appends a missing extension", () => {
+    expect(appendExt("receipt", ".pdf")).toBe("receipt.pdf")
+  })
+
+  it("does not double an extension already present", () => {
+    expect(appendExt("receipt.pdf", ".pdf")).toBe("receipt.pdf")
+  })
+
+  it("matches case-insensitively", () => {
+    expect(appendExt("Receipt.PDF", ".pdf")).toBe("Receipt.PDF")
+  })
+
+  it("appends a genuinely different extension", () => {
+    expect(appendExt("archive.tar", ".gz")).toBe("archive.tar.gz")
+  })
+
+  it("is a no-op without an extension or a name", () => {
+    expect(appendExt("receipt", undefined)).toBe("receipt")
+    expect(appendExt("", ".pdf")).toBe("")
+  })
+})

--- a/frontend/src/lib/filename.ts
+++ b/frontend/src/lib/filename.ts
@@ -1,0 +1,16 @@
+// appendExt gives `name` the extension `ext`, unless it already ends with it.
+//
+// `files.path` is NOMINALLY the name without its extension, but nothing enforces
+// that and the API accepts one that carries it ("receipt.pdf"), so concatenating
+// blindly renders — and offers for download — `receipt.pdf.pdf` (#2250).
+//
+// Case-insensitive: a user who typed "Receipt.PDF" gets one extension, not two.
+//
+// The server does the same for the `Content-Disposition` header
+// (filekit.DownloadName), and that is the one that DECIDES the saved filename —
+// per RFC 6266 the header takes priority over an <a download> attribute. This
+// helper keeps the displayed name and the download attribute honest alongside it.
+export function appendExt(name: string, ext: string | undefined | null): string {
+  if (!name || !ext) return name
+  return name.toLowerCase().endsWith(ext.toLowerCase()) ? name : `${name}${ext}`
+}

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/backup/export"
 	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/internal/filekit"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
@@ -298,7 +299,7 @@ func (api *exportsAPI) downloadExport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set streaming headers
-	filename := fileEntity.Path + fileEntity.Ext
+	filename := filekit.DownloadName(fileEntity.Path, fileEntity.Ext)
 	downloadutils.SetStreamingHeaders(w, fileEntity.MIMEType, attrs.Size, filename)
 
 	// Open and stream the file

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -21,6 +21,7 @@ import (
 	"github.com/denisvmedia/inventario/apiserver/internal/downloadutils"
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/assets"
+	"github.com/denisvmedia/inventario/internal/filekit"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/internal/textutils"
 	"github.com/denisvmedia/inventario/jsonapi"
@@ -777,7 +778,7 @@ func (api *filesAPI) downloadOriginalFile(w http.ResponseWriter, r *http.Request
 		disposition = services.DispositionInline
 	}
 
-	api.streamFileFromStorage(w, r, filePath, mimeType, file.Path+file.Ext, disposition)
+	api.streamFileFromStorage(w, r, filePath, mimeType, filekit.DownloadName(file.Path, file.Ext), disposition)
 }
 
 // downloadThumbnail downloads a thumbnail file (always JPEG) with deferred generation support

--- a/go/apiserver/files_download_name_test.go
+++ b/go/apiserver/files_download_name_test.go
@@ -1,0 +1,104 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// TestDownload_ContentDispositionFilename asserts the filename the user actually
+// gets — the `Content-Disposition` header on the real download response (#2250).
+//
+// This is the boundary that decides. `files.path` is nominally the name without
+// its extension, but the API accepts one that carries it, and the handler used to
+// send `file.Path + file.Ext` — so a row with path="receipt.pdf", ext=".pdf" made
+// the browser save `receipt.pdf.pdf`.
+//
+// A frontend fix could not repair that, and this is the lesson the test encodes:
+// per RFC 6266 the header takes PRIORITY over an <a download> attribute, so a
+// test that asserted the DOM attribute passed while the saved filename was
+// unchanged. Assert where the outcome is decided, not where the value was set.
+func TestDownload_ContentDispositionFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		ext  string
+		want string
+	}{
+		{
+			name: "path already carries the extension",
+			path: "receipt.pdf",
+			ext:  ".pdf",
+			want: `attachment; filename=receipt.pdf`,
+		},
+		{
+			name: "path without an extension gets one",
+			path: "receipt",
+			ext:  ".pdf",
+			want: `attachment; filename=receipt.pdf`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			params, testUser, testGroup := newParams()
+			handler := apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false})
+
+			// Seed a file row plus its blob, exactly as an upload would leave them:
+			// the key is UUID-minted, the human name lives on Path.
+			ctx := appctx.WithUser(context.Background(), testUser)
+			registrySet := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+			ctx = appctx.WithGroup(ctx, testGroup)
+
+			blobKey := blobkeys.BuildFileBlobKey(testUser.TenantID, "f47ac10b-58cc-4372-a567-0e02b2c3d479", tt.ext)
+			bucket := must.Must(blob.OpenBucket(ctx, params.UploadLocation))
+			defer bucket.Close()
+			c.Assert(bucket.WriteAll(ctx, blobKey, []byte("%PDF-1.4 fake"), nil), qt.IsNil)
+
+			file := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+					TenantID: testUser.TenantID, GroupID: testGroup.ID, CreatedByUserID: testUser.ID,
+				},
+				Title: "Receipt",
+				Type:  models.FileTypeDocument,
+				File: &models.File{
+					Path: tt.path, OriginalPath: blobKey, Ext: tt.ext, MIMEType: "application/pdf",
+				},
+			}))
+
+			// Ask the API for a signed URL, then follow it — the same two steps the
+			// browser takes.
+			req := httptest.NewRequest(http.MethodPost,
+				"/api/v1/g/"+testGroup.Slug+"/files/"+file.ID+"/signed-url", bytes.NewReader(nil))
+			addTestUserAuthHeader(req, testUser.ID)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("body=%s", rr.Body.String()))
+
+			var signed jsonapi.SignedFileURLResponse
+			c.Assert(json.Unmarshal(rr.Body.Bytes(), &signed), qt.IsNil)
+
+			dl := httptest.NewRequest(http.MethodGet, signed.Attributes.URL, nil)
+			dlRR := httptest.NewRecorder()
+			handler.ServeHTTP(dlRR, dl)
+			c.Assert(dlRR.Code, qt.Equals, http.StatusOK, qt.Commentf("body=%s", dlRR.Body.String()))
+
+			c.Assert(dlRR.Header().Get("Content-Disposition"), qt.Equals, tt.want)
+		})
+	}
+}

--- a/go/backup/export/service_shared.go
+++ b/go/backup/export/service_shared.go
@@ -248,30 +248,12 @@ type exportFileMetaFields struct {
 	Tags             models.StringSlice
 }
 
-// DeleteExportFile is deprecated - export files are now managed through the
-// file entity system. Kept for backward compatibility.
-func (s *ExportService) DeleteExportFile(ctx context.Context, filePath string) error {
-	if filePath == "" {
-		return nil // Nothing to delete
-	}
-
-	b, err := blob.OpenBucket(ctx, s.uploadLocation)
-	if err != nil {
-		return errxtrace.Wrap("failed to open blob bucket", err)
-	}
-	defer func() {
-		if closeErr := b.Close(); closeErr != nil {
-			err = errxtrace.Wrap("failed to close blob bucket", closeErr)
-		}
-	}()
-
-	err = b.Delete(ctx, filePath)
-	if err != nil {
-		return errxtrace.Wrap("failed to delete export file", err)
-	}
-
-	return nil
-}
+// DeleteExportFile was REMOVED (#2250). It was a raw, unguarded blob delete by
+// key — "deprecated, kept for backward compatibility" — with no callers anywhere
+// in the tree. A blob key is not row-unique for rows written before #2241, so an
+// unguarded key delete is a loaded gun: it destroys the bytes of every other row
+// pointing at that key, irreversibly. Export blobs are deleted through the file
+// entity system, which asks who else owns the key first.
 
 // getFileSize gets the size of a file in blob storage.
 func (s *ExportService) getFileSize(ctx context.Context, filePath string) (int64, error) {

--- a/go/backup/inb_orphan_blob_test.go
+++ b/go/backup/inb_orphan_blob_test.go
@@ -148,3 +148,53 @@ func TestINBRestore_MergeUpdate_DeletesStaleBlob(t *testing.T) {
 	c.Assert(f.blobExists(c, srcKey), qt.IsFalse,
 		qt.Commentf("MergeUpdate must delete the superseded blob at the old key %s", srcKey))
 }
+
+// MergeUpdate must NOT delete the superseded blob when ANOTHER live file row
+// shares that stale key (#2250).
+//
+// The stale key is the EXISTING row's pre-#2241 key, which another row can
+// legitimately share (two same-named uploads in one second). Re-pointing the
+// restored row must not take the sharer's bytes with it — `files` has no
+// soft-delete.
+//
+// Without a test like this the guard is invisible: removing the whole
+// BlobSharedByOtherRows check from deleteSupersededBlob leaves every other
+// backup test green, because none of them plant a sharer on the stale key.
+func TestINBRestore_MergeUpdate_KeepsStaleBlobSharedByAnotherRow(t *testing.T) {
+	c := qt.New(t)
+	signer := testSigner(c)
+	f := newInbFixture(c)
+
+	const size = 4096
+	staleKey := "t/tenant-a/files/receipt-1783824560.jpg"
+	fileUUID, _ := f.attachCommodityFileAtKey(c, "images", staleKey, ".jpg", "image/jpeg", size)
+
+	// A SECOND live file row sharing the exact same blob key — the sharer whose
+	// bytes must survive. Service registry so it can carry a different group.
+	sharerReg := f.fs.FileRegistryFactory.CreateServiceRegistry()
+	sharer := must.Must(sharerReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "tenant-a", GroupID: "another-group", CreatedByUserID: f.user.ID,
+		},
+		Title: "sharer", Type: models.FileTypeImage,
+		File: &models.File{Path: "receipt", OriginalPath: staleKey, Ext: ".jpg", MIMEType: "image/jpeg"},
+	}))
+
+	blobKey, _ := f.runExport(c, signer)
+
+	final, err := restoreInbWithOptions(c, f, signer, blobKey, models.RestoreOptions{
+		Strategy: string(types.RestoreStrategyMergeUpdate),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.Status, qt.Equals, models.RestoreStatusCompleted, qt.Commentf("errors: %v", final.ErrorMessage))
+
+	// The restored row moved to its canonical key…
+	canonicalKey := blobkeys.BuildFileBlobKey("tenant-a", fileUUID, ".jpg")
+	restored := f.fileByUUID(c, fileUUID)
+	c.Assert(restored.File.OriginalPath, qt.Equals, canonicalKey)
+
+	// …but the stale key's bytes SURVIVE, because the sharer still points there.
+	c.Assert(f.blobExists(c, staleKey), qt.IsTrue,
+		qt.Commentf("MergeUpdate destroyed the bytes of a live file sharing the stale key %s", staleKey))
+	c.Assert(must.Must(sharerReg.Get(f.ctx, sharer.ID)).File.OriginalPath, qt.Equals, staleKey)
+}

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -902,10 +902,42 @@ func (w *inbWalker) staleBlobKeyForUpdate(action fileAction, refID string) strin
 // re-pointed the row to newBlobKey. A no-op when the key is unchanged, empty, or
 // no bucket is configured. Swallow+log: a failed cleanup must never fail an
 // otherwise-successful restore (issue #2125).
+//
+// SHARED-KEY GUARD (#2250). staleBlobKey is whatever key the EXISTING row
+// carried, and for a pre-#2241 row that is `<sanitized-name>-<unix SECONDS><ext>`
+// — a key another row can legitimately share (two members of different groups
+// who uploaded the same filename in one second). The new key is UUID-minted, so
+// `stale != new` is the NORMAL case for such a row and this delete always fires.
+// Without the guard, restoring one file destroys the other, still-live file's
+// bytes: `files` has no soft-delete and there is no trash.
+//
+// The guard lives in FileService for the delete paths that go through it; this
+// path does not, so it must ask the same question itself. Fail closed on any
+// doubt — an unswept blob is recoverable, a destroyed one is not.
+//
+// NO row is exempt from the check, and that is load-bearing: this runs AFTER
+// applyStrategyForFileModel has already re-pointed our row to newBlobKey, so
+// anything still holding staleBlobKey is by definition somebody else. (Asking
+// before the re-point would be useless — our own row would answer every time.
+// Excluding our row by id would be worse than useless: it reads as if it
+// protects something while matching nothing.)
 func (w *inbWalker) deleteSupersededBlob(staleBlobKey, newBlobKey string) {
 	if staleBlobKey == "" || staleBlobKey == newBlobKey || w.bucket == nil {
 		return
 	}
+
+	shared, err := w.proc.fileService().BlobSharedByOtherRows(w.ctx, staleBlobKey, "")
+	if err != nil {
+		slog.WarnContext(w.ctx, "keeping superseded file blob: could not establish sole ownership (#2250)",
+			"stale_blob_key", staleBlobKey, "new_blob_key", newBlobKey, "error", err.Error())
+		return
+	}
+	if shared {
+		slog.WarnContext(w.ctx, "keeping superseded file blob: another file row still references it (#2250)",
+			"stale_blob_key", staleBlobKey, "new_blob_key", newBlobKey)
+		return
+	}
+
 	if err := w.bucket.Delete(w.ctx, staleBlobKey); err != nil {
 		slog.WarnContext(w.ctx, "failed to delete superseded file blob after merge-update restore (best-effort)",
 			"stale_blob_key", staleBlobKey, "new_blob_key", newBlobKey, "error", err.Error())

--- a/go/backup/restore/processor/processor_shared.go
+++ b/go/backup/restore/processor/processor_shared.go
@@ -62,6 +62,21 @@ func NewRestoreOperationProcessor(restoreOperationID string, factorySet *registr
 	}
 }
 
+// fileService exposes the shared-key guard (#2250) to the restore importer.
+//
+// The importer deletes blobs directly — it supersedes the old blob of a row it
+// re-points during MergeUpdate — so it must ask the same question the
+// FileService delete paths ask before removing any bytes: does another file row
+// still reference this key? Pre-#2241 keys are shareable, and `files` has no
+// soft-delete, so the answer is the difference between reclaiming a blob and
+// destroying a live file.
+//
+// Constructed per call rather than cached: FileService is a thin façade over the
+// factory set, and the restore path builds one at most once per superseded blob.
+func (l *RestoreOperationProcessor) fileService() *services.FileService {
+	return services.NewFileService(l.factorySet, l.uploadLocation)
+}
+
 // Process drives the full restore lifecycle: status/step bookkeeping, blob open,
 // then the per-build decodeAndRestore (XML or `.inb`). The decode/verify/apply
 // body differs per format; everything around it is format-agnostic.

--- a/go/internal/filekit/filekit.go
+++ b/go/internal/filekit/filekit.go
@@ -60,6 +60,27 @@ func Extension(filePath string) string {
 	return getMultiPartExtension(filePath)
 }
 
+// DownloadName is the filename the user gets on disk: the human-readable Path
+// with its extension, without doubling one that is already there.
+//
+// `files.path` is NOMINALLY the name without its extension, but nothing enforces
+// that and the API accepts one that carries it ("receipt.pdf" round-trips
+// through the update validator). Concatenating blindly produced
+// `Content-Disposition: filename="receipt.pdf.pdf"` — and since the header takes
+// priority over the browser's `download` attribute (RFC 6266), no amount of
+// fixing the frontend could change what was actually saved (#2250).
+//
+// Case-insensitive: a user who typed "Receipt.PDF" gets one extension, not two.
+func DownloadName(path, ext string) string {
+	if ext == "" {
+		return path
+	}
+	if strings.HasSuffix(strings.ToLower(path), strings.ToLower(ext)) {
+		return path
+	}
+	return path + ext
+}
+
 func getMultiPartExtension(filePath string) string {
 	ext := filepath.Ext(filePath)                 // Get the last element of the path
 	filename := strings.TrimSuffix(filePath, ext) // Remove the extension from the filename

--- a/go/internal/filekit/filekit_test.go
+++ b/go/internal/filekit/filekit_test.go
@@ -68,3 +68,34 @@ func TestUploadFileNameWithCurrentTime(t *testing.T) {
 	ext := filepath.Ext(fileName)
 	c.Assert(filepath.Ext(result), qt.Equals, ext)
 }
+
+// The download filename is what the user gets on disk. `files.path` is nominally
+// the name WITHOUT its extension, but the API accepts one that carries it, and
+// concatenating blindly produced `receipt.pdf.pdf`.
+//
+// This is the server-side half, and it is the half that decides: the
+// Content-Disposition header takes priority over the browser's `download`
+// attribute (RFC 6266), so fixing only the frontend changed nothing a user could
+// see (#2250).
+func TestDownloadName(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		ext  string
+		want string
+	}{
+		{"appends a missing extension", "receipt", ".pdf", "receipt.pdf"},
+		{"does not double an extension already present", "receipt.pdf", ".pdf", "receipt.pdf"},
+		{"matches case-insensitively", "Receipt.PDF", ".pdf", "Receipt.PDF"},
+		{"a different extension is appended, not swallowed", "archive.tar", ".gz", "archive.tar.gz"},
+		{"multi-part extension already present", "archive.tar.gz", ".tar.gz", "archive.tar.gz"},
+		{"no extension to add", "receipt", "", "receipt"},
+		{"a name that merely contains the ext is not confused", "pdf-notes", ".pdf", "pdf-notes.pdf"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(filekit.DownloadName(tt.path, tt.ext), qt.Equals, tt.want)
+		})
+	}
+}

--- a/go/services/blobbackfill/blobbackfill.go
+++ b/go/services/blobbackfill/blobbackfill.go
@@ -180,9 +180,21 @@ func (s *Service) processRow(
 
 	// Step 1: copy. If destination already exists, copyIfAbsent
 	// short-circuits — that's how interrupted runs become idempotent.
-	copied, err := copyIfAbsent(ctx, bucket, legacyKey, newKey)
+	copied, srcPresent, err := copyIfAbsent(ctx, bucket, legacyKey, newKey)
 	if err != nil {
 		logger.Warn("blobbackfill: copy failed", "file_id", file.ID, "err", err)
+		stats.RowsErrored++
+		return
+	}
+	if !srcPresent {
+		// The row claims bytes that the bucket does not have. DO NOT re-point it
+		// (#2250): the legacy key is the only record of where those bytes were
+		// supposed to be, and overwriting it with a destination that was never
+		// written turns "the blob is missing" into "the blob is missing AND we
+		// have forgotten where it lived" — with the row counted as successfully
+		// moved. Leave it alone, name it, and let the operator decide.
+		logger.Warn("blobbackfill: row claims a blob the bucket does not have; leaving the row untouched",
+			"file_id", file.ID, "tenant_id", file.TenantID, "legacy_key", legacyKey)
 		stats.RowsErrored++
 		return
 	}
@@ -200,12 +212,42 @@ func (s *Service) processRow(
 		return
 	}
 
-	// Step 3: delete the legacy blob. Failure here is non-fatal — the
-	// row already points at the new key, so the legacy blob is
-	// unreferenced; a later sweep can clean it up. NotFound is the
-	// expected state on a re-run (we already deleted it last time) or
-	// on a partially-pruned bucket where copyIfAbsent took the
-	// short-circuit path, so suppress it to keep the log quiet.
+	// Step 3: delete the legacy blob — but ONLY if this row was its last
+	// reference (#2250).
+	//
+	// A legacy flat key has no tenant prefix, so rows in DIFFERENT tenants can
+	// share one (that is what #1793 was fixing). Their destinations differ —
+	// `t/<T1>/files/K` vs `t/<T2>/files/K` — so each row needs its own copy, and
+	// a row that deletes the source after ITS copy leaves the next row's copy
+	// with nothing to read. The old code did exactly that, and then re-pointed
+	// the second row anyway: it ended up claiming a key that was never written,
+	// while the bytes sat under the first tenant's namespace with nothing
+	// linking them. Silent, permanent, and invisible in the stats.
+	//
+	// Our own row already points at newKey (step 2), so anything still holding
+	// legacyKey is somebody else. Whoever backfills LAST finds it unreferenced
+	// and reclaims it. Errors fail closed — an unswept legacy blob is a leak; a
+	// prematurely swept one is data loss.
+	refs, err := fileReg.ListIDsByOriginalPath(ctx, legacyKey)
+	if err != nil {
+		logger.Warn("blobbackfill: keeping legacy blob, could not establish sole ownership",
+			"file_id", file.ID, "legacy_key", legacyKey, "err", err)
+		s.maybeMigrateThumbs(ctx, bucket, file, opts.DryRun, logger, stats)
+		stats.RowsMoved++
+		return
+	}
+	if len(refs) > 0 {
+		logger.Info("blobbackfill: keeping legacy blob, another row still references it",
+			"file_id", file.ID, "legacy_key", legacyKey, "still_referenced_by", len(refs))
+		s.maybeMigrateThumbs(ctx, bucket, file, opts.DryRun, logger, stats)
+		stats.RowsMoved++
+		return
+	}
+
+	// Failure here is non-fatal — the row already points at the new key, so the
+	// legacy blob is unreferenced; a later sweep can clean it up. NotFound is the
+	// expected state on a re-run (we already deleted it last time) or on a
+	// partially-pruned bucket, so suppress it to keep the log quiet.
 	switch err := bucket.Delete(ctx, legacyKey); {
 	case err == nil:
 		stats.BlobsDeleted++
@@ -316,7 +358,7 @@ func migrateOneThumb(ctx context.Context, bucket *blob.Bucket, k thumbKeys) (mov
 		return 1, 0, nil
 	}
 
-	if _, err := copyIfAbsent(ctx, bucket, k.Legacy, k.Canonical); err != nil {
+	if _, _, err := copyIfAbsent(ctx, bucket, k.Legacy, k.Canonical); err != nil {
 		return 0, 0, errxtrace.Wrap("failed to copy legacy thumbnail", err)
 	}
 	_ = bucket.Delete(ctx, k.Legacy)
@@ -324,46 +366,55 @@ func migrateOneThumb(ctx context.Context, bucket *blob.Bucket, k thumbKeys) (mov
 }
 
 // copyIfAbsent copies from src to dst unless dst already exists.
-// Returns true if a copy happened, false otherwise. The bucket-level
-// Copy operation isn't always available on every gocloud backend so we
-// use a streaming reader→writer to stay portable.
-func copyIfAbsent(ctx context.Context, bucket *blob.Bucket, src, dst string) (bool, error) {
+//
+// Returns (copied, srcPresent, err). srcPresent is a SEPARATE signal from copied
+// (#2250): the old two-value shape collapsed "already at the destination" and
+// "the source does not exist" into one `false`, so the caller re-pointed a row
+// at a key it had never written and counted it as moved. Those are opposite
+// situations — one is idempotent success, the other is a row whose bytes are
+// missing — and a caller that cannot tell them apart will destroy the only
+// record of where the bytes were supposed to be.
+//
+// The bucket-level Copy operation isn't always available on every gocloud
+// backend so we use a streaming reader→writer to stay portable.
+func copyIfAbsent(ctx context.Context, bucket *blob.Bucket, src, dst string) (copied, srcPresent bool, err error) {
 	dstExists, err := bucket.Exists(ctx, dst)
 	if err != nil {
-		return false, errxtrace.Wrap("failed to probe destination", err)
+		return false, false, errxtrace.Wrap("failed to probe destination", err)
 	}
 	if dstExists {
-		return false, nil
+		// Already copied by an earlier (interrupted) run. The bytes are at the
+		// destination, so the row is safe to re-point regardless of the source.
+		return false, true, nil
 	}
 
 	srcExists, err := bucket.Exists(ctx, src)
 	if err != nil {
-		return false, errxtrace.Wrap("failed to probe source", err)
+		return false, false, errxtrace.Wrap("failed to probe source", err)
 	}
 	if !srcExists {
-		// The row claims a blob lives here but the bucket disagrees —
-		// not an error per se (an admin may have manually pruned the
-		// bucket), just nothing to copy. The row update step still
-		// runs so the row eventually points at the canonical location.
-		return false, nil
+		// The row claims a blob lives here but the bucket disagrees. Nothing to
+		// copy — and, crucially, nothing at the destination either, so the caller
+		// must NOT re-point the row.
+		return false, false, nil
 	}
 
 	reader, err := bucket.NewReader(ctx, src, nil)
 	if err != nil {
-		return false, errxtrace.Wrap("failed to open source reader", err)
+		return false, true, errxtrace.Wrap("failed to open source reader", err)
 	}
 	defer reader.Close()
 
 	writer, err := bucket.NewWriter(ctx, dst, nil)
 	if err != nil {
-		return false, errxtrace.Wrap("failed to open destination writer", err)
+		return false, true, errxtrace.Wrap("failed to open destination writer", err)
 	}
 	if _, err := io.Copy(writer, reader); err != nil {
 		_ = writer.Close()
-		return false, errxtrace.Wrap("failed to copy bytes", err)
+		return false, true, errxtrace.Wrap("failed to copy bytes", err)
 	}
 	if err := writer.Close(); err != nil {
-		return false, errxtrace.Wrap("failed to close destination writer", err)
+		return false, true, errxtrace.Wrap("failed to close destination writer", err)
 	}
-	return true, nil
+	return true, true, nil
 }

--- a/go/services/blobbackfill/blobbackfill_test.go
+++ b/go/services/blobbackfill/blobbackfill_test.go
@@ -69,6 +69,47 @@ func seedRow(c *qt.C, ctx context.Context, factorySet *registry.FactorySet, uplo
 	return created.ID, tenant.ID
 }
 
+// An interrupted run must resume, not brick the row (#2250). copyIfAbsent's
+// three-value contract exists for exactly this: if the destination blob is
+// already present (a previous run copied it, then died before updating the row),
+// srcPresent must be TRUE so the re-run re-points the row — even though the
+// SOURCE may already be gone.
+//
+// This pins the `dstExists ⇒ srcPresent=true` branch. Flip it to false and the
+// re-run treats the row as "bytes missing", leaves it on the legacy key forever,
+// and the migration never completes for that row — silently.
+func TestBackfill_ResumesWhenDestinationAlreadyCopied(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	fileID, tenantID := seedRow(c, ctx, factorySet, uploadLocation, "half-migrated.jpg", "image/jpeg")
+	canonical := blobkeys.RewriteForTenant("half-migrated.jpg", tenantID)
+
+	// Simulate a run that copied the bytes to the canonical key and then died
+	// before updating the row OR deleting the source: the destination exists AND
+	// the source is already gone.
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	c.Assert(b.Copy(ctx, canonical, "half-migrated.jpg", nil), qt.IsNil)
+	c.Assert(b.Delete(ctx, "half-migrated.jpg"), qt.IsNil)
+	b.Close()
+
+	stats, err := blobbackfill.New(factorySet, uploadLocation).Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.RowsErrored, qt.Equals, 0,
+		qt.Commentf("a resumable row was treated as broken — the dstExists branch reported the source missing"))
+	c.Assert(stats.RowsMoved, qt.Equals, 1)
+
+	// The row is re-pointed to the canonical key, whose bytes are present.
+	row := must.Must(factorySet.FileRegistryFactory.CreateServiceRegistry().Get(ctx, fileID))
+	c.Assert(row.OriginalPath, qt.Equals, canonical)
+	b2 := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b2.Close()
+	c.Assert(must.Must(b2.Exists(ctx, canonical)), qt.IsTrue)
+}
+
 func TestBackfill_RewritesLegacyFileKeys(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/services/blobbackfill/blobbackfill_test.go
+++ b/go/services/blobbackfill/blobbackfill_test.go
@@ -165,17 +165,115 @@ func TestBackfill_DryRunDoesNotMutate(t *testing.T) {
 	c.Assert(must.Must(b.Exists(ctx, "legacy-photo.jpg")), qt.IsTrue)
 }
 
-func TestBackfill_SurvivesMissingBlob(t *testing.T) {
-	// A row claims a blob that the bucket doesn't have. The backfill
-	// should still update the row to the canonical key (so future
-	// uploads + reads land at the new location) and report no error.
+// seedRowInTenant is seedRow with the tenant named explicitly, so two rows in
+// two DIFFERENT tenants can be given the SAME legacy key — the collision that
+// #1793 (flat, un-prefixed keys) makes possible and that #2250 is about.
+func seedRowInTenant(c *qt.C, ctx context.Context, factorySet *registry.FactorySet, uploadLocation, tenantSlug, legacyKey string) (fileID, tenantID string) {
+	c.Helper()
+
+	tenant := must.Must(factorySet.TenantRegistry.Create(ctx, models.Tenant{
+		Name: tenantSlug, Slug: tenantSlug, Status: models.TenantStatusActive,
+	}))
+	user := must.Must(factorySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Email:               "u@" + tenantSlug + ".example.com",
+		Name:                "u",
+		IsActive:            true,
+	}))
+	group := must.Must(factorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Name:                "g", Slug: "g-" + tenantSlug, CreatedBy: user.ID,
+	}))
+
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	created := must.Must(fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: tenant.ID, GroupID: group.ID, CreatedByUserID: user.ID,
+		},
+		Title: "legacy", Type: models.FileTypeImage, Category: models.FileCategoryImages,
+		Tags: models.StringSlice{},
+		File: &models.File{
+			Path: "legacy", OriginalPath: legacyKey, Ext: ".jpg", MIMEType: "image/jpeg",
+		},
+	}))
+
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, legacyKey, []byte{0xff, 0xd8, 0xff, 0xe0}, nil), qt.IsNil)
+	return created.ID, tenant.ID
+}
+
+// TWO TENANTS, ONE LEGACY KEY (#2250). A flat key has no tenant prefix — that is
+// exactly what #1793 was fixing — so rows in different tenants can reference one.
+//
+// Their destinations differ (`t/<T1>/files/K` vs `t/<T2>/files/K`), so each row
+// needs its own copy of the bytes. The old backfill deleted the source right
+// after ITS copy, which left the second row's copy with nothing to read — and
+// then re-pointed that row anyway, at a key it had never written. The row ended
+// up claiming a location that has never existed, its bytes stranded under the
+// first tenant's namespace with nothing linking them, and the run reported it as
+// successfully moved. Silent, permanent, invisible in the stats.
+//
+// Whoever backfills LAST is the one who reclaims the legacy blob.
+func TestBackfill_SharedLegacyKeyAcrossTenants(t *testing.T) {
 	c := qt.New(t)
 
 	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
 	factorySet := memory.NewFactorySet()
 	ctx := context.Background()
 
-	fileID, tenantID := seedRow(c, ctx, factorySet, uploadLocation, "missing-photo.jpg", "image/jpeg")
+	const shared = "receipt-1783824560.jpg"
+	idA, tenantA := seedRowInTenant(c, ctx, factorySet, uploadLocation, "tenant-a", shared)
+	idB, tenantB := seedRowInTenant(c, ctx, factorySet, uploadLocation, "tenant-b", shared)
+
+	svc := blobbackfill.New(factorySet, uploadLocation)
+	stats, err := svc.Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.RowsErrored, qt.Equals, 0,
+		qt.Commentf("a row lost its bytes to the other tenant's backfill"))
+	c.Assert(stats.RowsMoved, qt.Equals, 2)
+
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+
+	// BOTH rows must point at their own tenant-namespaced key, and both keys must
+	// actually hold bytes. A row pointing at a key that was never written is the
+	// failure this test exists for.
+	for _, tc := range []struct{ id, tenant string }{{idA, tenantA}, {idB, tenantB}} {
+		row := must.Must(fileReg.Get(ctx, tc.id))
+		want := blobkeys.RewriteForTenant(shared, tc.tenant)
+		c.Assert(row.OriginalPath, qt.Equals, want)
+		c.Assert(must.Must(b.Exists(ctx, want)), qt.IsTrue,
+			qt.Commentf("row %s points at %q, which holds no bytes", tc.id, want))
+	}
+
+	// The legacy key is reclaimed — but only once nobody references it any more.
+	c.Assert(must.Must(b.Exists(ctx, shared)), qt.IsFalse,
+		qt.Commentf("the last owner did not reclaim the legacy blob"))
+}
+
+// A row claims a blob the bucket does not have. The backfill must NOT re-point
+// it (#2250).
+//
+// The old contract re-pointed the row anyway and counted it as moved, on the
+// theory that "future reads land at the canonical location". They don't — there
+// is nothing there to read, and there never was. What the rewrite actually
+// destroys is the legacy key, which is the ONLY record of where those bytes were
+// supposed to live: an operator restoring a pruned bucket from a snapshot can
+// put `missing-photo.jpg` back, but cannot know that the row now expects
+// `t/<tenant>/files/missing-photo.jpg`. And because the run reported RowsMoved=1
+// and RowsErrored=0, nobody would ever look.
+//
+// So: leave the row alone, count it as errored, and name it in the log.
+func TestBackfill_LeavesRowAloneWhenItsBlobIsMissing(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	fileID, _ := seedRow(c, ctx, factorySet, uploadLocation, "missing-photo.jpg", "image/jpeg")
 
 	// Delete the seeded blob to simulate an admin-pruned bucket.
 	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
@@ -184,13 +282,13 @@ func TestBackfill_SurvivesMissingBlob(t *testing.T) {
 
 	svc := blobbackfill.New(factorySet, uploadLocation)
 	stats, err := svc.Run(ctx, blobbackfill.Options{})
-	c.Assert(err, qt.IsNil)
-	c.Assert(stats.RowsErrored, qt.Equals, 0)
-	c.Assert(stats.RowsMoved, qt.Equals, 1)
-	c.Assert(stats.BlobsCopied, qt.Equals, 0) // nothing to copy
+	c.Assert(err, qt.IsNil) // a bad row must never abort the sweep
+	c.Assert(stats.RowsErrored, qt.Equals, 1)
+	c.Assert(stats.RowsMoved, qt.Equals, 0)
+	c.Assert(stats.BlobsCopied, qt.Equals, 0)
 
 	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
 	row := must.Must(fileReg.Get(ctx, fileID))
-	expected := blobkeys.RewriteForTenant("missing-photo.jpg", tenantID)
-	c.Assert(row.OriginalPath, qt.Equals, expected)
+	c.Assert(row.OriginalPath, qt.Equals, "missing-photo.jpg",
+		qt.Commentf("the row was re-pointed at a key that was never written, erasing where its bytes belonged"))
 }

--- a/go/services/entity_service.go
+++ b/go/services/entity_service.go
@@ -439,11 +439,61 @@ func (s *EntityService) DeleteExportWithFile(ctx context.Context, id string) err
 	// delete must not resurrect an error for a successful logical delete (the
 	// same row-first / blob-best-effort contract as DeleteFileWithPhysical).
 	if sourceBlobToDelete != "" {
-		if delErr := s.fileService.DeletePhysicalFile(ctx, sourceBlobToDelete); delErr != nil {
-			slog.WarnContext(ctx, "failed to delete pending imported-export source blob (best-effort)",
-				"export_id", id, "source_blob_key", sourceBlobToDelete, "error", delErr.Error())
+		// SHARED-KEY GUARD for a ROWLESS blob (#2250). This key has no owning file
+		// row, so the row-based guard in FileService cannot see a sharer — and
+		// restore-upload keys minted before #2241 were `<name>-<unix SECONDS>.inb`,
+		// which two uploads of `backup.inb` in one second collide on. Two pending
+		// imported exports can therefore point at ONE blob, and deleting either
+		// export would destroy the other's source archive: the surviving import
+		// then restores nothing, or worse, is left pointing at bytes that are gone.
+		//
+		// The owner set for a rowless restore blob is the EXPORTS table, so that is
+		// what we ask. Our own export row is already deleted, so anything still
+		// carrying this FilePath is somebody else's. ListWithDeleted, not List: a
+		// soft-deleted export still owns its artifacts.
+		shared, cerr := s.restoreBlobSharedByOtherExports(ctx, expReg, sourceBlobToDelete)
+		switch {
+		case cerr != nil:
+			slog.WarnContext(ctx, "keeping pending imported-export source blob: could not establish sole ownership",
+				"export_id", id, "source_blob_key", sourceBlobToDelete, "error", cerr.Error())
+		case shared:
+			slog.WarnContext(ctx, "keeping pending imported-export source blob: another export still references it",
+				"export_id", id, "source_blob_key", sourceBlobToDelete)
+		default:
+			if delErr := s.fileService.DeletePhysicalFile(ctx, sourceBlobToDelete); delErr != nil {
+				slog.WarnContext(ctx, "failed to delete pending imported-export source blob (best-effort)",
+					"export_id", id, "source_blob_key", sourceBlobToDelete, "error", delErr.Error())
+			}
 		}
 	}
 
 	return nil
+}
+
+// restoreBlobSharedByOtherExports reports whether any export row still carries
+// blobKey as its FilePath (#2250).
+//
+// A pending imported export's source `.inb` blob is ROWLESS — it has no
+// FileEntity, which is why the file-row guard in FileService cannot protect it
+// (#2121). Its owner set is the exports table, so that is what gets asked.
+//
+// ListWithDeleted, not List: a soft-deleted export still owns its artifacts, and
+// treating one as gone is how you delete the artifacts out from under it.
+//
+// Callers must fail closed on error: without proof that nobody else holds the
+// key, the bytes stay.
+func (s *EntityService) restoreBlobSharedByOtherExports(ctx context.Context, expReg registry.ExportRegistry, blobKey string) (bool, error) {
+	if blobKey == "" {
+		return false, nil
+	}
+	exports, err := expReg.ListWithDeleted(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range exports {
+		if e != nil && e.FilePath == blobKey {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/go/services/entity_service.go
+++ b/go/services/entity_service.go
@@ -440,24 +440,32 @@ func (s *EntityService) DeleteExportWithFile(ctx context.Context, id string) err
 	// same row-first / blob-best-effort contract as DeleteFileWithPhysical).
 	if sourceBlobToDelete != "" {
 		// SHARED-KEY GUARD for a ROWLESS blob (#2250). This key has no owning file
-		// row, so the row-based guard in FileService cannot see a sharer — and
-		// restore-upload keys minted before #2241 were `<name>-<unix SECONDS>.inb`,
-		// which two uploads of `backup.inb` in one second collide on. Two pending
-		// imported exports can therefore point at ONE blob, and deleting either
-		// export would destroy the other's source archive: the surviving import
-		// then restores nothing, or worse, is left pointing at bytes that are gone.
+		// row at the moment of deletion, so the row-based guard in FileService is
+		// not enough on its own — and restore-upload keys minted before #2241 were
+		// `<name>-<unix SECONDS>.inb`, which two uploads of `backup.inb` collide on
+		// (no group segment, no randomness). Two pending imported exports can point
+		// at ONE blob, and deleting either would destroy the other's source archive.
 		//
-		// The owner set for a rowless restore blob is the EXPORTS table, so that is
-		// what we ask. Our own export row is already deleted, so anything still
-		// carrying this FilePath is somebody else's. ListWithDeleted, not List: a
-		// soft-deleted export still owns its artifacts.
-		shared, cerr := s.restoreBlobSharedByOtherExports(ctx, expReg, sourceBlobToDelete)
+		// Two things this guard MUST do, and the first cut of it did neither:
+		//
+		//   1. Run SERVICE-MODE. `expReg` above is user-scoped (tenant AND group
+		//      RLS), so it cannot see the very sharer this exists to protect: a
+		//      colliding export in another group or tenant is invisible, the guard
+		//      concludes "sole owner", and deletes another user's archive. That is
+		//      the exact fail-open the whole #2250 effort is about.
+		//   2. Union BOTH owner tables — exports AND files. SourceFilePath is
+		//      REQUEST-CONTROLLED (apiserver/exports.go only checks the tenant
+		//      prefix), so a user can point a pending import at a pre-#2241 FILES
+		//      key belonging to another group, then delete the export to weaponise
+		//      this into a blob-delete against that file. Consulting only exports
+		//      leaves the files owner invisible; the delete proceeds.
+		shared, cerr := s.sourceBlobReferencedByOtherRows(ctx, sourceBlobToDelete)
 		switch {
 		case cerr != nil:
 			slog.WarnContext(ctx, "keeping pending imported-export source blob: could not establish sole ownership",
 				"export_id", id, "source_blob_key", sourceBlobToDelete, "error", cerr.Error())
 		case shared:
-			slog.WarnContext(ctx, "keeping pending imported-export source blob: another export still references it",
+			slog.WarnContext(ctx, "keeping pending imported-export source blob: another row references it",
 				"export_id", id, "source_blob_key", sourceBlobToDelete)
 		default:
 			if delErr := s.fileService.DeletePhysicalFile(ctx, sourceBlobToDelete); delErr != nil {
@@ -470,23 +478,38 @@ func (s *EntityService) DeleteExportWithFile(ctx context.Context, id string) err
 	return nil
 }
 
-// restoreBlobSharedByOtherExports reports whether any export row still carries
-// blobKey as its FilePath (#2250).
+// sourceBlobReferencedByOtherRows reports whether ANY row — a file OR an export —
+// still references blobKey (#2250). Our own export row is already deleted before
+// this runs, and a pending import has no file row, so any hit is somebody else's.
 //
-// A pending imported export's source `.inb` blob is ROWLESS — it has no
-// FileEntity, which is why the file-row guard in FileService cannot protect it
-// (#2121). Its owner set is the exports table, so that is what gets asked.
+// Both lookups are SERVICE-MODE (RLS-bypassing) and deliberately not
+// tenant/group-scoped, for the same reason FileService.blobSharedOutsideBatch is:
+// a pre-#2241 key carries no group segment and a pre-#1793 key no tenant prefix,
+// so the sharer whose bytes are at stake can live in another group or tenant
+// entirely, and a scoped lookup would not see it.
 //
-// ListWithDeleted, not List: a soft-deleted export still owns its artifacts, and
-// treating one as gone is how you delete the artifacts out from under it.
+// BOTH tables, because the two owner sets are disjoint and either can hold the
+// key: a rowless restore blob is owned by an export row (FilePath), a normal blob
+// by a file row (original_path), and SourceFilePath is request-controlled so a
+// caller can aim a pending export at either. ListWithDeleted, not List — a
+// soft-deleted export still owns its artifacts.
 //
-// Callers must fail closed on error: without proof that nobody else holds the
-// key, the bytes stay.
-func (s *EntityService) restoreBlobSharedByOtherExports(ctx context.Context, expReg registry.ExportRegistry, blobKey string) (bool, error) {
+// Callers fail closed on error: without proof that nobody else holds the key, the
+// bytes stay.
+func (s *EntityService) sourceBlobReferencedByOtherRows(ctx context.Context, blobKey string) (bool, error) {
 	if blobKey == "" {
 		return false, nil
 	}
-	exports, err := expReg.ListWithDeleted(ctx)
+
+	fileIDs, err := s.factorySet.FileRegistryFactory.CreateServiceRegistry().ListIDsByOriginalPath(ctx, blobKey)
+	if err != nil {
+		return false, err
+	}
+	if len(fileIDs) > 0 {
+		return true, nil
+	}
+
+	exports, err := s.factorySet.ExportRegistryFactory.CreateServiceRegistry().ListWithDeleted(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/go/services/entity_service_test.go
+++ b/go/services/entity_service_test.go
@@ -542,6 +542,105 @@ func TestEntityService_DeleteExport_CleansPendingImportSourceBlob(t *testing.T) 
 		qt.Commentf("pending imported-export source blob %s must not leak", sourceKey))
 }
 
+// A pending imported export's source blob must NOT be deleted while ANOTHER
+// pending export — in a DIFFERENT GROUP — still points at it (#2250).
+//
+// This is the fail-open the review caught: the first cut of the guard asked a
+// USER-scoped export registry, which is RLS-scoped to the caller's tenant AND
+// group, so a colliding export in another group was invisible and the guard
+// happily deleted its archive. Pre-#2241 restore keys had no group segment, so
+// two `backup.inb` uploads in two groups of one tenant collide on one key —
+// permanently, in deployed databases.
+//
+// Mutation check: point sourceBlobReferencedByOtherRows at expReg (user-scoped)
+// again and this reds.
+func TestEntityService_DeleteExport_KeepsSourceBlobSharedByAnotherGroup(t *testing.T) {
+	c := qt.New(t)
+
+	tempDir := c.TempDir()
+	uploadLocation := uploadLocationForTempDir(tempDir)
+
+	factorySet := memory.NewFactorySet()
+	baseCtx := newTestContext(factorySet)
+	service := services.NewEntityService(factorySet, uploadLocation)
+
+	const sharedKey = "t/test-tenant/restores/backup-1783824560.inb"
+	b := must.Must(blob.OpenBucket(baseCtx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(baseCtx, sharedKey, []byte("group-b's only copy"), nil), qt.IsNil)
+
+	// Two pending imported exports, same key, in two DIFFERENT groups.
+	ctxA := appctx.WithGroup(baseCtx, &models.LocationGroup{TenantAwareEntityID: models.TenantAwareEntityID{EntityID: models.EntityID{ID: "group-a"}, TenantID: "test-tenant-id"}})
+	ctxB := appctx.WithGroup(baseCtx, &models.LocationGroup{TenantAwareEntityID: models.TenantAwareEntityID{EntityID: models.EntityID{ID: "group-b"}, TenantID: "test-tenant-id"}})
+
+	mkPending := func(ctx context.Context) string {
+		regSet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+		e := must.Must(regSet.ExportRegistry.Create(ctx, models.Export{
+			Type: models.ExportTypeImported, Status: models.ExportStatusPending,
+			Description: "pending", FilePath: sharedKey, Imported: true,
+		}))
+		return e.ID
+	}
+	exportA := mkPending(ctxA)
+	_ = mkPending(ctxB) // the sharer in group B
+
+	// Group A deletes its export.
+	c.Assert(service.DeleteExportWithFile(ctxA, exportA), qt.IsNil)
+
+	// Group B's source archive must survive — another pending import still needs it.
+	c.Assert(must.Must(b.Exists(baseCtx, sharedKey)), qt.IsTrue,
+		qt.Commentf("deleting group A's export destroyed group B's live import source"))
+}
+
+// A pending imported export's source blob must NOT be deleted while a FILE row
+// owns the same key (#2250) — the weaponisable case.
+//
+// SourceFilePath is request-controlled (only the tenant prefix is validated), so
+// a user can create a pending import pointing at ANOTHER group's pre-#2241 FILES
+// blob, then delete the export to turn this cleanup into a blob-delete against
+// that file. The guard therefore has to union the FILES owner set, not just
+// exports — consulting exports alone leaves the file owner invisible.
+//
+// Mutation check: drop the files branch from sourceBlobReferencedByOtherRows and
+// this reds.
+func TestEntityService_DeleteExport_KeepsSourceBlobOwnedByAFileRow(t *testing.T) {
+	c := qt.New(t)
+
+	tempDir := c.TempDir()
+	uploadLocation := uploadLocationForTempDir(tempDir)
+
+	factorySet := memory.NewFactorySet()
+	ctx := newTestContext(factorySet)
+	service := services.NewEntityService(factorySet, uploadLocation)
+
+	// A live file owns the key — the victim.
+	const key = "t/test-tenant/files/invoice-1783824560.pdf"
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, key, []byte("the victim file's bytes"), nil), qt.IsNil)
+
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	_ = must.Must(fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "test-tenant-id", GroupID: "victim-group", CreatedByUserID: "victim",
+		},
+		Title: "invoice", Type: models.FileTypeDocument,
+		File: &models.File{Path: "invoice", OriginalPath: key, Ext: ".pdf", MIMEType: "application/pdf"},
+	}))
+
+	// The attacker's pending import points at the victim's file key.
+	regSet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+	attack := must.Must(regSet.ExportRegistry.Create(ctx, models.Export{
+		Type: models.ExportTypeImported, Status: models.ExportStatusPending,
+		Description: "attack", FilePath: key, Imported: true,
+	}))
+
+	c.Assert(service.DeleteExportWithFile(ctx, attack.ID), qt.IsNil)
+
+	c.Assert(must.Must(b.Exists(ctx, key)), qt.IsTrue,
+		qt.Commentf("a pending-import delete destroyed a live file's bytes it merely pointed at"))
+}
+
 // TestDeleteFileWithPhysical_DeletesThumbnailJob asserts the #2117 cleanup
 // order: deleting a file also removes the thumbnail-generation job that
 // references it and the concurrency slot that references that job, so the

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -371,9 +371,12 @@ func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, tenan
 	// in deployed databases can, forever. So the delete asks the question
 	// directly, every time: does a row OUTSIDE this caller's batch still
 	// reference this blob? If so the bytes stay, and the blob is simply left
-	// behind — an orphan the GC (#2237) will reclaim once the last owner is
-	// gone. Leaking a blob is recoverable; destroying a live file's bytes is
-	// not, so the guard fails in that direction on purpose.
+	// behind, and reclaimed by the LAST owner's delete (which finds no other
+	// row on the key and sweeps it). Note the orphan-file GC does NOT collect
+	// rowless ORIGINAL blobs — it sweeps file rows and thumbnails only — so the
+	// last owner is the reclaim path, not a backstop. Leaking a blob is
+	// recoverable; destroying a live file's bytes is not, so the guard fails in
+	// that direction on purpose.
 	shared, err := s.blobSharedOutsideBatch(ctx, filePath, batch)
 	if err != nil {
 		// FAIL CLOSED: if we cannot prove the key unshared, we do not delete
@@ -432,12 +435,50 @@ func (s *FileService) blobSharedOutsideBatch(ctx context.Context, blobKey string
 	if err != nil {
 		return false, err
 	}
+
+	// FAIL CLOSED when the answer is empty but the caller is holding rows
+	// (#2250). A non-empty batch means those rows are STILL in the table — the
+	// group and tenant purges sweep blobs before their rows are dropped — so a
+	// lookup that returns nothing has failed to see rows we have in our hand. A
+	// lookup that cannot see our own rows is equally blind to the cross-tenant
+	// sharer this guard exists to protect, and its silence is not evidence that
+	// the bytes are free.
+	//
+	// (An empty answer with an EMPTY batch is the opposite: that is
+	// DeleteFileWithPhysical, whose row is already gone, so "no ids" is exactly
+	// the sole-owner case. Same emptiness, opposite meaning — which is why the
+	// batch, not the count, decides.)
+	if len(batch) > 0 && len(ids) == 0 {
+		return true, nil
+	}
+
 	for _, id := range ids {
 		if !batch[id] {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+// BlobSharedByOtherRows reports whether any file row OTHER than excludeFileID
+// references blobKey (#2250). It is the guard for blob deletes that happen
+// OUTSIDE FileService — the restore importer superseding a re-pointed row's old
+// blob, the blob backfill dropping a legacy key — which is to say: outside
+// deletePhysicalFileAndThumbnails, where the #2241 guard lives.
+//
+// Those paths exist and they delete by key, so the invariant "no blob delete
+// destroys a live row's bytes" is only true if they ask this too. Pass "" for
+// excludeFileID when no row is exempt.
+//
+// Errors are the caller's to fail closed on: a caller that cannot prove the key
+// unshared must KEEP the bytes. Leaking a blob is recoverable; destroying a live
+// file's bytes is not.
+func (s *FileService) BlobSharedByOtherRows(ctx context.Context, blobKey, excludeFileID string) (bool, error) {
+	batch := map[string]bool{}
+	if excludeFileID != "" {
+		batch[excludeFileID] = true
+	}
+	return s.blobSharedOutsideBatch(ctx, blobKey, batch)
 }
 
 // deletePhysicalFile is the unified implementation for deleting physical files

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -309,6 +309,79 @@ func TestFileService_DeletePhysicalFilesForTenant_SharedLegacyKeyAcrossTenants(t
 	c.Assert(string(got), qt.Equals, "tenant-2's only copy")
 }
 
+// blindFileRegistry answers "nobody references that key" for rows the caller is
+// holding — a lagging read replica, a concurrent delete, a registry bug.
+type blindFileRegistry struct {
+	registry.FileRegistry
+}
+
+func (blindFileRegistry) ListIDsByOriginalPath(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+// blindFileFactory hands out the blind registry in service mode, which is the
+// only mode the shared-key guard uses.
+type blindFileFactory struct {
+	registry.FileRegistryFactory
+}
+
+func (f blindFileFactory) CreateServiceRegistry() registry.FileRegistry {
+	return blindFileRegistry{f.FileRegistryFactory.CreateServiceRegistry()}
+}
+
+// FAIL CLOSED on an empty ownership answer when the caller is holding rows
+// (#2250).
+//
+// The group and tenant purges sweep blobs while their own rows are STILL in the
+// table, so a lookup that comes back empty has failed to see rows we have in our
+// hand. A lookup that cannot see our own rows is equally blind to the
+// cross-tenant sharer this guard exists to protect, and its silence is not
+// evidence that the bytes are free.
+//
+// (The same empty answer is CORRECT for DeleteFileWithPhysical, whose row is
+// already gone — which is exactly why the batch, not the count, decides. That
+// asymmetry is the point, and it is why this is not simply "empty means keep".)
+func TestFileService_PurgeFailsClosedWhenOwnershipIsUnknowable(t *testing.T) {
+	c := qt.New(t)
+	ctx := newTestContext()
+
+	tempDir := c.TempDir()
+	uploadLocation := "file://" + tempDir + "?create_dir=1"
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	}
+
+	factorySet := memory.NewFactorySet()
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+
+	const key = "t/tenant-1/files/receipt-1783824560.jpg"
+	c.Assert(b.WriteAll(ctx, key, []byte("bytes that may belong to someone else"), nil), qt.IsNil)
+
+	_, err = fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "tenant-1", GroupID: "group-1", CreatedByUserID: "user-1",
+		},
+		Title: "f", Type: models.FileTypeImage,
+		File: &models.File{Path: "f", OriginalPath: key, Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Same factory set, but the ownership lookup has gone blind.
+	factorySet.FileRegistryFactory = blindFileFactory{factorySet.FileRegistryFactory}
+	service := NewFileService(factorySet, uploadLocation)
+
+	c.Assert(service.DeletePhysicalFilesForGroup(ctx, "tenant-1", "group-1"), qt.IsNil)
+
+	exists, err := b.Exists(ctx, key)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsTrue,
+		qt.Commentf("the purge destroyed bytes whose ownership it could not establish"))
+}
+
 func TestFileService_DeleteFileWithPhysical_FileNotFound(t *testing.T) {
 	c := qt.New(t)
 	ctx := newTestContext()


### PR DESCRIPTION
Closes #2250.

#2248 put a shared-key guard in `FileService.deletePhysicalFileAndThumbnails` and declared that no blob delete can destroy a live row's bytes. That claim was false on merge. I verified the callers of **my own function** instead of enumerating every blob delete in the tree — so the paths that never call it kept doing exactly what #2241 was opened to stop.

There are **six** production blob deletes. **Four bypassed the guard.**

| Site | Before | Now |
|---|---|---|
| `services/file_service.go:369` (via the primitive) | ✅ guarded | ✅ |
| `services/orphan_file_gc_worker.go` (thumbnails, keyed by row id) | ✅ row-unique by construction | ✅ |
| `apiserver/uploads.go:428` (cleanup of the blob just written) | ✅ UUID key since #2241 | ✅ |
| **`backup/restore/processor/processor.go`** | ❌ raw delete | ✅ guarded |
| **`services/blobbackfill/blobbackfill.go`** | ❌ raw delete | ✅ guarded |
| **`services/entity_service.go`** (rowless `restores/` blob) | ❌ raw delete | ✅ guarded against the exports table |
| `backup/export/service_shared.go` — `DeleteExportFile` | ❌ raw delete, deprecated, **zero callers** | 🗑️ removed |

## The four bypasses

**Restore (MergeUpdate).** It re-points a row to its new UUID key, then raw-deletes the row's **old** key — which for a pre-#2241 row is the shared `<name>-<unix seconds><ext>`. So `stale != new` is the *normal* case for a legacy row and the delete always fired: restoring one file destroyed a live file's bytes in another group. It now asks who else holds the key — **after** the re-point, because that is what makes "anything still holding it is somebody else" true. (Asking before would be useless: our own row answers every time. Excluding our row by id would be worse than useless — it reads as protection while matching nothing.)

**Backfill.** A flat legacy key has no tenant prefix — that is what #1793 was fixing — so rows in *different tenants* can share one, and their destinations differ (`t/T1/files/K` vs `t/T2/files/K`). The first row copied its bytes and deleted the source; the second then found nothing to copy, **was re-pointed anyway to a key that had never been written**, and was counted as moved. Silent, permanent, invisible in the stats. Now the legacy blob dies with its **last** reference, and a row whose bytes are missing is left **alone** — the legacy key is the only record of where those bytes belonged — and reported as errored instead of "moved".

**Pending-import source blob.** Rowless by design (#2121), so the row-based guard cannot see a sharer at all. Legacy restore keys (`<name>-<unix seconds>.inb`) collided the same way, so deleting one export destroyed another pending import's archive. Guarded against its actual owner set: the **exports** table (`ListWithDeleted` — a soft-deleted export still owns its artifacts).

**Fail-open on an empty answer.** `blobSharedOutsideBatch` read "no ids" as "nobody owns this". But the group and tenant purges sweep blobs while **their own rows are still in the table**, so empty there means the lookup cannot see rows we are holding — and a lookup blind to those is equally blind to the cross-tenant sharer the guard exists to protect. This is the identical fail-open Copilot caught in the GC gate on #2248, left standing on the other side. (Empty is still *correct* for `DeleteFileWithPhysical`, whose row is already gone — same emptiness, opposite meaning, which is exactly why the **batch**, not the count, decides.)

## The #2248 download-filename fix never worked

The frontend set `download="receipt.pdf"`. The server sent `Content-Disposition: attachment; filename="receipt.pdf.pdf"` (`Path + Ext`, no dedup) — and per RFC 6266 the **header overrides** the `<a download>` attribute. The vitest asserted the DOM attribute, so it was green while the saved filename was completely unchanged.

Fixed server-side (`filekit.DownloadName`, both download endpoints) and pinned by a test that asserts the **real `Content-Disposition` on the real download response**. Mutation-verified: make the helper concatenate blindly and the test reds with `filename=receipt.pdf.pdf` — the exact string users were getting.

That is the lesson this PR encodes: **assert where the outcome is decided, not where you set the value.**

## Tests

Every fix mutation-verified — revert it and the named test reds:

| Test | Mutation |
|---|---|
| `TestBackfill_SharedLegacyKeyAcrossTenants` | delete the legacy key unconditionally → *"a row lost its bytes to the other tenant's backfill"* |
| `TestBackfill_LeavesRowAloneWhenItsBlobIsMissing` | re-point a row whose bytes are gone |
| `TestFileService_PurgeFailsClosedWhenOwnershipIsUnknowable` | drop the fail-closed branch |
| `TestDownload_ContentDispositionFilename` | concatenate `Path+Ext` → `filename=receipt.pdf.pdf` |
| `TestDownloadName` (7 cases incl. multi-part `.tar.gz`) | — |

Gates: `go build` both tags ✅ · `golangci-lint` ✅ 0 issues · `nolintguard` / `qtlint` ✅ · `go test ./...` ✅ 83 packages · `tsc` ✅ · `eslint` ✅ · `prettier` ✅ · `vitest` ✅ 1398 tests.

_Found by an adversarial review of the merged #2248 — the pass CodeRabbit never ran, because it was rate-limited on the final commit._

https://claude.ai/code/session_013wnhe7acR8KrzcLDw3UW8y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded and displayed filenames now include file extensions exactly once, including case-insensitive matches.
  * Improved file migration safety when source data is missing or shared, preventing invalid references and accidental deletion of data still in use.
  * Cleanup operations now fail safely when ownership cannot be confirmed.
* **Tests**
  * Added coverage for filename formatting, shared storage references, missing files, and safe cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->